### PR TITLE
Hierarchical LLM config on Tasks + workflow/ decorator refactor

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,7 @@
 .DS_Store
 secrets.json
 test
+.dapr
 
 # Byte-compiled / optimized / DLL files
 __pycache__/

--- a/cookbook/workflows/llm/multi_modal_task_chain.py
+++ b/cookbook/workflows/llm/multi_modal_task_chain.py
@@ -1,0 +1,60 @@
+from dapr_agents import OpenAIChatClient, NVIDIAChatClient
+from dapr_agents.types import DaprWorkflowContext
+from dapr_agents. workflow import WorkflowApp, task, workflow
+from dotenv import load_dotenv
+import os
+import logging
+
+load_dotenv()
+
+nvidia_llm = NVIDIAChatClient(
+    model="meta/llama-3.1-8b-instruct",
+    api_key=os.getenv("NVIDIA_API_KEY")
+)
+
+oai_llm = OpenAIChatClient(
+    api_key=os.getenv("OPENAI_API_KEY"),
+    model="gpt-4o",
+    base_url=os.getenv("OPENAI_API_BASE_URL"),
+)
+
+azoai_llm = OpenAIChatClient(
+    api_key=os.getenv("AZURE_OPENAI_API_KEY"),
+    azure_deployment="gpt-4o-mini",
+    azure_endpoint=os.getenv("AZURE_OPENAI_ENDPOINT"),
+    azure_api_version="2024-12-01-preview"
+)
+
+
+@workflow
+def test_workflow(ctx: DaprWorkflowContext):
+    """
+    A simple workflow that uses a multi-modal task chain.
+    """
+    oai_results = yield ctx.call_activity(invoke_oai, input="Peru")
+    azoai_results = yield ctx.call_activity(invoke_azoai, input=oai_results)
+    nvidia_results = yield ctx.call_activity(invoke_nvidia, input=azoai_results)
+    return nvidia_results
+
+@task(description="What is the name of the capital of {country}?. Reply with just the name.", llm=oai_llm)
+def invoke_oai(country: str) -> str:
+    pass
+
+@task(description="What is a famous thing about {capital}?", llm=azoai_llm)
+def invoke_azoai(capital: str) -> str:
+    pass
+
+@task(description="Context: {context}. From the previous context. Pick one thing to do.", llm=nvidia_llm)
+def invoke_nvidia(context: str) -> str:
+    pass
+
+if __name__ == '__main__':
+
+    logging.basicConfig(level=logging.INFO)
+
+    wfapp = WorkflowApp()
+
+    results = wfapp.run_and_monitor_workflow(workflow=test_workflow)
+
+    logging.info("Workflow results: %s", results)
+    logging.info("Workflow completed successfully.")

--- a/dapr_agents/llm/huggingface/client.py
+++ b/dapr_agents/llm/huggingface/client.py
@@ -52,9 +52,21 @@ class HFHubInferenceClientBase(LLMClientBase):
 
         values['api_key'] = api_key
 
-        # Ensure mutual exclusivity of `model` and `base_url`
+        # mutual‑exclusivity
         if model is not None and base_url is not None:
-            raise ValueError("Cannot provide both 'model' and 'base_url'. They are mutually exclusive.")
+            raise ValueError("Cannot provide both 'model' and 'base_url'.")
+        
+        # require at least one
+        if model is None and base_url is None:
+            raise ValueError(
+                "HF Inference needs either `model` or `base_url`. "
+                "E.g. model='gpt2' or base_url='https://…/models/gpt2'."
+            )
+        
+        # auto‑derive model from base_url
+        if model is None:
+            derived = base_url.rstrip("/").split("/")[-1]
+            values["model"] = derived
 
         return values
 

--- a/dapr_agents/workflow/decorators.py
+++ b/dapr_agents/workflow/decorators.py
@@ -1,6 +1,7 @@
 import functools
 import inspect
 from typing import Any, Callable, Optional
+import logging
 
 from pydantic import BaseModel, ValidationError
 
@@ -65,18 +66,31 @@ def task(
     def decorator(f: Callable) -> Callable:
         if not callable(f):
             raise ValueError(f"@task must be applied to a function, got {type(f)}.")
-
-        # Attach task metadata for later consumption
-        f._is_task = True
-        f._task_name = name or f.__name__
-        f._task_description = description
-        f._task_agent = agent
-        f._task_llm = llm
+    
+        # Attach task metadata
+        f._is_task                   = True
+        f._task_name                 = name or f.__name__
+        f._task_description          = description
+        f._task_agent                = agent
+        f._task_llm                  = llm
         f._task_include_chat_history = include_chat_history
-        f._explicit_llm = llm is not None or bool(description)
-        f._task_kwargs = task_kwargs  # Forward anything else (e.g., structured_mode)
-
-        return f
+        f._explicit_llm              = llm is not None or bool(description)
+        f._task_kwargs               = task_kwargs
+        
+        # wrap it so we can log, validate, etc., without losing signature/docs
+        @functools.wraps(f)
+        def wrapper(*args, **kwargs):
+            logging.getLogger(__name__).debug(f"Calling task '{f._task_name}'")
+            return f(*args, **kwargs)
+        
+        # copy our metadata onto the wrapper so discovery still sees it
+        for attr in (
+            "_is_task", "_task_name", "_task_description", "_task_agent",
+            "_task_llm", "_task_include_chat_history", "_explicit_llm", "_task_kwargs"
+        ):
+            setattr(wrapper, attr, getattr(f, attr))
+        
+        return wrapper
 
     return decorator(func) if func else decorator # Supports both @task and @task(name="custom")
 
@@ -146,6 +160,8 @@ def workflow(func: Optional[Callable] = None, *, name: Optional[str] = None) -> 
         def wrapper(*args, **kwargs):
             """Wrapper for handling input validation and execution."""
 
+            logging.getLogger(__name__).info(f"Starting workflow '{f._workflow_name}'")
+
             bound_args = sig.bind_partial(*args, **kwargs)
             bound_args.apply_defaults()
 
@@ -179,6 +195,8 @@ def workflow(func: Optional[Callable] = None, *, name: Optional[str] = None) -> 
 
             return f(*bound_args.args, **bound_args.kwargs)
 
+        wrapper._is_workflow   = True
+        wrapper._workflow_name = f._workflow_name
         return wrapper
 
     return decorator(func) if func else decorator  # Supports both `@workflow` and `@workflow(name="custom")`

--- a/dapr_agents/workflow/messaging/routing.py
+++ b/dapr_agents/workflow/messaging/routing.py
@@ -11,7 +11,7 @@ from dapr.clients.grpc.subscription import StreamInactiveError
 from dapr.common.pubsub.subscription import StreamCancelledError, SubscriptionMessage
 from dapr_agents.workflow.messaging.parser import extract_cloudevent_data, validate_message_model
 from dapr_agents.workflow.messaging.utils import is_valid_routable_model
-from dapr_agents.workflow.utils import get_callable_decorated_methods
+from dapr_agents.workflow.utils import get_decorated_methods
 
 logger = logging.getLogger(__name__)
 
@@ -46,7 +46,7 @@ class MessageRoutingMixin:
         - Wraps each handler and maps it by `(pubsub_name, topic_name)` and schema name.
         - Ensures only one handler per schema per topic is allowed.
         """
-        message_handlers = get_callable_decorated_methods(self, "_is_message_handler")
+        message_handlers = get_decorated_methods(self, "_is_message_handler")
 
         for method_name, method in message_handlers.items():
             try:

--- a/dapr_agents/workflow/orchestrators/roundrobin.py
+++ b/dapr_agents/workflow/orchestrators/roundrobin.py
@@ -1,9 +1,7 @@
 from dapr_agents.workflow.messaging.decorator import message_router
 from dapr_agents.workflow.orchestrators.base import OrchestratorWorkflowBase
-from dapr_agents.types import DaprWorkflowContext, BaseMessage, EventMessageMetadata
+from dapr_agents.types import DaprWorkflowContext, BaseMessage
 from dapr_agents.workflow.decorators import workflow, task
-from fastapi.responses import JSONResponse
-from fastapi import Response, status
 from typing import Any, Optional, Dict
 from pydantic import BaseModel, Field
 from datetime import timedelta
@@ -21,8 +19,9 @@ class TriggerAction(BaseModel):
     """
     Represents a message used to trigger an agent's activity within the workflow.
     """
-    task: Optional[str] = None
-    iteration: Optional[int] = 0
+    task: Optional[str] = Field(None, description="The specific task to execute. If not provided, the agent will act based on its memory or predefined behavior.")
+    iteration: Optional[int] = Field(0, description="")
+    workflow_instance_id: Optional[str] = Field(default=None, description="Dapr workflow instance id from source if available")
 
 class RoundRobinOrchestrator(OrchestratorWorkflowBase):
     """
@@ -161,30 +160,31 @@ class RoundRobinOrchestrator(OrchestratorWorkflowBase):
         """
         await self.send_message_to_agent(
             name=name,
-            message=TriggerAction(task=None),
-            workflow_instance_id=instance_id,
+            message=TriggerAction(workflow_instance_id=instance_id),
         )
-
+    
     @message_router
-    async def process_agent_response(self, message: AgentTaskResponse,
-                                   metadata: EventMessageMetadata) -> Response:
+    async def process_agent_response(self, message: AgentTaskResponse):
         """
         Processes agent response messages sent directly to the agent's topic.
 
         Args:
             message (AgentTaskResponse): The agent's response containing task results.
-            metadata (EventMessageMetadata): Metadata associated with the message, including headers.
 
         Returns:
-            Response: A JSON response confirming the workflow event was successfully triggered.
+            None: The function raises a workflow event with the agent's response.
         """
-        agent_response = (message).model_dump()
-        workflow_instance_id = metadata.headers.get("workflow_instance_id")
-        event_name = metadata.headers.get("event_name", "AgentTaskResponse")
+        try:
+            workflow_instance_id = message.get("workflow_instance_id")
 
-        # Raise a workflow event with the Agent's Task Response!
-        self.raise_workflow_event(instance_id=workflow_instance_id, event_name=event_name,
-                                data=agent_response)
+            if not workflow_instance_id:
+                logger.error(f"{self.name} received an agent response without a valid workflow_instance_id. Ignoring.")
+                return
 
-        return JSONResponse(content={"message": "Workflow event triggered successfully."},
-                          status_code=status.HTTP_200_OK)
+            logger.info(f"{self.name} processing agent response for workflow instance '{workflow_instance_id}'.")
+
+            # Raise a workflow event with the Agent's Task Response
+            self.raise_workflow_event(instance_id=workflow_instance_id, event_name="AgentTaskResponse", data=message)
+
+        except Exception as e:
+            logger.error(f"Error processing agent response: {e}", exc_info=True)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -27,13 +27,13 @@ classifiers = [
 
 dependencies = [
     "durabletask-dapr >= 0.2.0a7",
-    "pydantic == 2.10.5",
-    "openai == 1.59.6",
+    "pydantic == 2.11.3",
+    "openai == 1.75.0",
     "openapi-pydantic == 0.5.1",
     "openapi-schema-pydantic==1.2.4",
     "regex >= 2023.12.25",
     "Jinja2 >= 3.1.6",
-    "azure-identity == 1.19.0",
+    "azure-identity == 1.21.0",
     "dapr >= 1.15.0",
     "dapr-ext-fastapi == 1.15.0",
     "dapr-ext-workflow == 1.15.0",
@@ -41,7 +41,7 @@ dependencies = [
     "cloudevents == 1.11.0",
     "pyyaml == 6.0.2",
     "rich == 13.9.4",
-    "huggingface_hub == 0.27.1",
+    "huggingface_hub == 0.30.2",
     "numpy == 2.2.2",
 ]
 

--- a/quickstarts/01-hello-world/02_build_agent.py
+++ b/quickstarts/01-hello-world/02_build_agent.py
@@ -1,18 +1,24 @@
+import asyncio
 from dapr_agents import tool, Agent
 from dotenv import load_dotenv
 
 load_dotenv()
+
 @tool
 def my_weather_func() -> str:
     """Get current weather."""
     return "It's 72°F and sunny"
 
-weather_agent = Agent(
-    name="WeatherAgent",
-    role="Weather Assistant",
-    instructions=["Help users with weather information"],
-    tools=[my_weather_func]
-)
+async def main():
+    weather_agent = Agent(
+        name="WeatherAgent",
+        role="Weather Assistant",
+        instructions=["Help users with weather information"],
+        tools=[my_weather_func]
+    )
 
-response = weather_agent.run("What's the weather?")
-print(response)
+    response = await weather_agent.run("What's the weather?")
+    print(response)
+
+if __name__ == "__main__":
+    asyncio.run(main())

--- a/quickstarts/01-hello-world/03_reason_act.py
+++ b/quickstarts/01-hello-world/03_reason_act.py
@@ -1,7 +1,9 @@
+import asyncio
 from dapr_agents import tool, ReActAgent
 from dotenv import load_dotenv
 
 load_dotenv()
+
 @tool
 def search_weather(city: str) -> str:
     """Get weather information for a city."""
@@ -14,14 +16,17 @@ def get_activities(weather: str) -> str:
     activities = {"rainy": "Visit museums", "sunny": "Go hiking"}
     return activities.get(weather.lower(), "Stay comfortable")
 
-react_agent = ReActAgent(
-    name="TravelAgent",
-    role="Travel Assistant",
-    instructions=["Check weather, then suggest activities"],
-    tools=[search_weather, get_activities]
-)
+async def main():
+    react_agent = ReActAgent(
+        name="TravelAgent",
+        role="Travel Assistant",
+        instructions=["Check weather, then suggest activities"],
+        tools=[search_weather, get_activities]
+    )
 
-result = react_agent.run("What should I do in London today?")
+    result = await react_agent.run("What should I do in London today?")
+    if result:
+        print("Result:", result)
 
-if len(result) > 0:
-    print ("Result:", result)
+if __name__ == "__main__":
+    asyncio.run(main())

--- a/quickstarts/01-hello-world/README.md
+++ b/quickstarts/01-hello-world/README.md
@@ -92,24 +92,30 @@ python 02_build_agent.py
 This example shows how to create a basic agent with a custom tool:
 
 ```python
+import asyncio
 from dapr_agents import tool, Agent
 from dotenv import load_dotenv
 
 load_dotenv()
+
 @tool
 def my_weather_func() -> str:
     """Get current weather."""
     return "It's 72°F and sunny"
 
-weather_agent = Agent(
-    name="WeatherAgent",
-    role="Weather Assistant",
-    instructions=["Help users with weather information"],
-    tools=[my_weather_func]
-)
+async def main():
+    weather_agent = Agent(
+        name="WeatherAgent",
+        role="Weather Assistant",
+        instructions=["Help users with weather information"],
+        tools=[my_weather_func]
+    )
 
-response = weather_agent.run("What's the weather?")
-print(response)
+    response = await weather_agent.run("What's the weather?")
+    print(response)
+
+if __name__ == "__main__":
+    asyncio.run(main())
 ```
 
 **Expected output:** The agent will use the weather tool to provide the current weather.
@@ -141,10 +147,12 @@ python 03_reason_act.py
 <!-- END_STEP -->
 
 ```python
+import asyncio
 from dapr_agents import tool, ReActAgent
 from dotenv import load_dotenv
 
 load_dotenv()
+
 @tool
 def search_weather(city: str) -> str:
     """Get weather information for a city."""
@@ -154,17 +162,23 @@ def search_weather(city: str) -> str:
 @tool
 def get_activities(weather: str) -> str:
     """Get activity recommendations."""
-    activities = {"rainy": "Visit museums", "Sunny": "Go hiking"}
+    activities = {"rainy": "Visit museums", "sunny": "Go hiking"}
     return activities.get(weather.lower(), "Stay comfortable")
 
-react_agent = ReActAgent(
-    name="TravelAgent",
-    role="Travel Assistant",
-    instructions=["Check weather, then suggest activities"],
-    tools=[search_weather, get_activities]
-)
+async def main():
+    react_agent = ReActAgent(
+        name="TravelAgent",
+        role="Travel Assistant",
+        instructions=["Check weather, then suggest activities"],
+        tools=[search_weather, get_activities]
+    )
 
-react_agent.run("What should I do in London today?")
+    result = await react_agent.run("What should I do in London today?")
+    if result:
+        print("Result:", result)
+
+if __name__ == "__main__":
+    asyncio.run(main())
 ```
 
 **Expected output:** The agent will first check the weather in London, find it's rainy, and then recommend visiting museums.

--- a/quickstarts/02_llm_call_hugging_face/README.md
+++ b/quickstarts/02_llm_call_hugging_face/README.md
@@ -70,7 +70,7 @@ if len(response.get_content()) > 0:
     print("Response with prompty: ", response.get_content())
 
 # Chat completion with user input
-llm = HFHubChatClient()
+llm = HFHubChatClient(model="microsoft/Phi-3-mini-4k-instruct")
 response = llm.generate(messages=[UserMessage("hello")])
 
 print("Response with user input: ", response.get_content())

--- a/quickstarts/02_llm_call_hugging_face/text_completion.py
+++ b/quickstarts/02_llm_call_hugging_face/text_completion.py
@@ -22,7 +22,7 @@ if len(response.get_content()) > 0:
     print("Response with prompty: ", response.get_content())
 
 # Chat completion with user input
-llm = HFHubChatClient()
+llm = HFHubChatClient(model="microsoft/Phi-3-mini-4k-instruct")
 response = llm.generate(messages=[UserMessage("hello")])
 
 

--- a/quickstarts/05-multi-agent-workflow-actors/README.md
+++ b/quickstarts/05-multi-agent-workflow-actors/README.md
@@ -80,31 +80,38 @@ from dotenv import load_dotenv
 import asyncio
 import logging
 
+
 async def main():
     try:
         # Define Agent
-        hobbit_agent = Agent(
-            role="Hobbit",
-            name="Frodo",
-            goal="Take the ring to Mordor",
-            instructions=["Speak like Frodo"]
-        )
-        
-        # Expose Agent as an Actor Service
-        hobbit_service = AgentActor(
+        hobbit_agent = Agent(role="Hobbit", name="Frodo",
+            goal="Carry the One Ring to Mount Doom, resisting its corruptive power while navigating danger and uncertainty.",
+            instructions=[
+                "Speak like Frodo, with humility, determination, and a growing sense of resolve.",
+                "Endure hardships and temptations, staying true to the mission even when faced with doubt.",
+                "Seek guidance and trust allies, but bear the ultimate burden alone when necessary.",
+                "Move carefully through enemy-infested lands, avoiding unnecessary risks.",
+                "Respond concisely, accurately, and relevantly, ensuring clarity and strict alignment with the task."])
+
+        # Expose Agent as an Actor over a Service
+        hobbit_actor = AgentActor(
             agent=hobbit_agent,
             message_bus_name="messagepubsub",
-            agents_state_store_name="agentstatestore",
-            service_port=8001,
+            agents_registry_store_name="agentstatestore",
+            agents_registry_key="agents_registry",
+            service_port=8001
         )
 
-        await hobbit_service.start()
+        await hobbit_actor.start()
     except Exception as e:
-        print(f"Error starting service: {e}")
+        print(f"Error starting actor: {e}")
+
 
 if __name__ == "__main__":
     load_dotenv()
+
     logging.basicConfig(level=logging.INFO)
+
     asyncio.run(main())
 ```
 
@@ -120,24 +127,29 @@ from dotenv import load_dotenv
 import asyncio
 import logging
 
+
 async def main():
     try:
         random_workflow = RandomOrchestrator(
             name="RandomOrchestrator",
             message_bus_name="messagepubsub",
-            state_store_name="agenticworkflowstate",
+            state_store_name="workflowstatestore",
             state_key="workflow_state",
             agents_registry_store_name="agentstatestore",
             agents_registry_key="agents_registry",
             max_iterations=3
         ).as_service(port=8004)
+
         await random_workflow.start()
     except Exception as e:
         print(f"Error starting workflow: {e}")
 
+
 if __name__ == "__main__":
     load_dotenv()
+
     logging.basicConfig(level=logging.INFO)
+
     asyncio.run(main())
 ```
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,10 +1,10 @@
-pydantic==2.10.5
-openai==1.59.6
+pydantic==2.11.3
+openai==1.75.0
 openapi-pydantic==0.5.1
 openapi-schema-pydantic==1.2.4
 regex>=2023.12.25
 Jinja2>=3.1.6
-azure-identity==1.19.0
+azure-identity==1.21.0
 dapr>=1.15.0
 dapr-ext-fastapi==1.15.0
 dapr-ext-workflow==1.15.0
@@ -12,6 +12,6 @@ colorama==0.4.6
 cloudevents==1.11.0
 pyyaml==6.0.2
 rich==13.9.4
-huggingface_hub==0.27.1
+huggingface_hub==0.30.2
 numpy==2.2.2
 mcp==1.6.0


### PR DESCRIPTION
## Overview  
This PR refactors the core **WorkflowApp**, its task/workflow decorators, and related utilities to boost readability, testability, and observability **_and_ introduces hierarchical LLM‑client configuration for tasks**.

Key goals:

- Separate discovery vs. registration logic  
- **Enable “default‑LLM at app level, override at task level” behaviour**  
- Centralize LLM selection in one helper  
- Strengthen decorator metadata preservation & logging hooks  
- Simplify and fully type‑annotate utility code  

## Key Changes  

### WorkflowApp  
- **Hierarchical LLM config** – new `_choose_llm_for()` picks the per‑task override if present, otherwise falls back to the app‑level `llm` default.  
- Split `register_all_tasks` into `_discover_tasks()` and `_register_tasks()` phases.  
- Extract workflow discovery+registration (`_discover_workflows()` / `_register_workflows()`).  
- Wrapped workflow functions with a real `def wrapped()` for clearer stack traces.  
- Added INFO log at the start of every workflow invocation.

### Decorators  
- `@task` now wraps the original function, logs on call, and copies metadata to the wrapper.  
- `@workflow` logs at invocation start and keeps `_is_workflow` / `_workflow_name` on the wrapper for reliable reflection.  
- Avoided built‑in name shadowing (`input` → `payload`, etc.).

### Utilities  
- Consolidated helper into `get_decorated_methods()`.  
- Added type hints, richer docstrings, and debug‑level logging.

## Comments

Updated and tested all quickstarts with this branch.
