### PR TITLE
Fix Structured Output Validation Across Python Versions

### DIFF
--- a/dapr_agents/llm/utils/response.py
+++ b/dapr_agents/llm/utils/response.py
@@ -1,10 +1,11 @@
-from typing import Union, Dict, Any, Type, Optional, Iterator, Literal, get_args
-from dapr_agents.llm.utils import StreamHandler, StructureHandler
-from dataclasses import is_dataclass, asdict
-from dapr_agents.types import ChatCompletion
-from collections.abc import Iterable
-from pydantic import BaseModel
 import logging
+from dataclasses import asdict, is_dataclass
+from typing import Any, Dict, Iterator, Literal, Optional, Type, Union
+
+from pydantic import BaseModel
+
+from dapr_agents.llm.utils import StreamHandler, StructureHandler
+from dapr_agents.types import ChatCompletion
 
 logger = logging.getLogger(__name__)
 
@@ -43,30 +44,26 @@ class ResponseHandler:
         else:
             if response_format:
                 structured_response_json = StructureHandler.extract_structured_response(
-                    response=response, llm_provider=llm_provider, structured_mode=structured_mode
+                    response=response,
+                    llm_provider=llm_provider,
+                    structured_mode=structured_mode,
                 )
 
-                # Processing Iterable Models
-                is_iterable = isinstance(response_format, Iterable)
-                if is_iterable:
-                    item_model = get_args(response_format)[0]
-                    response_format = StructureHandler.create_iterable_model(item_model)
-                
-                # Validating Response
+                # Normalize format and resolve actual model class
+                normalized_format = StructureHandler.normalize_iterable_format(response_format)
+                model_cls = StructureHandler.resolve_response_model(normalized_format)
+
+                if not model_cls:
+                    raise TypeError(f"Could not resolve a valid Pydantic model from response_format: {response_format}")
+
                 structured_response_instance = StructureHandler.validate_response(
-                    structured_response_json, response_format
+                    structured_response_json, normalized_format
                 )
 
-                if isinstance(structured_response_instance, response_format):
-                    logger.info("Structured output was successfully validated.")
-                    if is_iterable:
-                        logger.debug(f"Returning objects from an instance of {type(structured_response_instance)}.")
-                        return structured_response_instance.objects
-                    else:
-                        logger.debug(f"Returning an instance of {type(structured_response_instance)}.")
-                        return structured_response_instance
-                else:
-                    logger.error("Validation failed for structured response.")
+                logger.info("Structured output was successfully validated.")
+                if hasattr(structured_response_instance, "objects"):
+                    return structured_response_instance.objects
+                return structured_response_instance
 
             # Convert response to dictionary
             if isinstance(response, dict):


### PR DESCRIPTION
This PR improves structured response handling across Python versions by addressing type introspection bugs that impacted task output validation. It ensures correct behavior when return types like List[Model] or List[dict[str, Any]] are used in workflow tasks.

##  Key Fixes
- Replaced `isinstance(..., Iterable)` check with `get_origin(...)` inside `normalize_iterable_format()` for consistent iterable detection.
- Ensured `List[Model]` types are correctly wrapped into generated Pydantic models for validation and schema generation.
- Resolved actual response model with `resolve_response_model()` before validating LLM outputs.
- Hardened `resolve_all_pydantic_models()` by:
- Guarding all `issubclass()` calls with `isinstance(..., type)`
- Catching TypeError to prevent crashes from invalid generic types like Dict or List[dict]
