### PR TITLE
Fix typo on Workflow Job name for docs

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -33,7 +33,7 @@ jobs:
 
   documentation_validation:
     needs: changed_files
-    name: Documantation validation
+    name: Documentation validation
     if: needs.changed_files.outputs.docs_any_changed == 'true'
     runs-on: ubuntu-latest
     steps:


### PR DESCRIPTION
Fixes typo on the name of one of the jobs for the docs workflow