### PR TITLE
Async‑first workflow runner, sync wrapper & registration closure fix

### DIFF
--- a/cookbook/workflows/basic/wf_taskchain_dapr_agents_activity.py
+++ b/cookbook/workflows/basic/wf_taskchain_dapr_agents_activity.py
@@ -1,6 +1,7 @@
+import logging
+
 from dapr_agents.workflow import WorkflowApp, workflow, task
 from dapr_agents.types import DaprWorkflowContext
-import logging
 
 @workflow(name='random_workflow')
 def task_chain_workflow(ctx:DaprWorkflowContext, input: int):
@@ -32,6 +33,6 @@ if __name__ == '__main__':
 
     wfapp = WorkflowApp()
 
-    results = wfapp.run_and_monitor_workflow(task_chain_workflow, input=10)
+    results = wfapp.run_and_monitor_workflow_sync(task_chain_workflow, input=10)
 
     print(f"Results: {results}")

--- a/cookbook/workflows/basic/wf_taskchain_dapr_agents_activity_async.py
+++ b/cookbook/workflows/basic/wf_taskchain_dapr_agents_activity_async.py
@@ -1,0 +1,40 @@
+import asyncio
+import logging
+
+from dapr_agents.workflow import WorkflowApp, workflow, task
+from dapr_agents.types import DaprWorkflowContext
+
+@workflow(name="random_workflow")
+def task_chain_workflow(ctx: DaprWorkflowContext, input: int):
+    result1 = yield ctx.call_activity(step1, input=input)
+    result2 = yield ctx.call_activity(step2, input=result1)
+    result3 = yield ctx.call_activity(step3, input=result2)
+    return [result1, result2, result3]
+
+@task
+def step1(activity_input: int) -> int:
+    print(f"Step 1: Received input: {activity_input}.")
+    return activity_input + 1
+
+@task
+def step2(activity_input: int) -> int:
+    print(f"Step 2: Received input: {activity_input}.")
+    return activity_input * 2
+
+@task
+def step3(activity_input: int) -> int:
+    print(f"Step 3: Received input: {activity_input}.")
+    return activity_input ^ 2
+
+async def main():
+    logging.basicConfig(level=logging.INFO)
+    wfapp = WorkflowApp()
+    
+    result = await wfapp.run_and_monitor_workflow_async(
+        task_chain_workflow,
+        input=10
+    )
+    print(f"Results: {result}")
+
+if __name__ == "__main__":
+    asyncio.run(main())

--- a/cookbook/workflows/basic/wf_taskchain_dapr_agents_oai_llm_request.py
+++ b/cookbook/workflows/basic/wf_taskchain_dapr_agents_oai_llm_request.py
@@ -1,0 +1,35 @@
+from dapr_agents.workflow import WorkflowApp, workflow, task
+from dapr_agents.types import DaprWorkflowContext
+from dotenv import load_dotenv
+import logging
+
+# Define Workflow logic
+@workflow(name='lotr_workflow')
+def task_chain_workflow(ctx: DaprWorkflowContext):
+    result1 = yield ctx.call_activity(get_character)
+    result2 = yield ctx.call_activity(get_line, input={"character": result1})
+    return result2
+
+@task(description="""
+    Pick a random character from The Lord of the Rings\n
+    and respond with the character's name ONLY
+""")
+def get_character() -> str:
+    pass
+
+@task(description="What is a famous line by {character}",)
+def get_line(character: str) -> str:
+    pass
+
+if __name__ == '__main__':
+    logging.basicConfig(level=logging.INFO)
+
+    # Load environment variables
+    load_dotenv()
+
+    # Initialize the WorkflowApp
+    wfapp = WorkflowApp()
+
+    # Run workflow
+    results = wfapp.run_and_monitor_workflow_sync(task_chain_workflow)
+    print(results)

--- a/cookbook/workflows/basic/wf_taskchain_dapr_agents_oai_llm_request_async.py
+++ b/cookbook/workflows/basic/wf_taskchain_dapr_agents_oai_llm_request_async.py
@@ -1,7 +1,9 @@
+import asyncio
+import logging
+
 from dapr_agents.workflow import WorkflowApp, workflow, task
 from dapr_agents.types import DaprWorkflowContext
 from dotenv import load_dotenv
-import logging
 
 # Define Workflow logic
 @workflow(name='lotr_workflow')
@@ -21,7 +23,7 @@ def get_character() -> str:
 def get_line(character: str) -> str:
     pass
 
-if __name__ == '__main__':
+async def main():
     logging.basicConfig(level=logging.INFO)
 
     # Load environment variables
@@ -29,7 +31,10 @@ if __name__ == '__main__':
 
     # Initialize the WorkflowApp
     wfapp = WorkflowApp()
-
+    
     # Run workflow
-    results = wfapp.run_and_monitor_workflow(task_chain_workflow)
-    print(results)
+    result = await wfapp.run_and_monitor_workflow_async(task_chain_workflow)
+    print(f"Results: {result}")
+
+if __name__ == "__main__":
+    asyncio.run(main())

--- a/cookbook/workflows/basic/wf_taskchain_dapr_agents_oai_structured_output.py
+++ b/cookbook/workflows/basic/wf_taskchain_dapr_agents_oai_structured_output.py
@@ -1,0 +1,33 @@
+import logging
+from dapr_agents.workflow import WorkflowApp, workflow, task
+from dapr_agents.types import DaprWorkflowContext
+from pydantic import BaseModel
+from dotenv import load_dotenv
+
+@workflow
+def question(ctx:DaprWorkflowContext, input:int):
+    step1 = yield ctx.call_activity(ask, input=input)
+    return step1
+
+class Dog(BaseModel):
+    name: str
+    bio: str
+    breed: str
+
+@task("Who was {name}?")
+def ask(name:str) -> Dog:
+    pass
+
+if __name__ == '__main__':
+    logging.basicConfig(level=logging.INFO)
+
+    load_dotenv()
+
+    wfapp = WorkflowApp()
+
+    results = wfapp.run_and_monitor_workflow_sync(
+        workflow=question,
+        input="Scooby Doo"
+    )
+
+    print(results)

--- a/cookbook/workflows/basic/wf_taskchain_dapr_agents_oai_structured_output_async.py
+++ b/cookbook/workflows/basic/wf_taskchain_dapr_agents_oai_structured_output_async.py
@@ -1,8 +1,10 @@
+import asyncio
+import logging
+
 from dapr_agents.workflow import WorkflowApp, workflow, task
 from dapr_agents.types import DaprWorkflowContext
 from pydantic import BaseModel
 from dotenv import load_dotenv
-import logging
 
 @workflow
 def question(ctx:DaprWorkflowContext, input:int):
@@ -18,12 +20,21 @@ class Dog(BaseModel):
 def ask(name:str) -> Dog:
     pass
 
-if __name__ == '__main__':
+async def main():
     logging.basicConfig(level=logging.INFO)
 
+    # Load environment variables
     load_dotenv()
 
+    # Initialize the WorkflowApp
     wfapp = WorkflowApp()
+    
+    # Run workflow
+    result = await wfapp.run_and_monitor_workflow_async(
+        workflow=question,
+        input="Scooby Doo"
+    )
+    print(f"Results: {result}")
 
-    results = wfapp.run_and_monitor_workflow(workflow=question, input="Scooby Doo")
-    print(results)
+if __name__ == "__main__":
+    asyncio.run(main())

--- a/cookbook/workflows/doc2podcast/workflow.py
+++ b/cookbook/workflows/doc2podcast/workflow.py
@@ -358,4 +358,4 @@ if __name__ == '__main__':
         raise ValueError("PDF URL must be provided via CLI or config file.")
     
     # Run the workflow
-    wfapp.run_and_monitor_workflow(workflow=doc2podcast, input=user_input)
+    wfapp.run_and_monitor_workflow_sync(workflow=doc2podcast, input=user_input)

--- a/cookbook/workflows/llm/multi_modal_task_chain.py
+++ b/cookbook/workflows/llm/multi_modal_task_chain.py
@@ -54,7 +54,7 @@ if __name__ == '__main__':
 
     wfapp = WorkflowApp()
 
-    results = wfapp.run_and_monitor_workflow(workflow=test_workflow)
+    results = wfapp.run_and_monitor_workflow_sync(workflow=test_workflow)
 
     logging.info("Workflow results: %s", results)
     logging.info("Workflow completed successfully.")

--- a/quickstarts/01-hello-world/04_chain_tasks.py
+++ b/quickstarts/01-hello-world/04_chain_tasks.py
@@ -27,7 +27,7 @@ def write_blog(outline: str) -> str:
 if __name__ == '__main__':
     wfapp = WorkflowApp()
 
-    results = wfapp.run_and_monitor_workflow(
+    results = wfapp.run_and_monitor_workflow_sync(
         analyze_topic,
         input="AI Agents"
     )

--- a/quickstarts/01-hello-world/README.md
+++ b/quickstarts/01-hello-world/README.md
@@ -234,7 +234,7 @@ def write_blog(outline: str) -> str:
 if __name__ == '__main__':
     wfapp = WorkflowApp()
 
-    results = wfapp.run_and_monitor_workflow(
+    results = wfapp.run_and_monitor_workflow_sync(
         analyze_topic,
         input="AI Agents"
     )

--- a/quickstarts/04-agentic-workflow/README.md
+++ b/quickstarts/04-agentic-workflow/README.md
@@ -103,7 +103,7 @@ def get_line(character: str) -> str:
 if __name__ == '__main__':
     wfapp = WorkflowApp()
 
-    results = wfapp.run_and_monitor_workflow(task_chain_workflow)
+    results = wfapp.run_and_monitor_workflow_sync(task_chain_workflow)
     print(f"Famous Line: {results}")
 ```
 
@@ -209,7 +209,7 @@ if __name__ == "__main__":
     research_topic = "The environmental impact of quantum computing"
 
     logging.info(f"Starting research workflow on: {research_topic}")
-    results = wfapp.run_and_monitor_workflow(research_workflow, input=research_topic)
+    results = wfapp.run_and_monitor_workflow_sync(research_workflow, input=research_topic)
     logging.info(f"\nResearch Report:\n{results}")
 ```
 

--- a/quickstarts/04-agentic-workflow/parallel_workflow.py
+++ b/quickstarts/04-agentic-workflow/parallel_workflow.py
@@ -73,6 +73,6 @@ if __name__ == "__main__":
     research_topic = "The environmental impact of quantum computing"
 
     logging.info(f"Starting research workflow on: {research_topic}")
-    results = wfapp.run_and_monitor_workflow(research_workflow, input=research_topic)
+    results = wfapp.run_and_monitor_workflow_sync(research_workflow, input=research_topic)
     if len(results) > 0:
         logging.info(f"\nResearch Report:\n{results}")

--- a/quickstarts/04-agentic-workflow/sequential_workflow.py
+++ b/quickstarts/04-agentic-workflow/sequential_workflow.py
@@ -26,5 +26,5 @@ def get_line(character: str) -> str:
 if __name__ == '__main__':
     wfapp = WorkflowApp()
 
-    results = wfapp.run_and_monitor_workflow(task_chain_workflow)
+    results = wfapp.run_and_monitor_workflow_sync(task_chain_workflow)
     print(f"Famous Line: {results}")

--- a/quickstarts/04-agentic-workflow/workflow_dapr_agent.py
+++ b/quickstarts/04-agentic-workflow/workflow_dapr_agent.py
@@ -5,8 +5,6 @@ from dotenv import load_dotenv
 # Load environment variables
 load_dotenv()
 
-# Initialize the WorkflowApp
-
 # Define Workflow logic
 @workflow(name='task_chain_workflow')
 def task_chain_workflow(ctx: DaprWorkflowContext):
@@ -31,5 +29,5 @@ def get_line(character: str) -> str:
 if __name__ == '__main__':
     wfapp = WorkflowApp()
 
-    results = wfapp.run_and_monitor_workflow(task_chain_workflow)
+    results = wfapp.run_and_monitor_workflow_sync(task_chain_workflow)
     print(f"Results: {results}")


### PR DESCRIPTION
Convert `run_and_monitor_workflow` into an async‑first implementation (with a new sync wrapper), fix late‑binding in workflow registration, and apply minor return‑type and style cleanups.

## Key Changes

### Async runner

- Renamed run_and_monitor_workflow → run_and_monitor_workflow_async 
- Off‑loaded blocking calls (`run_workflow`, `stop_runtime`) via `asyncio.to_thread`

### Sync wrapper

- Introduced `run_and_monitor_workflow_sync` for non‑async callers, using asyncio.run

### Registration closure fix

- Replaced inline wrapped function with a make_wrapped closure to avoid late‑binding capture in `_register_workflows`

### Return‑type adjustment

- Changed get_data_from_store signature from `Tuple[bool, dict]` to `Optional[dict]`

### UUID simplification

- Switched `str(uuid.uuid4()).replace("-", "")` → `uuid.uuid4().hex`

## Comments

Tested Cookbook and Quickstarts impacted.