### PR TITLE
improve register agent

### DIFF
--- a/dapr_agents/workflow/agentic.py
+++ b/dapr_agents/workflow/agentic.py
@@ -586,12 +586,11 @@ class AgenticWorkflow(WorkflowApp, DaprPubSub, MessageRoutingMixin):
         """
         try:
             # Update the agents registry store with the new agent metadata
-            self.transactional_update_store(
+            self.register_agent(
                 store_name=self.agents_registry_store_name,
-                key=self.agents_registry_key,
-                data={
-                    self.name: self._agent_metadata
-                }
+                store_key=self.agents_registry_key,
+                agent_name=self.name,
+                agent_metadata=self._agent_metadata
             )
             logger.info(f"{self.name} registered its metadata under key '{self.agents_registry_key}'")
         except Exception as e:


### PR DESCRIPTION
this PR tries to make the initial register agentic system process more seamless and less noisy.

Currently it logs too many errors and agents update the statestore even if they are already registered.

The changes consist of:
- reduce log verbosity, remove some log and change others to debug
- rename function to register_agent and change its signature
- added check to verify if the agent name and metadata already exist in the statestore 