### PR TITLE
Add transactional `register_agent` with optimistic‑concurrency + retry

### DIFF
--- a/cookbook/workflows/multi_agents/basic_calc_agent_as_actor/LLMOrchestrator_state.json
+++ b/cookbook/workflows/multi_agents/basic_calc_agent_as_actor/LLMOrchestrator_state.json
@@ -1,0 +1,151 @@
+{
+    "instances": {
+        "22fb2349f9a742279ddbfae9da3330ac": {
+            "input": "What is 1 + 1?",
+            "output": "The task is currently in progress. The MathematicsAgent has successfully acknowledged the mathematical problem, identified the operands (both as 1), and set up the addition operation 1 + 1. The initial result of the addition operation has been completed, yielding 2.0.\n\nNext steps involve verifying the calculation result to ensure its accuracy and confirming the solution to conclude the task.",
+            "start_time": "2025-04-21T03:19:34.372003",
+            "end_time": "2025-04-21T03:19:53.991669",
+            "messages": [
+                {
+                    "id": "61df6088-707b-4c39-aaad-a428f89f6007",
+                    "role": "user",
+                    "content": "## Mission Briefing\n\nWe have received the following task:\n\nWhat is 1 + 1?\n\n### Team of Agents\n- MathematicsAgent: Calculator Assistant (Goal: Assist Humans with calculation tasks.)\n\n### Execution Plan\nHere is the structured approach the team will follow to accomplish the task:\n\n[{'step': 1, 'description': 'Initiate the process by acknowledging the mathematical problem to solve: Determine the sum of 1 + 1.', 'status': 'not_started', 'substeps': None}, {'step': 2, 'description': \"Identify and note the operands involved in the calculation: The first number is '1', and the second number is '1'.\", 'status': 'not_started', 'substeps': [{'substep': 2.1, 'description': 'Record the first operand: 1', 'status': 'not_started'}, {'substep': 2.2, 'description': 'Record the second operand: 1', 'status': 'not_started'}]}, {'step': 3, 'description': 'Perform the addition of the identified numbers: Add the first number to the second number.', 'status': 'not_started', 'substeps': [{'substep': 3.1, 'description': 'Set up the addition operation: 1 + 1.', 'status': 'not_started'}, {'substep': 3.2, 'description': 'Execute the addition operation.', 'status': 'not_started'}]}, {'step': 4, 'description': 'Verify the calculation result to ensure accuracy of the addition process.', 'status': 'not_started', 'substeps': [{'substep': 4.1, 'description': 'Check if the operation result matches expected arithmetic principles.', 'status': 'not_started'}]}, {'step': 5, 'description': 'Conclude the task by recording and confirming the correct solution to the problem. Result: 2.', 'status': 'not_started', 'substeps': None}]\n",
+                    "timestamp": "2025-04-21T03:19:38.416157",
+                    "name": "LLMOrchestrator"
+                },
+                {
+                    "id": "9b758573-9ec5-4d59-a3ac-d0cb9941b4eb",
+                    "role": "user",
+                    "content": "Initiate the process by acknowledging the mathematical problem to solve: Determine the sum of 1 + 1.",
+                    "timestamp": "2025-04-21T03:19:39.479920",
+                    "name": "LLMOrchestrator"
+                },
+                {
+                    "id": "c29d839c-3a54-4c8f-bf33-88a228d4e902",
+                    "role": "user",
+                    "content": "Acknowledging the task: We need to determine the sum of 1 + 1. Let's proceed to the next step and identify the operands involved in this calculation.",
+                    "timestamp": "2025-04-21T03:19:40.831663",
+                    "name": "MathematicsAgent"
+                },
+                {
+                    "id": "cb95ebd3-8eb8-48c6-aaa3-ba2507ee9a62",
+                    "role": "user",
+                    "content": "Please record the second operand: 1.",
+                    "timestamp": "2025-04-21T03:19:43.579299",
+                    "name": "LLMOrchestrator"
+                },
+                {
+                    "id": "c3b61fe8-ea8b-48a8-a255-7d495d825727",
+                    "role": "user",
+                    "content": "The second operand involved in this calculation is recorded as: 1. Now, let's proceed to perform the addition of the identified numbers.",
+                    "timestamp": "2025-04-21T03:19:44.589307",
+                    "name": "MathematicsAgent"
+                },
+                {
+                    "id": "7fd1f829-eeae-42f0-b6f9-cf3ef6464fff",
+                    "role": "user",
+                    "content": "Proceed to set up the addition operation with the recorded operands: 1 + 1.",
+                    "timestamp": "2025-04-21T03:19:47.387450",
+                    "name": "LLMOrchestrator"
+                },
+                {
+                    "id": "035932ab-766e-43af-bab8-5fd1a8c6dd4b",
+                    "role": "user",
+                    "content": "The result of the addition operation 1 + 1 is 2.0. Let's verify the calculation result to ensure the accuracy of the addition process.",
+                    "timestamp": "2025-04-21T03:19:50.046203",
+                    "name": "MathematicsAgent"
+                }
+            ],
+            "last_message": {
+                "id": "035932ab-766e-43af-bab8-5fd1a8c6dd4b",
+                "role": "user",
+                "content": "The result of the addition operation 1 + 1 is 2.0. Let's verify the calculation result to ensure the accuracy of the addition process.",
+                "timestamp": "2025-04-21T03:19:50.046203",
+                "name": "MathematicsAgent"
+            },
+            "plan": [
+                {
+                    "step": 1,
+                    "description": "Initiate the process by acknowledging the mathematical problem to solve: Determine the sum of 1 + 1.",
+                    "status": "completed",
+                    "substeps": null
+                },
+                {
+                    "step": 2,
+                    "description": "Identify and note the operands involved in the calculation: The first number is '1', and the second number is '1'.",
+                    "status": "completed",
+                    "substeps": [
+                        {
+                            "substep": 2.1,
+                            "description": "Record the first operand: 1",
+                            "status": "completed"
+                        },
+                        {
+                            "substep": 2.2,
+                            "description": "Record the second operand: 1",
+                            "status": "completed"
+                        }
+                    ]
+                },
+                {
+                    "step": 3,
+                    "description": "Perform the addition of the identified numbers: Add the first number to the second number.",
+                    "status": "in_progress",
+                    "substeps": [
+                        {
+                            "substep": 3.1,
+                            "description": "Set up the addition operation: 1 + 1.",
+                            "status": "completed"
+                        },
+                        {
+                            "substep": 3.2,
+                            "description": "Execute the addition operation.",
+                            "status": "not_started"
+                        }
+                    ]
+                },
+                {
+                    "step": 4,
+                    "description": "Verify the calculation result to ensure accuracy of the addition process.",
+                    "status": "not_started",
+                    "substeps": [
+                        {
+                            "substep": 4.1,
+                            "description": "Check if the operation result matches expected arithmetic principles.",
+                            "status": "not_started"
+                        }
+                    ]
+                },
+                {
+                    "step": 5,
+                    "description": "Conclude the task by recording and confirming the correct solution to the problem. Result: 2.",
+                    "status": "in_progress",
+                    "substeps": null
+                }
+            ],
+            "task_history": [
+                {
+                    "agent": "MathematicsAgent",
+                    "step": 1,
+                    "substep": null,
+                    "result": "Acknowledging the task: We need to determine the sum of 1 + 1. Let's proceed to the next step and identify the operands involved in this calculation.",
+                    "timestamp": "2025-04-21T03:19:40.835007"
+                },
+                {
+                    "agent": "MathematicsAgent",
+                    "step": 2,
+                    "substep": 2.2,
+                    "result": "The second operand involved in this calculation is recorded as: 1. Now, let's proceed to perform the addition of the identified numbers.",
+                    "timestamp": "2025-04-21T03:19:44.590818"
+                },
+                {
+                    "agent": "MathematicsAgent",
+                    "step": 3,
+                    "substep": 3.1,
+                    "result": "The result of the addition operation 1 + 1 is 2.0. Let's verify the calculation result to ensure the accuracy of the addition process.",
+                    "timestamp": "2025-04-21T03:19:50.048520"
+                }
+            ]
+        }
+    }
+}

--- a/cookbook/workflows/multi_agents/basic_calc_agent_as_actor/README.md
+++ b/cookbook/workflows/multi_agents/basic_calc_agent_as_actor/README.md
@@ -1,0 +1,413 @@
+# Dapr Agents Calculator Demo
+
+## Prerequisites
+
+- Python 3.10 or later
+- Dapr CLI (v1.15.x)
+- Redis (for state storage and pub/sub)
+- Azure OpenAI API key
+
+## Setup
+
+1. Create and activate a virtual environment:
+
+```bash
+# Create a virtual environment
+python3.10 -m venv .venv
+
+# Activate the virtual environment 
+# On Windows:
+.venv\Scripts\activate
+# On macOS/Linux:
+source .venv/bin/activate
+```
+
+2. Install dependencies:
+
+```bash
+pip install -r requirements.txt
+```
+
+3. Set Up Environment Variables: Create an `.env` file to securely store your API keys and other sensitive information. For example:
+
+```
+OPENAI_API_KEY="your-api-key"
+OPENAI_BASE_URL="https://api.openai.com/v1"
+```
+
+## Running the Application
+
+Make sure Redis is running on your local machine (default port 6379).
+
+### Running All Components with Dapr
+
+1. Start the calculator agent:
+
+```bash
+dapr run --app-id CalculatorApp --app-port 8002 --resources-path ./components python calculator_agent.py
+```
+
+2. Start the LLM orchestrator:
+
+```bash
+dapr run --app-id OrchestratorApp --app-port 8004 --resources-path ./components python llm_orchestrator.py
+```
+
+3. Run the client:
+
+```bash
+dapr run --app-id ClientApp --dapr-http-port 3502 --resources-path ./components -- python client.py
+
+```
+
+## Expected Behavior
+
+### LLM Orchestrator
+
+```
+== APP == INFO:dapr_agents.workflow.orchestrators.llm.orchestrator:Workflow iteration 1 started (Instance ID: 22fb2349f9a742279ddbfae9da3330ac).
+== APP == 2025-04-21 03:19:34.372 durabletask-worker INFO: 22fb2349f9a742279ddbfae9da3330ac: Orchestrator yielded with 1 task(s) and 0 event(s) outstanding.
+== APP == INFO:dapr_agents.workflow.task:Invoking Regular Task
+== APP == INFO:dapr_agents.workflow.base:Started workflow with instance ID 22fb2349f9a742279ddbfae9da3330ac.
+== APP == INFO:dapr_agents.workflow.base:Monitoring workflow '22fb2349f9a742279ddbfae9da3330ac'...
+== APP == 2025-04-21 03:19:34.377 durabletask-client INFO: Waiting up to 300s for instance '22fb2349f9a742279ddbfae9da3330ac' to complete.
+== APP == INFO:dapr_agents.workflow.agentic:Agents found in 'agentstatestore' for key 'agents_registry'.
+== APP == INFO:dapr_agents.workflow.orchestrators.llm.orchestrator:Initial message from User -> LLMOrchestrator
+== APP == 2025-04-21 03:19:34.383 durabletask-worker INFO: 22fb2349f9a742279ddbfae9da3330ac: Orchestrator yielded with 1 task(s) and 0 event(s) outstanding.
+== APP == INFO:dapr_agents.workflow.task:Invoking Task with LLM...
+== APP == INFO:dapr_agents.llm.utils.request:Structured Mode Activated! Mode=json.
+== APP == INFO:dapr_agents.llm.openai.chat:Invoking ChatCompletion API.
+== APP == INFO:httpx:HTTP Request: POST https://api.openai.com/v1/chat/completions "HTTP/1.1 200 OK"
+== APP == INFO:dapr_agents.llm.openai.chat:Chat completion retrieved successfully.
+== APP == INFO:dapr_agents.llm.utils.response:Structured output was successfully validated.
+== APP == 2025-04-21 03:19:38.396 durabletask-worker INFO: 22fb2349f9a742279ddbfae9da3330ac: Orchestrator yielded with 1 task(s) and 0 event(s) outstanding.
+== APP == INFO:dapr_agents.workflow.task:Invoking Regular Task
+== APP == 2025-04-21 03:19:38.410 durabletask-worker INFO: 22fb2349f9a742279ddbfae9da3330ac: Orchestrator yielded with 1 task(s) and 0 event(s) outstanding.
+== APP == INFO:dapr_agents.workflow.task:Invoking Regular Task
+== APP == INFO:dapr_agents.workflow.agentic:Agents found in 'agentstatestore' for key 'agents_registry'.
+== APP == INFO:dapr_agents.workflow.agentic:LLMOrchestrator broadcasting message to beacon_channel.
+== APP == INFO:dapr_agents.workflow.messaging.pubsub:LLMOrchestrator published 'BroadcastMessage' to topic 'beacon_channel'.
+== APP == 2025-04-21 03:19:38.427 durabletask-worker INFO: 22fb2349f9a742279ddbfae9da3330ac: Orchestrator yielded with 1 task(s) and 0 event(s) outstanding.
+== APP == INFO:dapr_agents.workflow.task:Invoking Task with LLM...
+== APP == INFO:dapr_agents.workflow.task:Retrieving conversation history...
+== APP == INFO:dapr_agents.llm.utils.request:Structured Mode Activated! Mode=json.
+== APP == INFO:dapr_agents.llm.openai.chat:Invoking ChatCompletion API.
+== APP == INFO:httpx:HTTP Request: POST https://api.openai.com/v1/chat/completions "HTTP/1.1 200 OK"
+== APP == INFO:dapr_agents.llm.openai.chat:Chat completion retrieved successfully.
+== APP == INFO:dapr_agents.llm.utils.response:Structured output was successfully validated.
+== APP == 2025-04-21 03:19:39.462 durabletask-worker INFO: 22fb2349f9a742279ddbfae9da3330ac: Orchestrator yielded with 1 task(s) and 0 event(s) outstanding.
+== APP == INFO:dapr_agents.workflow.task:Invoking Regular Task
+== APP == 2025-04-21 03:19:39.476 durabletask-worker INFO: 22fb2349f9a742279ddbfae9da3330ac: Orchestrator yielded with 1 task(s) and 0 event(s) outstanding.
+== APP == INFO:dapr_agents.workflow.task:Invoking Regular Task
+== APP == INFO:dapr_agents.workflow.agentic:Agents found in 'agentstatestore' for key 'agents_registry'.
+== APP == INFO:dapr_agents.workflow.agentic:LLMOrchestrator broadcasting message to beacon_channel.
+== APP == INFO:dapr_agents.workflow.messaging.pubsub:LLMOrchestrator published 'BroadcastMessage' to topic 'beacon_channel'.
+== APP == 2025-04-21 03:19:39.490 durabletask-worker INFO: 22fb2349f9a742279ddbfae9da3330ac: Orchestrator yielded with 1 task(s) and 0 event(s) outstanding.
+== APP == INFO:dapr_agents.workflow.task:Invoking Regular Task
+== APP == INFO:dapr_agents.workflow.orchestrators.llm.orchestrator:Triggering agent MathematicsAgent for step 1, substep None (Instance ID: 22fb2349f9a742279ddbfae9da3330ac)
+== APP == INFO:dapr_agents.workflow.orchestrators.llm.orchestrator:Marked step 1, substep None as 'in_progress'
+== APP == INFO:dapr_agents.workflow.agentic:Agents found in 'agentstatestore' for key 'agents_registry'.
+== APP == INFO:dapr_agents.workflow.agentic:LLMOrchestrator sending message to agent 'MathematicsAgent'.
+== APP == INFO:dapr_agents.workflow.messaging.pubsub:LLMOrchestrator published 'TriggerAction' to topic 'MathematicsAgent'.
+== APP == INFO:dapr_agents.workflow.orchestrators.llm.orchestrator:Waiting for MathematicsAgent's response...
+== APP == 2025-04-21 03:19:39.502 durabletask-worker INFO: 22fb2349f9a742279ddbfae9da3330ac: Orchestrator yielded with 1 task(s) and 1 event(s) outstanding.
+== APP == INFO:dapr_agents.workflow.messaging.parser:Validating payload with model 'AgentTaskResponse'...
+== APP == INFO:dapr_agents.workflow.messaging.routing:Dispatched to handler 'process_agent_response' for event type 'AgentTaskResponse'
+== APP == INFO:dapr_agents.workflow.orchestrators.llm.orchestrator:LLMOrchestrator processing agent response for workflow instance '22fb2349f9a742279ddbfae9da3330ac'.
+== APP == INFO:dapr_agents.workflow.base:Raising workflow event 'AgentTaskResponse' for instance '22fb2349f9a742279ddbfae9da3330ac'
+== APP == 2025-04-21 03:19:40.819 durabletask-client INFO: Raising event 'AgentTaskResponse' for instance '22fb2349f9a742279ddbfae9da3330ac'.
+== APP == INFO:dapr_agents.workflow.base:Successfully raised workflow event 'AgentTaskResponse' for instance '22fb2349f9a742279ddbfae9da3330ac'!
+== APP == 2025-04-21 03:19:40.827 durabletask-worker INFO: 22fb2349f9a742279ddbfae9da3330ac Event raised: agenttaskresponse
+== APP == INFO:dapr_agents.workflow.orchestrators.llm.orchestrator:MathematicsAgent sent a response.
+== APP == 2025-04-21 03:19:40.827 durabletask-worker INFO: 22fb2349f9a742279ddbfae9da3330ac: Orchestrator yielded with 2 task(s) and 0 event(s) outstanding.
+== APP == INFO:dapr_agents.workflow.task:Invoking Regular Task
+== APP == INFO:dapr_agents.workflow.orchestrators.llm.orchestrator:Updating task history for MathematicsAgent at step 1, substep None (Instance ID: 22fb2349f9a742279ddbfae9da3330ac)
+== APP == 2025-04-21 03:19:40.843 durabletask-worker INFO: 22fb2349f9a742279ddbfae9da3330ac: Orchestrator yielded with 2 task(s) and 0 event(s) outstanding.
+== APP == INFO:dapr_agents.workflow.task:Invoking Task with LLM...
+== APP == INFO:dapr_agents.workflow.task:Retrieving conversation history...
+== APP == INFO:dapr_agents.llm.utils.request:Structured Mode Activated! Mode=json.
+== APP == INFO:dapr_agents.llm.openai.chat:Invoking ChatCompletion API.
+== APP == INFO:httpx:HTTP Request: POST https://api.openai.com/v1/chat/completions "HTTP/1.1 200 OK"
+== APP == INFO:dapr_agents.llm.openai.chat:Chat completion retrieved successfully.
+== APP == INFO:dapr_agents.llm.utils.response:Structured output was successfully validated.
+== APP == INFO:dapr_agents.workflow.orchestrators.llm.orchestrator:Tracking Progress: {'verdict': 'continue', 'plan_needs_update': False, 'plan_status_update': [{'step': 1, 'substep': None, 'status': 'completed'}, {'step': 2, 'substep': None, 'status': 'in_progress'}, {'step': 2, 'substep': 2.1, 'status': 'in_progress'}], 'plan_restructure': None}
+== APP == 2025-04-21 03:19:42.532 durabletask-worker INFO: 22fb2349f9a742279ddbfae9da3330ac: Orchestrator yielded with 2 task(s) and 0 event(s) outstanding.
+== APP == INFO:dapr_agents.workflow.task:Invoking Regular Task
+== APP == INFO:dapr_agents.workflow.orchestrators.llm.orchestrator:Updating plan for instance 22fb2349f9a742279ddbfae9da3330ac
+== APP == INFO:dapr_agents.workflow.orchestrators.llm.orchestrator:Updated status of step 1, substep None to 'completed'
+== APP == INFO:dapr_agents.workflow.orchestrators.llm.orchestrator:Updated status of step 2, substep None to 'in_progress'
+== APP == INFO:dapr_agents.workflow.orchestrators.llm.orchestrator:Updated status of step 2, substep 2.1 to 'in_progress'
+== APP == INFO:dapr_agents.workflow.orchestrators.llm.orchestrator:Plan successfully updated for instance 22fb2349f9a742279ddbfae9da3330ac
+== APP == INFO:dapr_agents.workflow.orchestrators.llm.orchestrator:Workflow iteration 2 started (Instance ID: 22fb2349f9a742279ddbfae9da3330ac).
+== APP == 2025-04-21 03:19:42.543 durabletask-worker INFO: 22fb2349f9a742279ddbfae9da3330ac: Orchestrator yielded with 1 task(s) and 0 event(s) outstanding.
+== APP == INFO:dapr_agents.workflow.task:Invoking Regular Task
+== APP == INFO:dapr_agents.workflow.agentic:Agents found in 'agentstatestore' for key 'agents_registry'.
+== APP == 2025-04-21 03:19:42.552 durabletask-worker INFO: 22fb2349f9a742279ddbfae9da3330ac: Orchestrator yielded with 1 task(s) and 0 event(s) outstanding.
+== APP == INFO:dapr_agents.workflow.task:Invoking Task with LLM...
+== APP == INFO:dapr_agents.workflow.task:Retrieving conversation history...
+== APP == INFO:dapr_agents.llm.utils.request:Structured Mode Activated! Mode=json.
+== APP == INFO:dapr_agents.llm.openai.chat:Invoking ChatCompletion API.
+== APP == INFO:httpx:HTTP Request: POST https://api.openai.com/v1/chat/completions "HTTP/1.1 200 OK"
+== APP == INFO:dapr_agents.llm.openai.chat:Chat completion retrieved successfully.
+== APP == INFO:dapr_agents.llm.utils.response:Structured output was successfully validated.
+== APP == 2025-04-21 03:19:43.561 durabletask-worker INFO: 22fb2349f9a742279ddbfae9da3330ac: Orchestrator yielded with 1 task(s) and 0 event(s) outstanding.
+== APP == INFO:dapr_agents.workflow.task:Invoking Regular Task
+== APP == 2025-04-21 03:19:43.574 durabletask-worker INFO: 22fb2349f9a742279ddbfae9da3330ac: Orchestrator yielded with 1 task(s) and 0 event(s) outstanding.
+== APP == INFO:dapr_agents.workflow.task:Invoking Regular Task
+== APP == INFO:dapr_agents.workflow.agentic:Agents found in 'agentstatestore' for key 'agents_registry'.
+== APP == INFO:dapr_agents.workflow.agentic:LLMOrchestrator broadcasting message to beacon_channel.
+== APP == INFO:dapr_agents.workflow.messaging.pubsub:LLMOrchestrator published 'BroadcastMessage' to topic 'beacon_channel'.
+== APP == 2025-04-21 03:19:43.593 durabletask-worker INFO: 22fb2349f9a742279ddbfae9da3330ac: Orchestrator yielded with 1 task(s) and 0 event(s) outstanding.
+== APP == INFO:dapr_agents.workflow.task:Invoking Regular Task
+== APP == INFO:dapr_agents.workflow.orchestrators.llm.orchestrator:Triggering agent MathematicsAgent for step 2, substep 2.2 (Instance ID: 22fb2349f9a742279ddbfae9da3330ac)
+== APP == INFO:dapr_agents.workflow.orchestrators.llm.orchestrator:Marked step 2, substep 2.2 as 'in_progress'
+== APP == INFO:dapr_agents.workflow.agentic:Agents found in 'agentstatestore' for key 'agents_registry'.
+== APP == INFO:dapr_agents.workflow.agentic:LLMOrchestrator sending message to agent 'MathematicsAgent'.
+== APP == INFO:dapr_agents.workflow.messaging.pubsub:LLMOrchestrator published 'TriggerAction' to topic 'MathematicsAgent'.
+== APP == INFO:dapr_agents.workflow.orchestrators.llm.orchestrator:Waiting for MathematicsAgent's response...
+== APP == 2025-04-21 03:19:43.605 durabletask-worker INFO: 22fb2349f9a742279ddbfae9da3330ac: Orchestrator yielded with 1 task(s) and 1 event(s) outstanding.
+== APP == INFO:dapr_agents.workflow.messaging.parser:Validating payload with model 'AgentTaskResponse'...
+== APP == INFO:dapr_agents.workflow.messaging.routing:Dispatched to handler 'process_agent_response' for event type 'AgentTaskResponse'
+== APP == INFO:dapr_agents.workflow.orchestrators.llm.orchestrator:LLMOrchestrator processing agent response for workflow instance '22fb2349f9a742279ddbfae9da3330ac'.
+== APP == INFO:dapr_agents.workflow.base:Raising workflow event 'AgentTaskResponse' for instance '22fb2349f9a742279ddbfae9da3330ac'
+== APP == 2025-04-21 03:19:44.581 durabletask-client INFO: Raising event 'AgentTaskResponse' for instance '22fb2349f9a742279ddbfae9da3330ac'.
+== APP == INFO:dapr_agents.workflow.base:Successfully raised workflow event 'AgentTaskResponse' for instance '22fb2349f9a742279ddbfae9da3330ac'!
+== APP == 2025-04-21 03:19:44.585 durabletask-worker INFO: 22fb2349f9a742279ddbfae9da3330ac Event raised: agenttaskresponse
+== APP == INFO:dapr_agents.workflow.orchestrators.llm.orchestrator:MathematicsAgent sent a response.
+== APP == 2025-04-21 03:19:44.585 durabletask-worker INFO: 22fb2349f9a742279ddbfae9da3330ac: Orchestrator yielded with 2 task(s) and 0 event(s) outstanding.
+== APP == INFO:dapr_agents.workflow.task:Invoking Regular Task
+== APP == INFO:dapr_agents.workflow.orchestrators.llm.orchestrator:Updating task history for MathematicsAgent at step 2, substep 2.2 (Instance ID: 22fb2349f9a742279ddbfae9da3330ac)
+== APP == 2025-04-21 03:19:44.600 durabletask-worker INFO: 22fb2349f9a742279ddbfae9da3330ac: Orchestrator yielded with 2 task(s) and 0 event(s) outstanding.
+== APP == INFO:dapr_agents.workflow.task:Invoking Task with LLM...
+== APP == INFO:dapr_agents.workflow.task:Retrieving conversation history...
+== APP == INFO:dapr_agents.llm.utils.request:Structured Mode Activated! Mode=json.
+== APP == INFO:dapr_agents.llm.openai.chat:Invoking ChatCompletion API.
+== APP == INFO:httpx:HTTP Request: POST https://api.openai.com/v1/chat/completions "HTTP/1.1 200 OK"
+== APP == INFO:dapr_agents.llm.openai.chat:Chat completion retrieved successfully.
+== APP == INFO:dapr_agents.llm.utils.response:Structured output was successfully validated.
+== APP == INFO:dapr_agents.workflow.orchestrators.llm.orchestrator:Tracking Progress: {'verdict': 'continue', 'plan_needs_update': False, 'plan_status_update': [{'step': 2, 'substep': 2.1, 'status': 'completed'}, {'step': 2, 'substep': 2.2, 'status': 'completed'}, {'step': 2, 'substep': None, 'status': 'completed'}], 'plan_restructure': None}
+== APP == 2025-04-21 03:19:46.130 durabletask-worker INFO: 22fb2349f9a742279ddbfae9da3330ac: Orchestrator yielded with 2 task(s) and 0 event(s) outstanding.
+== APP == INFO:dapr_agents.workflow.task:Invoking Regular Task
+== APP == INFO:dapr_agents.workflow.orchestrators.llm.orchestrator:Updating plan for instance 22fb2349f9a742279ddbfae9da3330ac
+== APP == INFO:dapr_agents.workflow.orchestrators.llm.orchestrator:Updated status of step 2, substep 2.1 to 'completed'
+== APP == INFO:dapr_agents.workflow.orchestrators.llm.orchestrator:Updated status of step 2, substep 2.2 to 'completed'
+== APP == INFO:dapr_agents.workflow.orchestrators.llm.orchestrator:Updated status of step 2, substep None to 'completed'
+== APP == INFO:dapr_agents.workflow.orchestrators.llm.orchestrator:Plan successfully updated for instance 22fb2349f9a742279ddbfae9da3330ac
+== APP == INFO:dapr_agents.workflow.orchestrators.llm.orchestrator:Workflow iteration 3 started (Instance ID: 22fb2349f9a742279ddbfae9da3330ac).
+== APP == 2025-04-21 03:19:46.159 durabletask-worker INFO: 22fb2349f9a742279ddbfae9da3330ac: Orchestrator yielded with 1 task(s) and 0 event(s) outstanding.
+== APP == INFO:dapr_agents.workflow.task:Invoking Regular Task
+== APP == INFO:dapr_agents.workflow.agentic:Agents found in 'agentstatestore' for key 'agents_registry'.
+== APP == 2025-04-21 03:19:46.174 durabletask-worker INFO: 22fb2349f9a742279ddbfae9da3330ac: Orchestrator yielded with 1 task(s) and 0 event(s) outstanding.
+== APP == INFO:dapr_agents.workflow.task:Invoking Task with LLM...
+== APP == INFO:dapr_agents.workflow.task:Retrieving conversation history...
+== APP == INFO:dapr_agents.llm.utils.request:Structured Mode Activated! Mode=json.
+== APP == INFO:dapr_agents.llm.openai.chat:Invoking ChatCompletion API.
+== APP == INFO:httpx:HTTP Request: POST https://api.openai.com/v1/chat/completions "HTTP/1.1 200 OK"
+== APP == INFO:dapr_agents.llm.openai.chat:Chat completion retrieved successfully.
+== APP == INFO:dapr_agents.llm.utils.response:Structured output was successfully validated.
+== APP == 2025-04-21 03:19:47.370 durabletask-worker INFO: 22fb2349f9a742279ddbfae9da3330ac: Orchestrator yielded with 1 task(s) and 0 event(s) outstanding.
+== APP == INFO:dapr_agents.workflow.task:Invoking Regular Task
+== APP == 2025-04-21 03:19:47.383 durabletask-worker INFO: 22fb2349f9a742279ddbfae9da3330ac: Orchestrator yielded with 1 task(s) and 0 event(s) outstanding.
+== APP == INFO:dapr_agents.workflow.task:Invoking Regular Task
+== APP == INFO:dapr_agents.workflow.agentic:Agents found in 'agentstatestore' for key 'agents_registry'.
+== APP == INFO:dapr_agents.workflow.agentic:LLMOrchestrator broadcasting message to beacon_channel.
+== APP == INFO:dapr_agents.workflow.messaging.pubsub:LLMOrchestrator published 'BroadcastMessage' to topic 'beacon_channel'.
+== APP == 2025-04-21 03:19:47.403 durabletask-worker INFO: 22fb2349f9a742279ddbfae9da3330ac: Orchestrator yielded with 1 task(s) and 0 event(s) outstanding.
+== APP == INFO:dapr_agents.workflow.task:Invoking Regular Task
+== APP == INFO:dapr_agents.workflow.orchestrators.llm.orchestrator:Triggering agent MathematicsAgent for step 3, substep 3.1 (Instance ID: 22fb2349f9a742279ddbfae9da3330ac)
+== APP == INFO:dapr_agents.workflow.orchestrators.llm.orchestrator:Marked step 3, substep 3.1 as 'in_progress'
+== APP == INFO:dapr_agents.workflow.agentic:Agents found in 'agentstatestore' for key 'agents_registry'.
+== APP == INFO:dapr_agents.workflow.agentic:LLMOrchestrator sending message to agent 'MathematicsAgent'.
+== APP == INFO:dapr_agents.workflow.messaging.pubsub:LLMOrchestrator published 'TriggerAction' to topic 'MathematicsAgent'.
+== APP == INFO:dapr_agents.workflow.orchestrators.llm.orchestrator:Waiting for MathematicsAgent's response...
+== APP == 2025-04-21 03:19:47.417 durabletask-worker INFO: 22fb2349f9a742279ddbfae9da3330ac: Orchestrator yielded with 1 task(s) and 1 event(s) outstanding.
+== APP == INFO:dapr_agents.workflow.messaging.parser:Validating payload with model 'AgentTaskResponse'...
+== APP == INFO:dapr_agents.workflow.messaging.routing:Dispatched to handler 'process_agent_response' for event type 'AgentTaskResponse'
+== APP == INFO:dapr_agents.workflow.orchestrators.llm.orchestrator:LLMOrchestrator processing agent response for workflow instance '22fb2349f9a742279ddbfae9da3330ac'.
+== APP == INFO:dapr_agents.workflow.base:Raising workflow event 'AgentTaskResponse' for instance '22fb2349f9a742279ddbfae9da3330ac'
+== APP == 2025-04-21 03:19:50.031 durabletask-client INFO: Raising event 'AgentTaskResponse' for instance '22fb2349f9a742279ddbfae9da3330ac'.
+== APP == INFO:dapr_agents.workflow.base:Successfully raised workflow event 'AgentTaskResponse' for instance '22fb2349f9a742279ddbfae9da3330ac'!
+== APP == 2025-04-21 03:19:50.038 durabletask-worker INFO: 22fb2349f9a742279ddbfae9da3330ac Event raised: agenttaskresponse
+== APP == INFO:dapr_agents.workflow.orchestrators.llm.orchestrator:MathematicsAgent sent a response.
+== APP == 2025-04-21 03:19:50.039 durabletask-worker INFO: 22fb2349f9a742279ddbfae9da3330ac: Orchestrator yielded with 2 task(s) and 0 event(s) outstanding.
+== APP == INFO:dapr_agents.workflow.task:Invoking Regular Task
+== APP == INFO:dapr_agents.workflow.orchestrators.llm.orchestrator:Updating task history for MathematicsAgent at step 3, substep 3.1 (Instance ID: 22fb2349f9a742279ddbfae9da3330ac)
+== APP == 2025-04-21 03:19:50.055 durabletask-worker INFO: 22fb2349f9a742279ddbfae9da3330ac: Orchestrator yielded with 2 task(s) and 0 event(s) outstanding.
+== APP == INFO:dapr_agents.workflow.task:Invoking Task with LLM...
+== APP == INFO:dapr_agents.workflow.task:Retrieving conversation history...
+== APP == INFO:dapr_agents.llm.utils.request:Structured Mode Activated! Mode=json.
+== APP == INFO:dapr_agents.llm.openai.chat:Invoking ChatCompletion API.
+== APP == INFO:httpx:HTTP Request: POST https://api.openai.com/v1/chat/completions "HTTP/1.1 200 OK"
+== APP == INFO:dapr_agents.llm.openai.chat:Chat completion retrieved successfully.
+== APP == INFO:dapr_agents.llm.utils.response:Structured output was successfully validated.
+== APP == INFO:dapr_agents.workflow.orchestrators.llm.orchestrator:Tracking Progress: {'verdict': 'completed', 'plan_needs_update': False, 'plan_status_update': [{'step': 3, 'substep': 3.1, 'status': 'completed'}, {'step': 3, 'substep': 3.2, 'status': 'completed'}, {'step': 3, 'substep': None, 'status': 'completed'}, {'step': 4, 'substep': 4.1, 'status': 'completed'}, {'step': 4, 'substep': None, 'status': 'completed'}, {'step': 5, 'substep': None, 'status': 'completed'}], 'plan_restructure': None}
+== APP == INFO:dapr_agents.workflow.orchestrators.llm.orchestrator:Workflow ending with verdict: completed
+== APP == 2025-04-21 03:19:52.263 durabletask-worker INFO: 22fb2349f9a742279ddbfae9da3330ac: Orchestrator yielded with 2 task(s) and 0 event(s) outstanding.
+== APP == INFO:dapr_agents.workflow.task:Invoking Task with LLM...
+== APP == INFO:dapr_agents.workflow.task:Retrieving conversation history...
+== APP == INFO:dapr_agents.llm.openai.chat:Invoking ChatCompletion API.
+== APP == INFO:httpx:HTTP Request: POST https://api.openai.com/v1/chat/completions "HTTP/1.1 200 OK"
+== APP == INFO:dapr_agents.llm.openai.chat:Chat completion retrieved successfully.
+== APP == 2025-04-21 03:19:53.984 durabletask-worker INFO: 22fb2349f9a742279ddbfae9da3330ac: Orchestrator yielded with 2 task(s) and 0 event(s) outstanding.
+== APP == INFO:dapr_agents.workflow.task:Invoking Regular Task
+== APP == INFO:dapr_agents.workflow.orchestrators.llm.orchestrator:Updating plan for instance 22fb2349f9a742279ddbfae9da3330ac
+== APP == INFO:dapr_agents.workflow.orchestrators.llm.orchestrator:Updated status of step 3, substep 3.1 to 'completed'
+== APP == INFO:dapr_agents.workflow.orchestrators.llm.orchestrator:Plan successfully updated for instance 22fb2349f9a742279ddbfae9da3330ac
+== APP == INFO:dapr_agents.workflow.orchestrators.llm.orchestrator:Workflow 22fb2349f9a742279ddbfae9da3330ac has been finalized with verdict: completed
+== APP == 2025-04-21 03:19:53.998 durabletask-worker INFO: 22fb2349f9a742279ddbfae9da3330ac: Orchestration completed with status: COMPLETED
+INFO[0044] 22fb2349f9a742279ddbfae9da3330ac: 'LLMWorkflow' completed with a COMPLETED status.  app_id=OrchestratorApp instance=mac.lan scope=dapr.wfengine.durabletask.backend type=log ver=1.15.3
+INFO[0044] Workflow Actor '22fb2349f9a742279ddbfae9da3330ac': workflow completed with status 'ORCHESTRATION_STATUS_COMPLETED' workflowName 'LLMWorkflow'  app_id=OrchestratorApp instance=mac.lan scope=dapr.runtime.actors.targets.workflow type=log ver=1.15.3
+== APP == 2025-04-21 03:19:53.999 durabletask-client INFO: Instance '22fb2349f9a742279ddbfae9da3330ac' completed.
+== APP == INFO:dapr_agents.workflow.base:Workflow 22fb2349f9a742279ddbfae9da3330ac completed with status: WorkflowStatus.COMPLETED.
+== APP == INFO:dapr_agents.workflow.base:Workflow '22fb2349f9a742279ddbfae9da3330ac' completed successfully. Status: COMPLETED.
+== APP == INFO:dapr_agents.workflow.base:Finished monitoring workflow '22fb2349f9a742279ddbfae9da3330ac'.
+INFO[0076] Placement tables updated, version: 103        app_id=OrchestratorApp instance=mac.lan scope=dapr.runtime.actors.placement type=log ver=1.15.3
+INFO[0076] Running actor reminder migration from state store to scheduler  app_id=OrchestratorApp instance=mac.lan scope=dapr.runtime.actors.reminders.migration type=log ver=1.15.3
+INFO[0076] Skipping migration, no missing scheduler reminders found  app_id=OrchestratorApp instance=mac.lan scope=dapr.runtime.actors.reminders.migration type=log ver=1.15.3
+INFO[0076] Found 0 missing scheduler reminders from state store  app_id=OrchestratorApp instance=mac.lan scope=dapr.runtime.actors.reminders.migration type=log ver=1.15.3
+INFO[0076] Migrated 0 reminders from state store to scheduler successfully  app_id=OrchestratorApp instance=mac.lan scope=dapr.runtime.actors.reminders.migration type=log ver=1.15.3
+^Cℹ️  
+terminated signal received: shutting down
+INFO[0081] Received signal 'interrupt'; beginning shutdown  app_id=OrchestratorApp instance=mac.lan scope=dapr.signals type=log ver=1.15.3
+✅  Exited Dapr successfully
+✅  Exited App successfully
+```
+
+### MathematicsAgent
+
+```
+== APP == INFO:dapr_agents.workflow.messaging.parser:Validating payload with model 'BroadcastMessage'...
+== APP == INFO:dapr_agents.workflow.messaging.routing:Dispatched to handler 'process_broadcast_message' for event type 'BroadcastMessage'
+== APP == INFO:dapr_agents.agent.actor.agent:MathematicsAgent received broadcast message of type 'BroadcastMessage' from 'LLMOrchestrator'.
+== APP == INFO:dapr_agents.agent.actor.base:Activating actor with ID: MathematicsAgent
+== APP == INFO:dapr_agents.agent.actor.base:Initializing state for MathematicsAgent
+WARN[0021] Redis does not support transaction rollbacks and should not be used in production as an actor state store.  app_id=CalculatorApp component="workflowstatestore (state.redis/v1)" instance=mac.lan scope=dapr.contrib type=log ver=1.15.3
+== APP == INFO:     127.0.0.1:59669 - "PUT /actors/MathematicsAgentActor/MathematicsAgent/method/AddMessage HTTP/1.1" 200 OK
+== APP == INFO:dapr_agents.workflow.messaging.parser:Validating payload with model 'BroadcastMessage'...
+== APP == INFO:dapr_agents.workflow.messaging.routing:Dispatched to handler 'process_broadcast_message' for event type 'BroadcastMessage'
+== APP == INFO:dapr_agents.agent.actor.agent:MathematicsAgent received broadcast message of type 'BroadcastMessage' from 'LLMOrchestrator'.
+== APP == INFO:     127.0.0.1:59669 - "PUT /actors/MathematicsAgentActor/MathematicsAgent/method/AddMessage HTTP/1.1" 200 OK
+== APP == INFO:dapr_agents.workflow.messaging.parser:Validating payload with model 'TriggerAction'...
+== APP == INFO:dapr_agents.workflow.messaging.routing:Dispatched to handler 'process_trigger_action' for event type 'TriggerAction'
+== APP == INFO:dapr_agents.agent.actor.agent:MathematicsAgent received TriggerAction from LLMOrchestrator.
+== APP == INFO:dapr_agents.agent.actor.agent:MathematicsAgent executing default task from memory.
+== APP == INFO:dapr_agents.agent.actor.base:Actor MathematicsAgent invoking a task
+== APP == INFO:dapr_agents.agent.patterns.toolcall.base:Iteration 1/10 started.
+== APP == INFO:dapr_agents.llm.utils.request:Tools are available in the request.
+== APP == INFO:dapr_agents.llm.openai.chat:Invoking ChatCompletion API.
+== APP == INFO:httpx:HTTP Request: POST https://api.openai.com/v1/chat/completions "HTTP/1.1 200 OK"
+== APP == INFO:dapr_agents.llm.openai.chat:Chat completion retrieved successfully.
+== APP == user:
+== APP == Initiate the process by acknowledging the mathematical problem to solve: Determine the sum of 1 + 1.
+== APP == 
+== APP == --------------------------------------------------------------------------------
+== APP == 
+== APP == assistant:
+== APP == Acknowledging the task: We need to determine the sum of 1 + 1. Let's proceed to the next step and identify the operands involved in this calculation.
+== APP == 
+== APP == --------------------------------------------------------------------------------
+== APP == 
+== APP == INFO:     127.0.0.1:59669 - "PUT /actors/MathematicsAgentActor/MathematicsAgent/method/InvokeTask HTTP/1.1" 200 OK
+== APP == INFO:dapr_agents.agent.actor.service:Agents found in 'agentstatestore' for key 'agents_registry'.
+== APP == INFO:dapr_agents.agent.actor.service:MathematicsAgent broadcasting message to selected agents.
+== APP == INFO:dapr_agents.workflow.messaging.pubsub:MathematicsAgent published 'BroadcastMessage' to topic 'beacon_channel'.
+== APP == INFO:dapr_agents.agent.actor.service:Agents found in 'agentstatestore' for key 'agents_registry'.
+== APP == INFO:dapr_agents.agent.actor.service:MathematicsAgent sending message to agent 'LLMOrchestrator'.
+== APP == INFO:dapr_agents.workflow.messaging.parser:Validating payload with model 'BroadcastMessage'...
+== APP == INFO:dapr_agents.workflow.messaging.routing:Dispatched to handler 'process_broadcast_message' for event type 'BroadcastMessage'
+== APP == INFO:dapr_agents.agent.actor.agent:MathematicsAgent received broadcast message of type 'BroadcastMessage' from 'MathematicsAgent'.
+== APP == INFO:dapr_agents.agent.actor.agent:MathematicsAgent ignored its own broadcast message of type 'BroadcastMessage'.
+== APP == INFO:dapr_agents.workflow.messaging.pubsub:MathematicsAgent published 'AgentTaskResponse' to topic 'LLMOrchestrator'.
+== APP == INFO:dapr_agents.workflow.messaging.parser:Validating payload with model 'BroadcastMessage'...
+== APP == INFO:dapr_agents.workflow.messaging.routing:Dispatched to handler 'process_broadcast_message' for event type 'BroadcastMessage'
+== APP == INFO:dapr_agents.agent.actor.agent:MathematicsAgent received broadcast message of type 'BroadcastMessage' from 'LLMOrchestrator'.
+== APP == INFO:     127.0.0.1:59669 - "PUT /actors/MathematicsAgentActor/MathematicsAgent/method/AddMessage HTTP/1.1" 200 OK
+== APP == INFO:dapr_agents.workflow.messaging.parser:Validating payload with model 'TriggerAction'...
+== APP == INFO:dapr_agents.workflow.messaging.routing:Dispatched to handler 'process_trigger_action' for event type 'TriggerAction'
+== APP == INFO:dapr_agents.agent.actor.agent:MathematicsAgent received TriggerAction from LLMOrchestrator.
+== APP == INFO:dapr_agents.agent.actor.agent:MathematicsAgent executing default task from memory.
+== APP == INFO:dapr_agents.agent.actor.base:Actor MathematicsAgent invoking a task
+== APP == INFO:dapr_agents.agent.patterns.toolcall.base:Iteration 1/10 started.
+== APP == INFO:dapr_agents.llm.utils.request:Tools are available in the request.
+== APP == INFO:dapr_agents.llm.openai.chat:Invoking ChatCompletion API.
+== APP == INFO:httpx:HTTP Request: POST https://api.openai.com/v1/chat/completions "HTTP/1.1 200 OK"
+== APP == INFO:dapr_agents.llm.openai.chat:Chat completion retrieved successfully.
+== APP == user:
+== APP == Please record the second operand: 1.
+== APP == 
+== APP == --------------------------------------------------------------------------------
+== APP == 
+== APP == assistant:
+== APP == The second operand involved in this calculation is recorded as: 1. Now, let's proceed to perform the addition of the identified numbers.
+== APP == 
+== APP == --------------------------------------------------------------------------------
+== APP == 
+== APP == INFO:     127.0.0.1:59669 - "PUT /actors/MathematicsAgentActor/MathematicsAgent/method/InvokeTask HTTP/1.1" 200 OK
+== APP == INFO:dapr_agents.agent.actor.service:Agents found in 'agentstatestore' for key 'agents_registry'.
+== APP == INFO:dapr_agents.agent.actor.service:MathematicsAgent broadcasting message to selected agents.
+== APP == INFO:dapr_agents.workflow.messaging.pubsub:MathematicsAgent published 'BroadcastMessage' to topic 'beacon_channel'.
+== APP == INFO:dapr_agents.agent.actor.service:Agents found in 'agentstatestore' for key 'agents_registry'.
+== APP == INFO:dapr_agents.agent.actor.service:MathematicsAgent sending message to agent 'LLMOrchestrator'.
+== APP == INFO:dapr_agents.workflow.messaging.parser:Validating payload with model 'BroadcastMessage'...
+== APP == INFO:dapr_agents.workflow.messaging.routing:Dispatched to handler 'process_broadcast_message' for event type 'BroadcastMessage'
+== APP == INFO:dapr_agents.agent.actor.agent:MathematicsAgent received broadcast message of type 'BroadcastMessage' from 'MathematicsAgent'.
+== APP == INFO:dapr_agents.agent.actor.agent:MathematicsAgent ignored its own broadcast message of type 'BroadcastMessage'.
+== APP == INFO:dapr_agents.workflow.messaging.pubsub:MathematicsAgent published 'AgentTaskResponse' to topic 'LLMOrchestrator'.
+== APP == INFO:dapr_agents.workflow.messaging.parser:Validating payload with model 'BroadcastMessage'...
+== APP == INFO:dapr_agents.workflow.messaging.routing:Dispatched to handler 'process_broadcast_message' for event type 'BroadcastMessage'
+== APP == INFO:dapr_agents.agent.actor.agent:MathematicsAgent received broadcast message of type 'BroadcastMessage' from 'LLMOrchestrator'.
+== APP == INFO:     127.0.0.1:59669 - "PUT /actors/MathematicsAgentActor/MathematicsAgent/method/AddMessage HTTP/1.1" 200 OK
+== APP == INFO:dapr_agents.workflow.messaging.parser:Validating payload with model 'TriggerAction'...
+== APP == INFO:dapr_agents.workflow.messaging.routing:Dispatched to handler 'process_trigger_action' for event type 'TriggerAction'
+== APP == INFO:dapr_agents.agent.actor.agent:MathematicsAgent received TriggerAction from LLMOrchestrator.
+== APP == INFO:dapr_agents.agent.actor.agent:MathematicsAgent executing default task from memory.
+== APP == INFO:dapr_agents.agent.actor.base:Actor MathematicsAgent invoking a task
+== APP == INFO:dapr_agents.agent.patterns.toolcall.base:Iteration 1/10 started.
+== APP == INFO:dapr_agents.llm.utils.request:Tools are available in the request.
+== APP == INFO:dapr_agents.llm.openai.chat:Invoking ChatCompletion API.
+== APP == INFO:httpx:HTTP Request: POST https://api.openai.com/v1/chat/completions "HTTP/1.1 200 OK"
+== APP == INFO:dapr_agents.llm.openai.chat:Chat completion retrieved successfully.
+== APP == INFO:dapr_agents.agent.patterns.toolcall.base:Executing Add with arguments {"a":1,"b":1}
+== APP == INFO:dapr_agents.tool.executor:Running tool (auto): Add
+== APP == INFO:dapr_agents.agent.patterns.toolcall.base:Iteration 2/10 started.
+== APP == INFO:dapr_agents.llm.utils.request:Tools are available in the request.
+== APP == INFO:dapr_agents.llm.openai.chat:Invoking ChatCompletion API.
+== APP == INFO:httpx:HTTP Request: POST https://api.openai.com/v1/chat/completions "HTTP/1.1 200 OK"
+== APP == INFO:dapr_agents.llm.openai.chat:Chat completion retrieved successfully.
+== APP == user:
+== APP == Proceed to set up the addition operation with the recorded operands: 1 + 1.
+== APP == 
+== APP == --------------------------------------------------------------------------------
+== APP == 
+== APP == assistant:
+== APP == Function name: Add (Call Id: call_ac3Xlh4pn7tBFkrI2K9uOqvG)
+== APP == Arguments: {"a":1,"b":1}
+== APP == 
+== APP == --------------------------------------------------------------------------------
+== APP == 
+== APP == Add(tool) (Id: call_ac3Xlh4pn7tBFkrI2K9uOqvG):
+== APP == 2.0
+== APP == 
+== APP == --------------------------------------------------------------------------------
+== APP == 
+== APP == assistant:
+== APP == The result of the addition operation 1 + 1 is 2.0. Let's verify the calculation result to ensure the accuracy of the addition process.
+== APP == 
+== APP == --------------------------------------------------------------------------------
+== APP == 
+== APP == INFO:     127.0.0.1:59669 - "PUT /actors/MathematicsAgentActor/MathematicsAgent/method/InvokeTask HTTP/1.1" 200 OK
+== APP == INFO:dapr_agents.agent.actor.service:Agents found in 'agentstatestore' for key 'agents_registry'.
+== APP == INFO:dapr_agents.agent.actor.service:MathematicsAgent broadcasting message to selected agents.
+== APP == INFO:dapr_agents.workflow.messaging.pubsub:MathematicsAgent published 'BroadcastMessage' to topic 'beacon_channel'.
+== APP == INFO:dapr_agents.agent.actor.service:Agents found in 'agentstatestore' for key 'agents_registry'.
+== APP == INFO:dapr_agents.agent.actor.service:MathematicsAgent sending message to agent 'LLMOrchestrator'.
+== APP == INFO:dapr_agents.workflow.messaging.parser:Validating payload with model 'BroadcastMessage'...
+== APP == INFO:dapr_agents.workflow.messaging.routing:Dispatched to handler 'process_broadcast_message' for event type 'BroadcastMessage'
+== APP == INFO:dapr_agents.agent.actor.agent:MathematicsAgent received broadcast message of type 'BroadcastMessage' from 'MathematicsAgent'.
+== APP == INFO:dapr_agents.agent.actor.agent:MathematicsAgent ignored its own broadcast message of type 'BroadcastMessage'.
+== APP == INFO:dapr_agents.workflow.messaging.pubsub:MathematicsAgent published 'AgentTaskResponse' to topic 'LLMOrchestrator'.
+^Cℹ️  
+terminated signal received: shutting down
+✅  Exited Dapr successfully
+✅  Exited App successfully
+```

--- a/cookbook/workflows/multi_agents/basic_calc_agent_as_actor/calculator_agent.py
+++ b/cookbook/workflows/multi_agents/basic_calc_agent_as_actor/calculator_agent.py
@@ -1,0 +1,62 @@
+from dapr_agents import tool
+from dapr_agents import AgentActor
+from pydantic import BaseModel, Field
+from dapr_agents import Agent
+from dotenv import load_dotenv
+import logging
+import asyncio
+import os
+
+
+class AddSchema(BaseModel):
+    a: float = Field(description="first number to add")
+    b: float = Field(description="second number to add")
+
+
+@tool(args_model=AddSchema)
+def add(a: float, b: float) -> float:
+    """Add two numbers."""
+    return a + b
+
+
+class SubSchema(BaseModel):
+    a: float = Field(description="first number to subtract")
+    b: float = Field(description="second number to subtract")
+
+
+@tool(args_model=SubSchema)
+def sub(a: float, b: float) -> float:
+    """Subtract two numbers."""
+    return a - b
+
+
+async def main():
+ 
+
+    calculator_agent = Agent(
+        name="MathematicsAgent",
+        role="Calculator Assistant",
+ 
+        goal="Assist Humans with calculation tasks.",
+        instructions=[
+            "Get accurate calculation results",
+            "Break down the calculation into smaller steps.",
+        ],
+        tools=[add, sub],
+    )
+
+    calculator_service = AgentActor(
+        agent=calculator_agent,
+        message_bus_name="pubsub",
+        agents_registry_key="agents_registry",
+        agents_registry_store_name="agentstatestore",
+        service_port=8002,
+    )
+
+    await calculator_service.start()
+
+
+if __name__ == "__main__":
+    load_dotenv()
+    logging.basicConfig(level=logging.INFO)
+    asyncio.run(main()) 

--- a/cookbook/workflows/multi_agents/basic_calc_agent_as_actor/client.py
+++ b/cookbook/workflows/multi_agents/basic_calc_agent_as_actor/client.py
@@ -1,0 +1,59 @@
+#!/usr/bin/env python3
+import json
+import sys
+import time
+from dapr.clients import DaprClient
+
+# Default Pub/Sub component
+PUBSUB_NAME = "pubsub"
+
+def main(orchestrator_topic, max_attempts=10, retry_delay=1):
+    """
+    Publishes a task to a specified Dapr Pub/Sub topic with retries.
+
+    Args:
+        orchestrator_topic (str): The name of the orchestrator topic.
+        max_attempts (int): Maximum number of retry attempts.
+        retry_delay (int): Delay in seconds between attempts.
+    """
+    task_message = {
+        "task": "What is 1 + 1?",
+    }
+
+    time.sleep(5)
+
+    attempt = 1
+
+    while attempt <= max_attempts:
+        try:
+            print(f"📢 Attempt {attempt}: Publishing to topic '{orchestrator_topic}'...")
+            
+            with DaprClient() as client:
+                client.publish_event(
+                    pubsub_name=PUBSUB_NAME,
+                    topic_name=orchestrator_topic,
+                    data=json.dumps(task_message),
+                    data_content_type="application/json",
+                    publish_metadata={
+                        "cloudevent.type": "TriggerAction",
+                    }
+                )
+
+            print(f"✅ Successfully published request to '{orchestrator_topic}'")
+            sys.exit(0)
+
+        except Exception as e:
+            print(f"❌ Request failed: {e}")
+        
+        attempt += 1
+        print(f"⏳ Waiting {retry_delay}s before next attempt...")
+        time.sleep(retry_delay)
+
+    print(f"❌ Maximum attempts ({max_attempts}) reached without success.")
+    sys.exit(1)
+
+if __name__ == "__main__":
+
+    orchestrator_topic = 'LLMOrchestrator'
+
+    main(orchestrator_topic) 

--- a/cookbook/workflows/multi_agents/basic_calc_agent_as_actor/components/agentstatestore.yaml
+++ b/cookbook/workflows/multi_agents/basic_calc_agent_as_actor/components/agentstatestore.yaml
@@ -1,0 +1,14 @@
+apiVersion: dapr.io/v1alpha1
+kind: Component
+metadata:
+  name: agentstatestore
+spec:
+  type: state.redis
+  version: v1
+  metadata:
+    - name: redisHost
+      value: localhost:6379
+    - name: redisPassword
+      value: ""
+    - name: keyPrefix
+      value: none

--- a/cookbook/workflows/multi_agents/basic_calc_agent_as_actor/components/pubsub.yaml
+++ b/cookbook/workflows/multi_agents/basic_calc_agent_as_actor/components/pubsub.yaml
@@ -1,0 +1,12 @@
+apiVersion: dapr.io/v1alpha1
+kind: Component
+metadata:
+  name: pubsub
+spec:
+  type: pubsub.redis
+  version: v1
+  metadata:
+    - name: redisHost
+      value: localhost:6379
+    - name: redisPassword
+      value: "" 

--- a/cookbook/workflows/multi_agents/basic_calc_agent_as_actor/components/workflowstatestore.yaml
+++ b/cookbook/workflows/multi_agents/basic_calc_agent_as_actor/components/workflowstatestore.yaml
@@ -1,0 +1,14 @@
+apiVersion: dapr.io/v1alpha1
+kind: Component
+metadata:
+  name: workflowstatestore
+spec:
+  type: state.redis
+  version: v1
+  metadata:
+    - name: redisHost
+      value: localhost:6379
+    - name: redisPassword
+      value: ""
+    - name: actorStateStore
+      value: "true" 

--- a/cookbook/workflows/multi_agents/basic_calc_agent_as_actor/llm_orchestrator.py
+++ b/cookbook/workflows/multi_agents/basic_calc_agent_as_actor/llm_orchestrator.py
@@ -1,0 +1,31 @@
+from dapr_agents import LLMOrchestrator
+from dotenv import load_dotenv
+import asyncio
+import logging
+
+
+async def main():
+    try:
+ 
+        workflow_service = LLMOrchestrator(
+            name="LLMOrchestrator",
+       
+            message_bus_name="pubsub",
+            state_store_name="workflowstatestore",
+            state_key="workflow_state",
+            agents_registry_store_name="agentstatestore",
+            agents_registry_key="agents_registry",
+            max_iterations=20,  # Increased from 3 to 20 to avoid potential issues
+        ).as_service(port=8004)
+
+        await workflow_service.start()
+    except Exception as e:
+        print(f"Error starting service: {e}")
+
+
+if __name__ == "__main__":
+    load_dotenv()
+
+    logging.basicConfig(level=logging.INFO)
+
+    asyncio.run(main()) 

--- a/cookbook/workflows/multi_agents/basic_calc_agent_as_actor/requirements.txt
+++ b/cookbook/workflows/multi_agents/basic_calc_agent_as_actor/requirements.txt
@@ -1,0 +1,2 @@
+dapr-agents>=0.4.2
+python-dotenv 


### PR DESCRIPTION
Adds a helper to the actor service that atomically registers/updates an agent entry in a Dapr state store.

* Reads current state + ETag; seeds key with `{}` if it does not yet exist so that future writes have an ETag to compare against.
* Merges the new `{agent_name: metadata}` pair into the existing map; skips the update when the agent is already present.
* Persists the merged map via `execute_state_transaction(...)`, passing the previously‑read ETag to enforce optimistic concurrency.
* Wraps the entire operation in a retry loop (10 attempts, 1 s back‑off) to survive concurrent writers or transient store errors.

This gives us a single‑method, idempotent way to “register” agents that is safe in a distributed environment and compatible with the Dapr outbox pattern we plan to adopt later.

This was supposed to be added in this other PR https://github.com/dapr/dapr-agents/pull/61, but it was only added to workflows. This PR adds it to actor-based Agents.