### PR TITLE
Agent memory: add support for all Dapr state stores

### DIFF
--- a/quickstarts/03-agent-tool-call/components/historystore.yaml
+++ b/quickstarts/03-agent-tool-call/components/historystore.yaml
@@ -1,0 +1,12 @@
+apiVersion: dapr.io/v1alpha1
+kind: Component
+metadata:
+  name: historystore
+spec:
+  type: state.redis
+  version: v1
+  metadata:
+  - name: redisHost
+    value: localhost:6379
+  - name: redisPassword
+    value: ""


### PR DESCRIPTION
Currently, the `ConversationDaprStateMemory` only supports Redis with the JSON module, and also requires a pre-built schema.

The current change changes the data structure to support all Dapr state stores.
