### PR TITLE
Fix: Return the content if hasattr(result, 'content') && hasattr(content, 'text') to reiterate from the model

### DIFF
--- a/dapr_agents/tool/mcp/client.py
+++ b/dapr_agents/tool/mcp/client.py
@@ -361,21 +361,16 @@ class MCPClient(BaseModel):
             for content in result.content:
                 if hasattr(content, 'text'):
                     text_contents.append(content.text)
-            
+
             # Return single string if only one content item
             if len(text_contents) == 1:
                 return text_contents[0]
             elif text_contents:
                 return text_contents
-
-        # Handle error result
+            
         if hasattr(result, 'isError') and result.isError:
-            error_message = "Unknown error"
-            if hasattr(result, 'content') and result.content:
-                for content in result.content:
-                    if hasattr(content, 'text'):
-                        error_message = content.text
-            raise ToolError(f"MCP tool error: {error_message}")
+            # This will only trigger if the above if didn't contain content.text
+            raise ToolError(f"MCP tool error: {result}")
                 
         # Fallback for unexpected formats
         return str(result)

--- a/dapr_agents/tool/mcp/client.py
+++ b/dapr_agents/tool/mcp/client.py
@@ -361,7 +361,6 @@ class MCPClient(BaseModel):
             if hasattr(result, 'content') and result.content:
                 for content in result.content:
                     if hasattr(content, 'text'):
-                        error_message = content.text
                         # This is not a real error, we just feed back the error from the tool
                         # to the model for iterating again
                         logger.info(f"MCP tool error thrown, returning result: {result}")

--- a/dapr_agents/tool/mcp/client.py
+++ b/dapr_agents/tool/mcp/client.py
@@ -355,18 +355,6 @@ class MCPClient(BaseModel):
         Raises:
             ToolError: If the result indicates an error
         """
-        # Handle error result
-        if hasattr(result, 'isError') and result.isError:
-            error_message = "Unknown error"
-            if hasattr(result, 'content') and result.content:
-                for content in result.content:
-                    if hasattr(content, 'text'):
-                        # This is not a real error, we just feed back the error from the tool
-                        # to the model for iterating again
-                        logger.info(f"MCP tool error thrown, returning result: {result}")
-                        return str(result)
-            raise ToolError(f"MCP tool error: {error_message}")
-        
         # Extract text content from result
         if hasattr(result, 'content') and result.content:
             text_contents = []
@@ -379,6 +367,15 @@ class MCPClient(BaseModel):
                 return text_contents[0]
             elif text_contents:
                 return text_contents
+
+        # Handle error result
+        if hasattr(result, 'isError') and result.isError:
+            error_message = "Unknown error"
+            if hasattr(result, 'content') and result.content:
+                for content in result.content:
+                    if hasattr(content, 'text'):
+                        error_message = content.text
+            raise ToolError(f"MCP tool error: {error_message}")
                 
         # Fallback for unexpected formats
         return str(result)

--- a/dapr_agents/tool/mcp/client.py
+++ b/dapr_agents/tool/mcp/client.py
@@ -362,7 +362,10 @@ class MCPClient(BaseModel):
                 for content in result.content:
                     if hasattr(content, 'text'):
                         error_message = content.text
-                        break
+                        # This is not a real error, we just feed back the error from the tool
+                        # to the model for iterating again
+                        logger.info(f"MCP tool error thrown, returning result: {result}")
+                        return str(result)
             raise ToolError(f"MCP tool error: {error_message}")
         
         # Extract text content from result

--- a/requirements.txt
+++ b/requirements.txt
@@ -14,3 +14,4 @@ pyyaml==6.0.2
 rich==13.9.4
 huggingface_hub==0.27.1
 numpy==2.2.2
+mcp==1.6.0


### PR DESCRIPTION
This PR fixes #83 and ensures we return the `content` result when `hasattr(result, 'content') && hasattr(content, 'text')` are set, otherwise it will still raise the `ToolError`.