### PR TITLE
fix workflow orchestrator generate_plan activity

### DIFF
--- a/dapr_agents/workflow/orchestrators/llm/orchestrator.py
+++ b/dapr_agents/workflow/orchestrators/llm/orchestrator.py
@@ -196,7 +196,7 @@ class LLMOrchestrator(OrchestratorServiceBase):
         return agent_list
     
     @task(description=TASK_PLANNING_PROMPT)
-    async def generate_plan(self, task: str, agents: str, plan_schema: str) -> List[PlanStep]:
+    async def generate_plan(task: str, agents: str, plan_schema: str) -> List[PlanStep]:
         """
         Generates a structured execution plan for the given task.
 


### PR DESCRIPTION
Testing the dapr workflow quickstart I found this error

```
Activity task #2 failed: Task 'generate_plan' execution failed: issubclass() arg 1 must be a class
```