### PR TITLE
Feat/mkdocs validator

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -47,6 +47,7 @@ jobs:
 
   deploy:
     runs-on: ubuntu-latest
+    needs: documentation_validation
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-python@v5

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -14,6 +14,37 @@ on:
 permissions:
   contents: write
 jobs:
+  changed_files:
+    runs-on: ubuntu-latest
+    name: Review changed files
+    outputs:
+      docs_any_changed: NaN
+    steps:
+      - uses: actions/checkout@v4
+      - name: Get changed files
+        id: changed-files
+        uses: tj-actions/changed-files@v45
+        with:
+          files_yaml: |
+            docs:
+              - 'docs/**'
+              - 'mkdocs.yml'
+          base_sha: 'main'
+
+  documentation_validation:
+    needs: changed_files
+    name: Documantation validation
+    if: needs.changed_files.outputs.docs_any_changed == 'true'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+      - name: Remove plugins from mkdocs configuration
+        run: |
+          sed -i '/^plugins:/,/^[^ ]/d' mkdocs.yml
+      - name: Run MkDocs build
+        uses: Kjuly/mkdocs-page-builder@main
+
   deploy:
     runs-on: ubuntu-latest
     steps:


### PR DESCRIPTION
Add validation step to ensure that
- upon changes in `docs/**` and `mkdocs.yaml` we trigger
- mkdocs rendering for validating output
- only deploy the docs if files changed and docs rendered valid

We use the same setup to render all `docs/**` towards backstage internally. It serves as a quick good validator that rendering and `nav` works as expected.