### PR TITLE
Agents registry transactional

### DIFF
--- a/dapr_agents/workflow/agentic.py
+++ b/dapr_agents/workflow/agentic.py
@@ -586,7 +586,7 @@ class AgenticWorkflow(WorkflowApp, DaprPubSub, MessageRoutingMixin):
         """
         try:
             # Update the agents registry store with the new agent metadata
-            self.transcational_update_store(
+            self.transactional_update_store(
                 store_name=self.agents_registry_store_name,
                 key=self.agents_registry_key,
                 data={

--- a/dapr_agents/workflow/agentic.py
+++ b/dapr_agents/workflow/agentic.py
@@ -585,23 +585,18 @@ class AgenticWorkflow(WorkflowApp, DaprPubSub, MessageRoutingMixin):
         Registers the agent's metadata in the Dapr state store under 'agents_metadata'.
         """
         try:
-            # Retrieve existing metadata (always returns a dict)
-            agents_metadata = self.get_agents_metadata()
-            agents_metadata[self.name] = self._agent_metadata
-
-            # Save the updated metadata back to Dapr store
-            with DaprClient() as client:
-                client.save_state(
-                    store_name=self.agents_registry_store_name,
-                    key=self.agents_registry_key,
-                    value=json.dumps(agents_metadata),
-                    state_metadata={"contentType": "application/json"}
-                )
-
+            # Update the agents registry store with the new agent metadata
+            self.transcational_update_store(
+                store_name=self.agents_registry_store_name,
+                key=self.agents_registry_key,
+                data={
+                    self.name: self._agent_metadata
+                }
+            )
             logger.info(f"{self.name} registered its metadata under key '{self.agents_registry_key}'")
-
         except Exception as e:
             logger.error(f"Failed to register metadata for agent {self.name}: {e}")
+            raise e
     
     async def run_workflow_from_request(self, request: Request) -> JSONResponse:
         """

--- a/dapr_agents/workflow/base.py
+++ b/dapr_agents/workflow/base.py
@@ -65,7 +65,7 @@ class WorkflowApp(BaseModel):
         # Proceed with base model setup
         super().model_post_init(__context)
     
-    def transcational_update_store(self, store_name: str, key: str, data: dict) -> None:
+    def transactional_update_store(self, store_name: str, key: str, data: dict) -> None:
         """
         Merges the existing data with the new data and updates the store.
 

--- a/dapr_agents/workflow/base.py
+++ b/dapr_agents/workflow/base.py
@@ -92,7 +92,7 @@ class WorkflowApp(BaseModel):
                     raise Exception(f"No etag found for key: {key}")
                 existing_data = json.loads(response.data) if response.data else {}
                 merged_data = {**existing_data, **data}
-                logger.info(f"read and merged data: {merged_data} etag: {response.etag}")
+                logger.debug(f"read and merged data: {merged_data} etag: {response.etag}")
                 try:
                     # using the transactional API to be able to later support the Dapr outbox pattern
                     self.client.execute_state_transaction(

--- a/dapr_agents/workflow/base.py
+++ b/dapr_agents/workflow/base.py
@@ -1,6 +1,8 @@
 from dapr.ext.workflow import WorkflowRuntime, WorkflowActivityContext, DaprWorkflowClient
 from dapr.ext.workflow.workflow_state import WorkflowState
 from dapr.clients.grpc._response import StateResponse
+from dapr.clients.grpc._request import TransactionalStateOperation, TransactionOperationType
+from dapr.clients.grpc._state import StateOptions, Concurrency, Consistency
 from dapr.clients import DaprClient
 from dapr_agents.types.workflow import DaprWorkflowStatus
 from dapr_agents.workflow.task import WorkflowTask
@@ -16,6 +18,7 @@ import logging
 import uuid
 import json
 import sys
+import time
 
 logger = logging.getLogger(__name__)
 
@@ -62,6 +65,58 @@ class WorkflowApp(BaseModel):
         # Proceed with base model setup
         super().model_post_init(__context)
     
+    def transcational_update_store(self, store_name: str, key: str, data: dict) -> None:
+        """
+        Merges the existing data with the new data and updates the store.
+
+        Args:
+            store_name (str): The name of the Dapr state store component.
+            key (str): The key to update.
+            data (dict): The data to update the store with.
+        """
+        # retry the entire operation up to ten times sleeping 1 second between each attempt
+        for attempt in range(1, 11):
+            try:
+                response: StateResponse = self.client.get_state(store_name=store_name, key=key)
+                if not response.etag:
+                    # if there is no etag the following transaction won't work as expected
+                    # so we need to save an empty object with a strong consistency to force the etag to be created
+                    self.client.save_state(
+                        store_name=store_name,
+                        key=key,
+                        value=json.dumps({}),
+                        state_metadata={"contentType": "application/json"},
+                        options=StateOptions(concurrency=Concurrency.first_write, consistency=Consistency.strong)
+                    )
+                    # raise an exception to retry the entire operation
+                    raise Exception(f"No etag found for key: {key}")
+                existing_data = json.loads(response.data) if response.data else {}
+                merged_data = {**existing_data, **data}
+                logger.info(f"read and merged data: {merged_data} etag: {response.etag}")
+                try:
+                    # using the transactional API to be able to later support the Dapr outbox pattern
+                    self.client.execute_state_transaction(
+                        store_name=store_name,
+                        operations=[
+                            TransactionalStateOperation(
+                                key=key,
+                                data=json.dumps(merged_data),
+                                etag=response.etag,
+                                operation_type=TransactionOperationType.upsert
+                            )
+                        ],
+                        transactional_metadata={"contentType": "application/json"}
+                    )
+                except Exception as e:
+                    logger.error(f"Error updating state store: {e}")
+                    raise e
+                return None
+            except Exception as e:
+                logger.error(f"Error on transaction attempt: {attempt}: {e}")
+                logger.info(f"Sleeping for 1 second before retrying transaction...")
+                time.sleep(1)
+        raise Exception(f"Failed to update state store key: {key} after 10 attempts.")
+
     def get_data_from_store(self, store_name: str, key: str) -> Tuple[bool, dict]:
         """
         Retrieves data from the Dapr state store using the given key.

--- a/quickstarts/05-multi-agent-workflow-dapr-workflows/services/client/http_client.py
+++ b/quickstarts/05-multi-agent-workflow-dapr-workflows/services/client/http_client.py
@@ -5,12 +5,35 @@ import sys
 
 
 if __name__ == "__main__":
+    status_url = "http://localhost:8004/status"
+    healthy = False
+    for attempt in range(1, 11):
+        try:
+            print(f"Attempt {attempt}...")
+            response = requests.get(status_url, timeout=5)
+
+            if response.status_code == 200:
+                print("Workflow app is healthy!")
+                healthy = True
+                break
+            else:
+                print(f"Received status code {response.status_code}: {response.text}")
+
+        except requests.exceptions.RequestException as e:
+            print(f"Request failed: {e}")
+
+        attempt += 1
+        print(f"Waiting 5s seconds before next health checkattempt...")
+        time.sleep(5)
+
+    if not healthy:
+        print("Workflow app is not healthy!")
+        sys.exit(1)
+
     workflow_url = "http://localhost:8004/start-workflow"
     task_payload = {"task": "How to get to Mordor? We all need to help!"}
 
-    attempt = 1
-
-    while attempt <= 10:
+    for attempt in range(1, 11):
         try:
             print(f"Attempt {attempt}...")
             response = requests.post(workflow_url, json=task_payload, timeout=5)


### PR DESCRIPTION
builds on top of https://github.com/dapr/dapr-agents/pull/59 , so we would need to wait first for that one to merge

this PR refactors the agents registration to fix the race condition of multiple apps writing to the same statestore key

this new logic uses a combination of retries and strong concurrency controls from the dapr state store to guarantee that an agent is registered into the state key without data loss or agents overriding each other

in the future this can be expanded to leverage the dapr outbox pattern to get real time notifications when new agents register

