### PR TITLE
Chore/type checking types 01

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -5,6 +5,7 @@ on:
     branches:
       - feature/*
       - feat/*
+      - chore/*
       - bugfix/*
       - hotfix/*
       - fix/*

--- a/dapr_agents/types/agent.py
+++ b/dapr_agents/types/agent.py
@@ -70,13 +70,15 @@ class AgentActorState(BaseModel):
     """Represents the state of an agent, tracking message history, task history, and overall status."""
 
     messages: Optional[List[AgentActorMessage]] = Field(
-        default_factory=list, description="History of messages exchanged by the agent"
+        default_factory=list[AgentActorMessage],
+        description="History of messages exchanged by the agent",
     )
     message_count: int = Field(
         0, description="Total number of messages exchanged by the agent"
     )
     task_history: Optional[List[AgentTaskEntry]] = Field(
-        default_factory=list, description="History of tasks the agent has performed"
+        default_factory=list[AgentTaskEntry],
+        description="History of tasks the agent has performed",
     )
     overall_status: AgentStatus = Field(
         AgentStatus.IDLE, description="Current operational status of the agent"

--- a/dapr_agents/types/llm.py
+++ b/dapr_agents/types/llm.py
@@ -143,7 +143,7 @@ class OpenAIModelConfig(OpenAIClientConfig):
     type: Literal["openai"] = Field(
         "openai", description="Type of the model, must always be 'openai'"
     )
-    name: str = Field(default=None, description="Name of the OpenAI model")
+    name: str = Field(default="", description="Name of the OpenAI model")
 
 
 class AzureOpenAIModelConfig(AzureOpenAIClientConfig):
@@ -157,7 +157,7 @@ class HFHubModelConfig(HFInferenceClientConfig):
         "huggingface", description="Type of the model, must always be 'huggingface'"
     )
     name: str = Field(
-        default=None, description="Name of the model available through Hugging Face"
+        default="", description="Name of the model available through Hugging Face"
     )
 
 
@@ -166,7 +166,7 @@ class NVIDIAModelConfig(NVIDIAClientConfig):
         "nvidia", description="Type of the model, must always be 'nvidia'"
     )
     name: str = Field(
-        default=None, description="Name of the model available through NVIDIA"
+        default="", description="Name of the model available through NVIDIA"
     )
 
 

--- a/dapr_agents/types/message.py
+++ b/dapr_agents/types/message.py
@@ -1,3 +1,4 @@
+from typing import Any
 from pydantic import (
     BaseModel,
     field_validator,
@@ -183,7 +184,7 @@ class ChatCompletion(BaseModel):
     object: Optional[str] = None
     usage: dict
 
-    def get_message(self) -> Optional[str]:
+    def get_message(self) -> Optional[Dict[str, Any]]:
         """
         Retrieve the main message content from the first choice.
         """

--- a/mypy.ini
+++ b/mypy.ini
@@ -41,7 +41,7 @@ ignore_errors = True
 ignore_errors = True
 
 [mypy-dapr_agents.types.*]
-ignore_errors = True
+disable_error_code = union-attr
 
 [mypy-dapr_agents.workflow.*]
 ignore_errors = True

--- a/requirements.txt
+++ b/requirements.txt
@@ -15,3 +15,4 @@ rich==13.9.4
 huggingface_hub==0.30.2
 numpy==2.2.2
 mcp==1.6.0
+dotenv==0.9.9


### PR DESCRIPTION
First iteration of fixing type errors reported by `mypy` for `dapr_agents.types`:

**before**
```shell
tox -e type
type: commands[0] quickstarts/05-multi-agent-workflow-dapr-workflows> mypy --config-file mypy.ini
dapr_agents/types/agent.py:73: error: Argument "default_factory" to "Field" has incompatible type "type[list[_T]]"; expected "Callable[[], Never] | Callable[[dict[str, Any]], Never]"  [arg-type]
dapr_agents/types/agent.py:79: error: Argument "default_factory" to "Field" has incompatible type "type[list[_T]]"; expected "Callable[[], Never] | Callable[[dict[str, Any]], Never]"  [arg-type]
dapr_agents/types/message.py:190: error: Incompatible return value type (got "dict[str, Any] | None", expected "str | None")  [return-value]
dapr_agents/types/message.py:213: error: "str" has no attribute "get"  [attr-defined]
dapr_agents/types/llm.py:146: error: Incompatible types in assignment (expression has type "None", variable has type "str")  [assignment]
dapr_agents/types/llm.py:159: error: Incompatible types in assignment (expression has type "None", variable has type "str")  [assignment]
dapr_agents/types/llm.py:168: error: Incompatible types in assignment (expression has type "None", variable has type "str")  [assignment]
dapr_agents/types/llm.py:428: error: Item "dict[Any, Any]" of "OpenAIModelConfig | AzureOpenAIModelConfig | HFHubModelConfig | NVIDIAModelConfig | dict[Any, Any] | Any" has no attribute "model_fields_set"  [union-attr]
dapr_agents/types/llm.py:429: error: Item "dict[Any, Any]" of "OpenAIChatCompletionParams | HFHubChatCompletionParams | NVIDIAChatCompletionParams | dict[Any, Any] | Any" has no attribute "model"  [union-attr]
dapr_agents/types/llm.py:429: error: Item "AzureOpenAIModelConfig" of "OpenAIModelConfig | AzureOpenAIModelConfig | HFHubModelConfig | NVIDIAModelConfig | dict[Any, Any] | Any" has no attribute "name"  [union-attr]
dapr_agents/types/llm.py:429: error: Item "dict[Any, Any]" of "OpenAIModelConfig | AzureOpenAIModelConfig | HFHubModelConfig | NVIDIAModelConfig | dict[Any, Any] | Any" has no attribute "name"  [union-attr]
dapr_agents/types/llm.py:430: error: Item "dict[Any, Any]" of "OpenAIModelConfig | AzureOpenAIModelConfig | HFHubModelConfig | NVIDIAModelConfig | dict[Any, Any] | Any" has no attribute "model_fields_set"  [union-attr]
dapr_agents/types/llm.py:431: error: Item "dict[Any, Any]" of "OpenAIChatCompletionParams | HFHubChatCompletionParams | NVIDIAChatCompletionParams | dict[Any, Any] | Any" has no attribute "model"  [union-attr]
dapr_agents/types/llm.py:431: error: Item "OpenAIModelConfig" of "OpenAIModelConfig | AzureOpenAIModelConfig | HFHubModelConfig | NVIDIAModelConfig | dict[Any, Any] | Any" has no attribute "azure_deployment"  [union-attr]
dapr_agents/types/llm.py:431: error: Item "HFHubModelConfig" of "OpenAIModelConfig | AzureOpenAIModelConfig | HFHubModelConfig | NVIDIAModelConfig | dict[Any, Any] | Any" has no attribute "azure_deployment"  [union-attr]
Found 19 errors in 3 files (checked 165 source files)
dapr_agents/types/llm.py:431: error: Item "NVIDIAModelConfig" of "OpenAIModelConfig | AzureOpenAIModelConfig | HFHubModelConfig | NVIDIAModelConfig | dict[Any, Any] | Any" has no attribute "azure_deployment"  [union-attr]
dapr_agents/types/llm.py:431: error: Item "dict[Any, Any]" of "OpenAIModelConfig | AzureOpenAIModelConfig | HFHubModelConfig | NVIDIAModelConfig | dict[Any, Any] | Any" has no attribute "azure_deployment"  [union-attr]
dapr_agents/types/llm.py:553: error: Item "tuple[Any, ...]" of "BufferedReader | IO[Any] | tuple[Any, ...]" has no attribute "closed"  [union-attr]
dapr_agents/types/llm.py:617: error: Item "tuple[Any, ...]" of "BufferedReader | IO[Any] | tuple[Any, ...]" has no attribute "closed"  [union-attr]
type: exit 1 (2.27 seconds) /Users/scni/workspace/dapr-agents> mypy --config-file mypy.ini pid=98092
  type: FAIL code 1 (2.29=setup[0.03]+cmd[2.27] seconds)
  evaluation failed :( (2.33 seconds)
```

**Now**

```shell
tox -e type
type: commands[0] quickstarts/05-multi-agent-workflow-dapr-workflows> mypy --config-file mypy.ini
Success: no issues found in 165 source files
  type: OK (2.16=setup[0.03]+cmd[2.13] seconds)
  congratulations :) (2.20 seconds)
```

**Remaining**

```shell
tox -e type
type: commands[0] quickstarts/05-multi-agent-workflow-dapr-workflows> mypy --config-file mypy.ini
dapr_agents/types/llm.py:428: error: Item "dict[Any, Any]" of "OpenAIModelConfig | AzureOpenAIModelConfig | HFHubModelConfig | NVIDIAModelConfig | dict[Any, Any] | Any" has no attribute "model_fields_set"  [union-attr]
dapr_agents/types/llm.py:429: error: Item "dict[Any, Any]" of "OpenAIChatCompletionParams | HFHubChatCompletionParams | NVIDIAChatCompletionParams | dict[Any, Any] | Any" has no attribute "model"  [union-attr]
dapr_agents/types/llm.py:429: error: Item "AzureOpenAIModelConfig" of "OpenAIModelConfig | AzureOpenAIModelConfig | HFHubModelConfig | NVIDIAModelConfig | dict[Any, Any] | Any" has no attribute "name"  [union-attr]
dapr_agents/types/llm.py:429: error: Item "dict[Any, Any]" of "OpenAIModelConfig | AzureOpenAIModelConfig | HFHubModelConfig | NVIDIAModelConfig | dict[Any, Any] | Any" has no attribute "name"  [union-attr]
dapr_agents/types/llm.py:430: error: Item "dict[Any, Any]" of "OpenAIModelConfig | AzureOpenAIModelConfig | HFHubModelConfig | NVIDIAModelConfig | dict[Any, Any] | Any" has no attribute "model_fields_set"  [union-attr]
dapr_agents/types/llm.py:431: error: Item "dict[Any, Any]" of "OpenAIChatCompletionParams | HFHubChatCompletionParams | NVIDIAChatCompletionParams | dict[Any, Any] | Any" has no attribute "model"  [union-attr]
dapr_agents/types/llm.py:431: error: Item "OpenAIModelConfig" of "OpenAIModelConfig | AzureOpenAIModelConfig | HFHubModelConfig | NVIDIAModelConfig | dict[Any, Any] | Any" has no attribute "azure_deployment"  [union-attr]
dapr_agents/types/llm.py:431: error: Item "HFHubModelConfig" of "OpenAIModelConfig | AzureOpenAIModelConfig | HFHubModelConfig | NVIDIAModelConfig | dict[Any, Any] | Any" has no attribute "azure_deployment"  [union-attr]
dapr_agents/types/llm.py:431: error: Item "NVIDIAModelConfig" of "OpenAIModelConfig | AzureOpenAIModelConfig | HFHubModelConfig | NVIDIAModelConfig | dict[Any, Any] | Any" has no attribute "azure_deployment"  [union-attr]
dapr_agents/types/llm.py:431: error: Item "dict[Any, Any]" of "OpenAIModelConfig | AzureOpenAIModelConfig | HFHubModelConfig | NVIDIAModelConfig | dict[Any, Any] | Any" has no attribute "azure_deployment"  [union-attr]
Found 12 errors in 1 file (checked 165 source files)
dapr_agents/types/llm.py:553: error: Item "tuple[Any, ...]" of "BufferedReader | IO[Any] | tuple[Any, ...]" has no attribute "closed"  [union-attr]
dapr_agents/types/llm.py:617: error: Item "tuple[Any, ...]" of "BufferedReader | IO[Any] | tuple[Any, ...]" has no attribute "closed"  [union-attr]
type: exit 1 (2.27 seconds) /Users/scni/workspace/dapr-agents> mypy --config-file mypy.ini pid=98818
  type: FAIL code 1 (2.30=setup[0.03]+cmd[2.27] seconds)
  evaluation failed :( (2.35 seconds)
```

@yaron2, @Cyb3rWard0g: How do you best want to deal with the `union-attr` error where some of the `parameters.model` will not contain all possible configurations?