### PR TITLE
Workflow App updates to Register Tasks and LLM client Fix

### DIFF
--- a/dapr_agents/agents/base.py
+++ b/dapr_agents/agents/base.py
@@ -27,7 +27,6 @@ from typing import (
 )
 from pydantic import BaseModel, Field, PrivateAttr, model_validator, ConfigDict
 from dapr_agents.llm.chat import ChatClientBase
-from dapr_agents.llm.openai import OpenAIChatClient
 
 logger = logging.getLogger(__name__)
 
@@ -66,8 +65,8 @@ class AgentBase(BaseModel, ABC):
         default=None,
         description="A custom system prompt, overriding name, role, goal, and instructions.",
     )
-    llm: ChatClientBase = Field(
-        default_factory=OpenAIChatClient,
+    llm: Optional[ChatClientBase] = Field(
+        default=None,
         description="Language model client for generating responses.",
     )
     prompt_template: Optional[PromptTemplateBase] = Field(
@@ -136,12 +135,16 @@ Your role is {role}.
     @model_validator(mode="after")
     def validate_llm(cls, values):
         """Validate that LLM is properly configured."""
-        if hasattr(values, "llm") and values.llm:
-            try:
-                # Validate LLM is properly configured by accessing it as this is required to be set.
-                _ = values.llm
-            except Exception as e:
-                raise ValueError(f"Failed to initialize LLM: {e}") from e
+        if hasattr(values, "llm"):
+            if values.llm is None:
+                logger.warning("LLM client is None, some functionality may be limited.")
+            else:
+                try:
+                    # Validate LLM is properly configured by accessing it as this is required to be set.
+                    _ = values.llm
+                except Exception as e:
+                    logger.error(f"Failed to initialize LLM: {e}")
+                    values.llm = None
 
         return values
 
@@ -160,10 +163,15 @@ Your role is {role}.
         if self.tool_choice is None:
             self.tool_choice = "auto" if self.tools else None
 
+        # Initialize LLM if not provided
+        if self.llm is None:
+            self.llm = self._create_default_llm()
+
         # Centralize prompt template selection logic
         self.prompt_template = self._initialize_prompt_template()
         # Ensure LLM client and agent both reference the same template
-        self.llm.prompt_template = self.prompt_template
+        if self.llm is not None:
+            self.llm.prompt_template = self.prompt_template
 
         self._validate_prompt_template()
         self.prefill_agent_attributes()
@@ -173,6 +181,18 @@ Your role is {role}.
         self._setup_signal_handlers()
 
         super().model_post_init(__context)
+
+    def _create_default_llm(self) -> Optional[ChatClientBase]:
+        """
+        Creates a default LLM client when none is provided.
+        Returns None if the default LLM cannot be created due to missing configuration.
+        """
+        try:
+            from dapr_agents.llm.openai import OpenAIChatClient
+            return OpenAIChatClient()
+        except Exception as e:
+            logger.warning(f"Failed to create default OpenAI client: {e}. LLM will be None.")
+            return None
 
     def _initialize_prompt_template(self) -> PromptTemplateBase:
         """
@@ -190,7 +210,7 @@ Your role is {role}.
             return self.prompt_template
 
         # 2) LLM client has one?
-        if self.llm.prompt_template:
+        if self.llm and hasattr(self.llm, 'prompt_template') and self.llm.prompt_template:
             logger.debug("🔄 Syncing from llm.prompt_template")
             return self.llm.prompt_template
 

--- a/dapr_agents/agents/base.py
+++ b/dapr_agents/agents/base.py
@@ -189,9 +189,12 @@ Your role is {role}.
         """
         try:
             from dapr_agents.llm.openai import OpenAIChatClient
+
             return OpenAIChatClient()
         except Exception as e:
-            logger.warning(f"Failed to create default OpenAI client: {e}. LLM will be None.")
+            logger.warning(
+                f"Failed to create default OpenAI client: {e}. LLM will be None."
+            )
             return None
 
     def _initialize_prompt_template(self) -> PromptTemplateBase:
@@ -210,7 +213,11 @@ Your role is {role}.
             return self.prompt_template
 
         # 2) LLM client has one?
-        if self.llm and hasattr(self.llm, 'prompt_template') and self.llm.prompt_template:
+        if (
+            self.llm
+            and hasattr(self.llm, "prompt_template")
+            and self.llm.prompt_template
+        ):
             logger.debug("🔄 Syncing from llm.prompt_template")
             return self.llm.prompt_template
 

--- a/dapr_agents/agents/durableagent/agent.py
+++ b/dapr_agents/agents/durableagent/agent.py
@@ -422,7 +422,7 @@ class DurableAgent(AgenticWorkflow, AgentBase):
             raise AgentError(f"Invalid JSON in tool args: {e}")
 
         # Run the tool
-        logger.info(f"Executing tool '{fn_name}' with args: {args}")
+        logger.debug(f"Executing tool '{fn_name}' with args: {args}")
         try:
             result = await self.tool_executor.run_tool(fn_name, **args)
         except Exception as e:

--- a/dapr_agents/llm/huggingface/chat.py
+++ b/dapr_agents/llm/huggingface/chat.py
@@ -162,10 +162,13 @@ class HFHubChatClient(HFHubInferenceClientBase, ChatClientBase):
         else:
             params.update(kwargs)
 
-        # 4) Override model if given
+        # 4) Add the stream parameter explicitly to params
+        params["stream"] = stream
+
+        # 5) Override model if given
         params["model"] = model or self.model
 
-        # 5) Inject tools / response_format via RequestHandler
+        # 6) Inject tools / response_format via RequestHandler
         params = RequestHandler.process_params(
             params,
             llm_provider=self.provider,
@@ -174,11 +177,11 @@ class HFHubChatClient(HFHubInferenceClientBase, ChatClientBase):
             structured_mode=structured_mode,
         )
 
-        # 6) Call HF API + delegate parsing to ResponseHandler
+        # 7) Call HF API + delegate parsing to ResponseHandler
         try:
             logger.info("Calling HF ChatCompletion Inference API...")
             logger.debug(f"HF params: {params}")
-            response = self.client.chat.completions.create(**params, stream=stream)
+            response = self.client.chat.completions.create(**params)
             logger.info("HF ChatCompletion response received.")
 
             # HF-specific error‐code handling
@@ -198,4 +201,4 @@ class HFHubChatClient(HFHubInferenceClientBase, ChatClientBase):
 
         except Exception as e:
             logger.error("Hugging Face ChatCompletion API error", exc_info=True)
-            raise ValueError("Failed to process HF chat completion") from e
+            raise ValueError(f"Failed to process HF chat completion: {e}") from e

--- a/dapr_agents/llm/nvidia/chat.py
+++ b/dapr_agents/llm/nvidia/chat.py
@@ -168,11 +168,14 @@ class NVIDIAChatClient(NVIDIAClientBase, ChatClientBase):
         else:
             params.update(kwargs)
 
-        # 4) Override model & max_tokens if provided
+        # 4) Add the stream parameter explicitly to params
+        params["stream"] = stream
+
+        # 5) Override model & max_tokens if provided
         params["model"] = model or self.model
         params["max_tokens"] = max_tokens or self.max_tokens
 
-        # 5) Inject tools / response_format / structured_mode
+        # 6) Inject tools / response_format / structured_mode
         params = RequestHandler.process_params(
             params,
             llm_provider=self.provider,
@@ -181,11 +184,11 @@ class NVIDIAChatClient(NVIDIAClientBase, ChatClientBase):
             structured_mode=structured_mode,
         )
 
-        # 6) Call NVIDIA API + dispatch to ResponseHandler
+        # 7) Call NVIDIA API + dispatch to ResponseHandler
         try:
             logger.info("Calling NVIDIA ChatCompletion API.")
             logger.debug(f"Parameters: {params}")
-            resp = self.client.chat.completions.create(**params, stream=stream)
+            resp = self.client.chat.completions.create(**params)
             return ResponseHandler.process_response(
                 response=resp,
                 llm_provider=self.provider,

--- a/dapr_agents/llm/openai/chat.py
+++ b/dapr_agents/llm/openai/chat.py
@@ -194,10 +194,13 @@ class OpenAIChatClient(OpenAIClientBase, ChatClientBase):
         else:
             params.update(kwargs)
 
-        # 4) Override model if given
+        # 4) Add the stream parameter explicitly to params
+        params["stream"] = stream
+
+        # 5) Override model if given
         params["model"] = model or self.model
 
-        # 5) Let RequestHandler inject tools / response_format / structured_mode
+        # 6) Let RequestHandler inject tools / response_format / structured_mode
         params = RequestHandler.process_params(
             params,
             llm_provider=self.provider,
@@ -206,12 +209,12 @@ class OpenAIChatClient(OpenAIClientBase, ChatClientBase):
             structured_mode=structured_mode,
         )
 
-        # 6) Call API + hand off to ResponseHandler
+        # 7) Call API + hand off to ResponseHandler
         try:
             logger.info("Calling OpenAI ChatCompletion...")
             logger.debug(f"ChatCompletion params: {params}")
             resp = self.client.chat.completions.create(
-                **params, stream=stream, timeout=self.timeout
+                **params, timeout=self.timeout
             )
             logger.info("ChatCompletion response received.")
             return ResponseHandler.process_response(

--- a/dapr_agents/llm/openai/chat.py
+++ b/dapr_agents/llm/openai/chat.py
@@ -213,9 +213,7 @@ class OpenAIChatClient(OpenAIClientBase, ChatClientBase):
         try:
             logger.info("Calling OpenAI ChatCompletion...")
             logger.debug(f"ChatCompletion params: {params}")
-            resp = self.client.chat.completions.create(
-                **params, timeout=self.timeout
-            )
+            resp = self.client.chat.completions.create(**params, timeout=self.timeout)
             logger.info("ChatCompletion response received.")
             return ResponseHandler.process_response(
                 response=resp,

--- a/dapr_agents/llm/openai/client/openai.py
+++ b/dapr_agents/llm/openai/client/openai.py
@@ -49,15 +49,15 @@ class OpenAIClient:
         # Build kwargs, only including non-None values so SDK can fall back to env vars
         kwargs = {}
         if self.api_key is not None:
-            kwargs['api_key'] = self.api_key
+            kwargs["api_key"] = self.api_key
         if self.base_url is not None:
-            kwargs['base_url'] = self.base_url
+            kwargs["base_url"] = self.base_url
         if self.organization is not None:
-            kwargs['organization'] = self.organization
+            kwargs["organization"] = self.organization
         if self.project is not None:
-            kwargs['project'] = self.project
-        kwargs['timeout'] = self.timeout
-        
+            kwargs["project"] = self.project
+        kwargs["timeout"] = self.timeout
+
         return OpenAI(**kwargs)
 
     @classmethod

--- a/dapr_agents/llm/openai/client/openai.py
+++ b/dapr_agents/llm/openai/client/openai.py
@@ -17,7 +17,7 @@ class OpenAIClient:
 
     def __init__(
         self,
-        api_key: str,
+        api_key: Optional[str] = None,
         base_url: Optional[str] = None,
         organization: Optional[str] = None,
         project: Optional[str] = None,
@@ -27,16 +27,16 @@ class OpenAIClient:
         Initializes the OpenAI client with API key, base URL, and organization.
 
         Args:
-            api_key: The OpenAI API key.
+            api_key: The OpenAI API key (will fall back to OPENAI_API_KEY env var if not provided).
             base_url: The base URL for OpenAI API (defaults to https://api.openai.com/v1).
             organization: The OpenAI organization (optional).
             project: The OpenAI Project name (optional).
             timeout: Timeout for requests (default is 1500 seconds).
         """
-        self.api_key = api_key  # or inferred from OPENAI_API_KEY env variable.
-        self.base_url = base_url  # or set to "https://api.openai.com/v1" by default.
-        self.organization = organization  # or inferred from OPENAI_ORG_ID env variable.
-        self.project = project  # or inferred from OPENAI_PROJECT_ID env variable.
+        self.api_key = api_key  # Will be None if not provided - OpenAI SDK will handle env var fallback
+        self.base_url = base_url
+        self.organization = organization
+        self.project = project
         self.timeout = HTTPHelper.configure_timeout(timeout)
 
     def get_client(self) -> OpenAI:
@@ -46,13 +46,19 @@ class OpenAIClient:
         Returns:
             OpenAI: The initialized OpenAI client.
         """
-        return OpenAI(
-            api_key=self.api_key,
-            base_url=self.base_url,
-            organization=self.organization,
-            project=self.project,
-            timeout=self.timeout,
-        )
+        # Build kwargs, only including non-None values so SDK can fall back to env vars
+        kwargs = {}
+        if self.api_key is not None:
+            kwargs['api_key'] = self.api_key
+        if self.base_url is not None:
+            kwargs['base_url'] = self.base_url
+        if self.organization is not None:
+            kwargs['organization'] = self.organization
+        if self.project is not None:
+            kwargs['project'] = self.project
+        kwargs['timeout'] = self.timeout
+        
+        return OpenAI(**kwargs)
 
     @classmethod
     def from_config(

--- a/dapr_agents/workflow/base.py
+++ b/dapr_agents/workflow/base.py
@@ -116,14 +116,14 @@ class WorkflowApp(BaseModel):
     def register_task(self, task_func: Callable, name: Optional[str] = None) -> None:
         """
         Manually register a @task-decorated function, similar to native Dapr pattern.
-        
+
         This allows explicit registration of tasks from other modules or packages.
         The task will be registered immediately with the Dapr runtime.
-        
+
         Args:
             task_func: The @task-decorated function to register
             name: Optional custom name (defaults to function name or _task_name)
-            
+
         Example:
             from tasks.my_tasks import generate_queries
             wfapp.register_task(generate_queries)
@@ -131,55 +131,65 @@ class WorkflowApp(BaseModel):
         """
         # Validate input
         if not callable(task_func):
-            raise ValueError(f"task_func must be callable, got {type(task_func)}: {task_func}")
-            
+            raise ValueError(
+                f"task_func must be callable, got {type(task_func)}: {task_func}"
+            )
+
         if not getattr(task_func, "_is_task", False):
-            raise ValueError(f"Function {getattr(task_func, '__name__', str(task_func))} is not decorated with @task")
-            
-        task_name = name or getattr(task_func, "_task_name", getattr(task_func, "__name__", "unknown_task"))
-        
+            raise ValueError(
+                f"Function {getattr(task_func, '__name__', str(task_func))} is not decorated with @task"
+            )
+
+        task_name = name or getattr(
+            task_func, "_task_name", getattr(task_func, "__name__", "unknown_task")
+        )
+
         # Check if already registered
         if task_name in self.tasks:
             logger.warning(f"Task '{task_name}' is already registered, skipping")
             return
-            
+
         # Register immediately with Dapr runtime using existing registration logic
         llm = self._choose_llm_for(task_func)
         logger.debug(
             f"Manually registering task '{task_name}' with llm={getattr(llm, '__class__', None)}"
         )
-        
+
         kwargs = getattr(task_func, "_task_kwargs", {})
         task_instance = WorkflowTask(
             func=task_func,
             description=getattr(task_func, "_task_description", None),
             agent=getattr(task_func, "_task_agent", None),
             llm=llm,
-            include_chat_history=getattr(task_func, "_task_include_chat_history", False),
+            include_chat_history=getattr(
+                task_func, "_task_include_chat_history", False
+            ),
             workflow_app=self,
             **kwargs,
         )
-        
+
         # Wrap for Dapr invocation
         wrapped = self._make_task_wrapper(task_name, task_func, task_instance)
         self.wf_runtime.register_activity(wrapped)
         self.tasks[task_name] = wrapped
 
-    def register_tasks_from_module(self, module_name_or_object: Union[str, Any]) -> None:
+    def register_tasks_from_module(
+        self, module_name_or_object: Union[str, Any]
+    ) -> None:
         """
         Register all @task-decorated functions from a specific module.
-        
+
         Args:
             module_name_or_object: Module name string (e.g., "tasks.queries") or imported module object
-            
+
         Example:
             # Using string name
             wfapp.register_tasks_from_module("tasks.queries")
-            
+
             # Using imported module
             import tasks.queries
             wfapp.register_tasks_from_module(tasks.queries)
-            
+
             # Using from import
             from tasks import queries
             wfapp.register_tasks_from_module(queries)
@@ -188,13 +198,14 @@ class WorkflowApp(BaseModel):
             # Handle both string names and module objects
             if isinstance(module_name_or_object, str):
                 import importlib
+
                 module = importlib.import_module(module_name_or_object)
                 module_name = module_name_or_object
             else:
                 # Assume it's a module object
                 module = module_name_or_object
-                module_name = getattr(module, '__name__', str(module))
-            
+                module_name = getattr(module, "__name__", str(module))
+
             registered_count = 0
             for name, fn in inspect.getmembers(module, inspect.isfunction):
                 if getattr(fn, "_is_task", False):
@@ -202,58 +213,67 @@ class WorkflowApp(BaseModel):
                     if task_name not in self.tasks:  # Skip if already registered
                         self.register_task(fn)
                         registered_count += 1
-                        
-            logger.info(f"Registered {registered_count} tasks from module '{module_name}'")
-            
+
+            logger.info(
+                f"Registered {registered_count} tasks from module '{module_name}'"
+            )
+
         except ImportError as e:
             raise ImportError(f"Could not import module '{module_name_or_object}': {e}")
         except Exception as e:
-            raise RuntimeError(f"Error registering tasks from module '{module_name_or_object}': {e}")
+            raise RuntimeError(
+                f"Error registering tasks from module '{module_name_or_object}': {e}"
+            )
 
     def register_tasks_from_package(self, package_name: str) -> None:
         """
         Register all @task-decorated functions from all modules in a package.
-        
+
         Args:
             package_name: Name of package to scan (e.g., "tasks")
-            
+
         Example:
             wfapp.register_tasks_from_package("tasks")  # Scans tasks/*.py
         """
         try:
             import importlib
             import pkgutil
+
             package = importlib.import_module(package_name)
-            
+
             # Collect all tasks first, then register using the original _register_tasks method
             discovered_tasks: Dict[str, Callable] = {}
-            
+
             total_tasks = 0
             for importer, modname, ispkg in pkgutil.iter_modules(package.__path__):
                 if not ispkg:  # Only scan modules, not sub-packages
                     full_module_name = f"{package_name}.{modname}"
                     try:
                         module = importlib.import_module(full_module_name)
-                        
+
                         for name, fn in inspect.getmembers(module, inspect.isfunction):
                             if getattr(fn, "_is_task", False):
                                 task_name = getattr(fn, "_task_name", name)
-                                if task_name not in self.tasks:  # Skip if already registered
+                                if (
+                                    task_name not in self.tasks
+                                ):  # Skip if already registered
                                     discovered_tasks[task_name] = fn
                                     total_tasks += 1
-                        
+
                     except Exception as e:
                         logger.warning(f"Failed to scan module {full_module_name}: {e}")
-            
+
             # Now register all discovered tasks using the original _register_tasks method
             if discovered_tasks:
                 self._register_tasks(discovered_tasks)
-            
+
             logger.info(f"Registered {total_tasks} tasks from package '{package_name}'")
         except ImportError as e:
             raise ImportError(f"Could not import package '{package_name}': {e}")
         except Exception as e:
-            raise RuntimeError(f"Error registering tasks from package '{package_name}': {e}")
+            raise RuntimeError(
+                f"Error registering tasks from package '{package_name}': {e}"
+            )
 
     def _register_tasks(self, tasks: Dict[str, Callable]) -> None:
         """Register each discovered task with the Dapr runtime using direct registration."""
@@ -276,7 +296,7 @@ class WorkflowApp(BaseModel):
             )
             # Wrap for Dapr invocation
             wrapped = self._make_task_wrapper(task_name, method, task_instance)
-            
+
             # Use direct registration like official Dapr examples
             self.wf_runtime.register_activity(wrapped)
             self.tasks[task_name] = wrapped
@@ -308,7 +328,7 @@ class WorkflowApp(BaseModel):
             except Exception:
                 logger.exception(f"Task '{task_name}' failed")
                 raise
-        
+
         return wrapper
 
     # TODO: workflow discovery can also come from dapr runtime
@@ -368,7 +388,9 @@ class WorkflowApp(BaseModel):
         if isinstance(task, str):
             task_name = task
         elif callable(task):
-            task_name = getattr(task, "_task_name", getattr(task, "__name__", "unknown_task"))
+            task_name = getattr(
+                task, "_task_name", getattr(task, "__name__", "unknown_task")
+            )
         else:
             raise ValueError(f"Invalid task reference: {task}")
 
@@ -394,7 +416,11 @@ class WorkflowApp(BaseModel):
         if isinstance(workflow, str):
             workflow_name = workflow  # Direct lookup by string name
         elif callable(workflow):
-            workflow_name = getattr(workflow, "_workflow_name", getattr(workflow, "__name__", "unknown_workflow"))
+            workflow_name = getattr(
+                workflow,
+                "_workflow_name",
+                getattr(workflow, "__name__", "unknown_workflow"),
+            )
         else:
             raise ValueError(f"Invalid workflow reference: {workflow}")
 

--- a/dapr_agents/workflow/base.py
+++ b/dapr_agents/workflow/base.py
@@ -17,7 +17,6 @@ from durabletask import task as dtask
 from pydantic import BaseModel, ConfigDict, Field
 
 from dapr_agents.agents.base import ChatClientBase
-from dapr_agents.llm.openai import OpenAIChatClient
 from dapr_agents.types.workflow import DaprWorkflowStatus
 from dapr_agents.workflow.task import WorkflowTask
 from dapr_agents.workflow.utils.core import get_decorated_methods, is_pydantic_model
@@ -32,9 +31,9 @@ class WorkflowApp(BaseModel):
     A Pydantic-based class to encapsulate a Dapr Workflow runtime and manage workflows and tasks.
     """
 
-    llm: ChatClientBase = Field(
-        default_factory=OpenAIChatClient,
-        description="The default LLM client for all LLM-based tasks.",
+    llm: Optional[ChatClientBase] = Field(
+        default=None,
+        description="The default LLM client for tasks that explicitly require an LLM but don't specify one (optional).",
     )
     # TODO: I think this should be within the wf client or wf runtime...?
     timeout: int = Field(
@@ -85,13 +84,18 @@ class WorkflowApp(BaseModel):
         """
         Encapsulate LLM selection logic.
           1. Use per-task override if provided on decorator.
-          2. Else if marked as explicitly requiring an LLM, fall back to default app LLM.
+          2. Else if marked as explicitly requiring an LLM, fall back to default app LLM (if available).
           3. Otherwise, returns None.
         """
         per_task = getattr(method, "_task_llm", None)
         if per_task:
             return per_task
         if getattr(method, "_explicit_llm", False):
+            if self.llm is None:
+                logger.warning(
+                    f"Task '{getattr(method, '_task_name', getattr(method, '__name__', str(method)))}' requires an LLM "
+                    "but no default LLM is configured in WorkflowApp and no explicit LLM was provided."
+                )
             return self.llm
         return None
 
@@ -109,8 +113,150 @@ class WorkflowApp(BaseModel):
         logger.debug(f"Discovered tasks: {list(tasks)}")
         return tasks
 
+    def register_task(self, task_func: Callable, name: Optional[str] = None) -> None:
+        """
+        Manually register a @task-decorated function, similar to native Dapr pattern.
+        
+        This allows explicit registration of tasks from other modules or packages.
+        The task will be registered immediately with the Dapr runtime.
+        
+        Args:
+            task_func: The @task-decorated function to register
+            name: Optional custom name (defaults to function name or _task_name)
+            
+        Example:
+            from tasks.my_tasks import generate_queries
+            wfapp.register_task(generate_queries)
+            wfapp.register_task(generate_queries, name="custom_name")
+        """
+        # Validate input
+        if not callable(task_func):
+            raise ValueError(f"task_func must be callable, got {type(task_func)}: {task_func}")
+            
+        if not getattr(task_func, "_is_task", False):
+            raise ValueError(f"Function {getattr(task_func, '__name__', str(task_func))} is not decorated with @task")
+            
+        task_name = name or getattr(task_func, "_task_name", getattr(task_func, "__name__", "unknown_task"))
+        
+        # Check if already registered
+        if task_name in self.tasks:
+            logger.warning(f"Task '{task_name}' is already registered, skipping")
+            return
+            
+        # Register immediately with Dapr runtime using existing registration logic
+        llm = self._choose_llm_for(task_func)
+        logger.debug(
+            f"Manually registering task '{task_name}' with llm={getattr(llm, '__class__', None)}"
+        )
+        
+        kwargs = getattr(task_func, "_task_kwargs", {})
+        task_instance = WorkflowTask(
+            func=task_func,
+            description=getattr(task_func, "_task_description", None),
+            agent=getattr(task_func, "_task_agent", None),
+            llm=llm,
+            include_chat_history=getattr(task_func, "_task_include_chat_history", False),
+            workflow_app=self,
+            **kwargs,
+        )
+        
+        # Wrap for Dapr invocation
+        wrapped = self._make_task_wrapper(task_name, task_func, task_instance)
+        self.wf_runtime.register_activity(wrapped)
+        self.tasks[task_name] = wrapped
+
+    def register_tasks_from_module(self, module_name_or_object: Union[str, Any]) -> None:
+        """
+        Register all @task-decorated functions from a specific module.
+        
+        Args:
+            module_name_or_object: Module name string (e.g., "tasks.queries") or imported module object
+            
+        Example:
+            # Using string name
+            wfapp.register_tasks_from_module("tasks.queries")
+            
+            # Using imported module
+            import tasks.queries
+            wfapp.register_tasks_from_module(tasks.queries)
+            
+            # Using from import
+            from tasks import queries
+            wfapp.register_tasks_from_module(queries)
+        """
+        try:
+            # Handle both string names and module objects
+            if isinstance(module_name_or_object, str):
+                import importlib
+                module = importlib.import_module(module_name_or_object)
+                module_name = module_name_or_object
+            else:
+                # Assume it's a module object
+                module = module_name_or_object
+                module_name = getattr(module, '__name__', str(module))
+            
+            registered_count = 0
+            for name, fn in inspect.getmembers(module, inspect.isfunction):
+                if getattr(fn, "_is_task", False):
+                    task_name = getattr(fn, "_task_name", name)
+                    if task_name not in self.tasks:  # Skip if already registered
+                        self.register_task(fn)
+                        registered_count += 1
+                        
+            logger.info(f"Registered {registered_count} tasks from module '{module_name}'")
+            
+        except ImportError as e:
+            raise ImportError(f"Could not import module '{module_name_or_object}': {e}")
+        except Exception as e:
+            raise RuntimeError(f"Error registering tasks from module '{module_name_or_object}': {e}")
+
+    def register_tasks_from_package(self, package_name: str) -> None:
+        """
+        Register all @task-decorated functions from all modules in a package.
+        
+        Args:
+            package_name: Name of package to scan (e.g., "tasks")
+            
+        Example:
+            wfapp.register_tasks_from_package("tasks")  # Scans tasks/*.py
+        """
+        try:
+            import importlib
+            import pkgutil
+            package = importlib.import_module(package_name)
+            
+            # Collect all tasks first, then register using the original _register_tasks method
+            discovered_tasks: Dict[str, Callable] = {}
+            
+            total_tasks = 0
+            for importer, modname, ispkg in pkgutil.iter_modules(package.__path__):
+                if not ispkg:  # Only scan modules, not sub-packages
+                    full_module_name = f"{package_name}.{modname}"
+                    try:
+                        module = importlib.import_module(full_module_name)
+                        
+                        for name, fn in inspect.getmembers(module, inspect.isfunction):
+                            if getattr(fn, "_is_task", False):
+                                task_name = getattr(fn, "_task_name", name)
+                                if task_name not in self.tasks:  # Skip if already registered
+                                    discovered_tasks[task_name] = fn
+                                    total_tasks += 1
+                        
+                    except Exception as e:
+                        logger.warning(f"Failed to scan module {full_module_name}: {e}")
+            
+            # Now register all discovered tasks using the original _register_tasks method
+            if discovered_tasks:
+                self._register_tasks(discovered_tasks)
+            
+            logger.info(f"Registered {total_tasks} tasks from package '{package_name}'")
+        except ImportError as e:
+            raise ImportError(f"Could not import package '{package_name}': {e}")
+        except Exception as e:
+            raise RuntimeError(f"Error registering tasks from package '{package_name}': {e}")
+
     def _register_tasks(self, tasks: Dict[str, Callable]) -> None:
-        """Register each discovered task with the Dapr runtime."""
+        """Register each discovered task with the Dapr runtime using direct registration."""
         for task_name, method in tasks.items():
             llm = self._choose_llm_for(method)
             logger.debug(
@@ -130,8 +276,10 @@ class WorkflowApp(BaseModel):
             )
             # Wrap for Dapr invocation
             wrapped = self._make_task_wrapper(task_name, method, task_instance)
-            activity_decorator = self.wf_runtime.activity(name=task_name)
-            self.tasks[task_name] = activity_decorator(wrapped)
+            
+            # Use direct registration like official Dapr examples
+            self.wf_runtime.register_activity(wrapped)
+            self.tasks[task_name] = wrapped
 
     def _make_task_wrapper(
         self, task_name: str, method: Callable, task_instance: WorkflowTask
@@ -160,7 +308,7 @@ class WorkflowApp(BaseModel):
             except Exception:
                 logger.exception(f"Task '{task_name}' failed")
                 raise
-
+        
         return wrapper
 
     # TODO: workflow discovery can also come from dapr runtime
@@ -220,7 +368,7 @@ class WorkflowApp(BaseModel):
         if isinstance(task, str):
             task_name = task
         elif callable(task):
-            task_name = getattr(task, "_task_name", task.__name__)
+            task_name = getattr(task, "_task_name", getattr(task, "__name__", "unknown_task"))
         else:
             raise ValueError(f"Invalid task reference: {task}")
 
@@ -246,7 +394,7 @@ class WorkflowApp(BaseModel):
         if isinstance(workflow, str):
             workflow_name = workflow  # Direct lookup by string name
         elif callable(workflow):
-            workflow_name = getattr(workflow, "_workflow_name", workflow.__name__)
+            workflow_name = getattr(workflow, "_workflow_name", getattr(workflow, "__name__", "unknown_workflow"))
         else:
             raise ValueError(f"Invalid workflow reference: {workflow}")
 

--- a/dapr_agents/workflow/task.py
+++ b/dapr_agents/workflow/task.py
@@ -72,7 +72,9 @@ class WorkflowTask(BaseModel):
             try:
                 self.llm = OpenAIChatClient()
             except Exception as e:
-                logger.warning(f"Could not create default OpenAI client: {e}. Task will require explicit LLM.")
+                logger.warning(
+                    f"Could not create default OpenAI client: {e}. Task will require explicit LLM."
+                )
                 self.llm = None
 
         if self.func:
@@ -81,7 +83,9 @@ class WorkflowTask(BaseModel):
                 update_wrapper(self, self.func)
             except AttributeError:
                 # If the function doesn't have the expected attributes, skip update_wrapper
-                logger.debug(f"Could not update wrapper for function {self.func}, skipping")
+                logger.debug(
+                    f"Could not update wrapper for function {self.func}, skipping"
+                )
                 pass
 
         # Capture signature for input / output handling
@@ -109,7 +113,7 @@ class WorkflowTask(BaseModel):
         """
         # Prepare input dict
         data = self._normalize_input(payload) if payload is not None else {}
-        func_name = getattr(self.func, '__name__', 'unknown_function')
+        func_name = getattr(self.func, "__name__", "unknown_function")
         logger.info(f"Executing task '{func_name}'")
         logger.debug(f"Executing task '{func_name}' with input {data!r}")
 
@@ -137,7 +141,7 @@ class WorkflowTask(BaseModel):
             return validated
 
         except Exception:
-            func_name = getattr(self.func, '__name__', 'unknown_function')
+            func_name = getattr(self.func, "__name__", "unknown_function")
             logger.exception(f"Error in task '{func_name}'")
             raise
 

--- a/dapr_agents/workflow/task.py
+++ b/dapr_agents/workflow/task.py
@@ -69,11 +69,20 @@ class WorkflowTask(BaseModel):
         """
         # Default to OpenAIChatClient if prompt‐based but no llm provided
         if self.description and not self.llm:
-            self.llm = OpenAIChatClient()
+            try:
+                self.llm = OpenAIChatClient()
+            except Exception as e:
+                logger.warning(f"Could not create default OpenAI client: {e}. Task will require explicit LLM.")
+                self.llm = None
 
         if self.func:
             # Preserve name / docs for stack traces
-            update_wrapper(self, self.func)
+            try:
+                update_wrapper(self, self.func)
+            except AttributeError:
+                # If the function doesn't have the expected attributes, skip update_wrapper
+                logger.debug(f"Could not update wrapper for function {self.func}, skipping")
+                pass
 
         # Capture signature for input / output handling
         self.signature = inspect.signature(self.func) if self.func else None
@@ -100,8 +109,9 @@ class WorkflowTask(BaseModel):
         """
         # Prepare input dict
         data = self._normalize_input(payload) if payload is not None else {}
-        logger.info(f"Executing task '{self.func.__name__}'")
-        logger.debug(f"Executing task '{self.func.__name__}' with input {data!r}")
+        func_name = getattr(self.func, '__name__', 'unknown_function')
+        logger.info(f"Executing task '{func_name}'")
+        logger.debug(f"Executing task '{func_name}' with input {data!r}")
 
         try:
             executor = self._choose_executor()
@@ -127,7 +137,8 @@ class WorkflowTask(BaseModel):
             return validated
 
         except Exception:
-            logger.exception(f"Error in task '{self.func.__name__}'")
+            func_name = getattr(self.func, '__name__', 'unknown_function')
+            logger.exception(f"Error in task '{func_name}'")
             raise
 
     def _choose_executor(self) -> Literal["agent", "llm", "python"]:

--- a/quickstarts/02_llm_call_hugging_face/README.md
+++ b/quickstarts/02_llm_call_hugging_face/README.md
@@ -172,10 +172,10 @@ This will print each partial chunk as it arrives, so you can build up the full a
 
 **2. Streaming with Tool Calls:**
 
-Use `text_completion_with_tools.py` to combine streaming with function‐call “tools”:
+Use `text_completion_stream_with_tools.py` to combine streaming with function‐call “tools”:
 
 ```bash
-python text_completion_with_tools.py
+python text_completion_stream_with_tools.py
 ```
 
 ```python

--- a/quickstarts/02_llm_call_hugging_face/text_completion_with_tools.py
+++ b/quickstarts/02_llm_call_hugging_face/text_completion_with_tools.py
@@ -42,8 +42,6 @@ messages = [
     {"role": "user", "content": "Add 5 and 7 and 2 and 2."},
 ]
 
-response: LLMChatResponse = llm.generate(
-    messages=messages, tools=[add_tool]
-)
+response: LLMChatResponse = llm.generate(messages=messages, tools=[add_tool])
 
 print(response)

--- a/quickstarts/02_llm_call_hugging_face/text_completion_with_tools.py
+++ b/quickstarts/02_llm_call_hugging_face/text_completion_with_tools.py
@@ -1,0 +1,49 @@
+from dotenv import load_dotenv
+
+from dapr_agents import HFHubChatClient
+from dapr_agents.types.message import LLMChatResponse
+from typing import Iterator
+import logging
+
+logging.basicConfig(level=logging.INFO)
+
+# Load environment variables from .env
+load_dotenv()
+
+# Basic chat completion
+llm = HFHubChatClient(model="HuggingFaceTB/SmolLM3-3B", hf_provider="auto")
+
+
+# Define a tool for addition
+def add_numbers(a: int, b: int) -> int:
+    return a + b
+
+
+# Define the tool function call schema
+add_tool = {
+    "type": "function",
+    "function": {
+        "name": "add_numbers",
+        "description": "Add two numbers together.",
+        "parameters": {
+            "type": "object",
+            "properties": {
+                "a": {"type": "integer", "description": "The first number."},
+                "b": {"type": "integer", "description": "The second number."},
+            },
+            "required": ["a", "b"],
+        },
+    },
+}
+
+# Define messages for the chat
+messages = [
+    {"role": "system", "content": "You are a helpful assistant."},
+    {"role": "user", "content": "Add 5 and 7 and 2 and 2."},
+]
+
+response: LLMChatResponse = llm.generate(
+    messages=messages, tools=[add_tool]
+)
+
+print(response)

--- a/quickstarts/02_llm_call_nvidia/README.md
+++ b/quickstarts/02_llm_call_nvidia/README.md
@@ -196,10 +196,10 @@ This will print each partial chunk as it arrives, so you can build up the full a
 
 **2. Streaming with Tool Calls:**
 
-Use `text_completion_with_tools.py` to combine streaming with function‐call “tools”:
+Use `text_completion_stream_with_tools.py` to combine streaming with function‐call “tools”:
 
 ```bash
-python text_completion_with_tools.py
+python text_completion_stream_with_tools.py
 ```
 
 ```python

--- a/quickstarts/02_llm_call_open_ai/README.md
+++ b/quickstarts/02_llm_call_open_ai/README.md
@@ -181,10 +181,10 @@ This will print each partial chunk as it arrives, so you can build up the full a
 
 **2. Streaming with Tool Calls:**
 
-Use `text_completion_with_tools.py` to combine streaming with function‐call “tools”:
+Use `text_completion_stream_with_tools.py` to combine streaming with function‐call “tools”:
 
 ```bash
-python text_completion_with_tools.py
+python text_completion_stream_with_tools.py
 ```
 
 ```python


### PR DESCRIPTION
This PR adds a new method `register_task` to the `WorkflowApp` to be able to register `tasks` defined outside of main. It also fixes a few minor LLM client parameters (i.e. stream)