### PR TITLE
feat: provide type hints and better DX for new community members/users

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -57,6 +57,9 @@ Source = "https://github.com/dapr/python-sdk"
 include = ["dapr_agents"]
 exclude = ["tests"]
 
+[tool.setuptools.package-data]
+dapr_agents = ["py.typed"]
+
 [tool.setuptools_scm]
 version_scheme = "guess-next-dev"
 local_scheme = "no-local-version"


### PR DESCRIPTION
This PR adds a py.typed marker file and updates myproject.toml to include it in package-data. This signals to type checkers that the package provides inline type annotations, following PEP 561. It improves type-checking support for users of the package, and gives better support in IDEs.

For reference:
https://peps.python.org/pep-0561/#packaging-type-information
https://blog.whtsky.me/tech/2021/dont-forget-py.typed-for-your-typed-python-package/

I've also added this in the python sdk for dapr so when we are using their packages, we can benefit from this on a consuming side too :) https://github.com/dapr/python-sdk/pull/812