### PR TITLE
Fix: Return import

### DIFF
--- a/dapr_agents/types/workflow.py
+++ b/dapr_agents/types/workflow.py
@@ -1,3 +1,4 @@
+from dapr.ext.workflow import DaprWorkflowContext
 from enum import Enum
 
 


### PR DESCRIPTION
@Cyb3rWard0g returning the import of `from dapr.ext.workflow import DaprWorkflowContext`