### PR TITLE
fix: correct Pydantic type generation for anyOf/oneOf in MCP tool schemas

### DIFF
--- a/dapr_agents/tool/base.py
+++ b/dapr_agents/tool/base.py
@@ -250,7 +250,7 @@ class AgentTool(BaseModel):
         if self.args_model:
             try:
                 validated_args = self.args_model(**kwargs)
-                return validated_args.model_dump()
+                return validated_args.model_dump(exclude_none=True)
             except ValidationError as ve:
                 logger.debug(f"Validation failed for tool '{self.name}': {ve}")
                 raise ToolError(f"Validation error in tool '{self.name}': {ve}") from ve

--- a/dapr_agents/tool/mcp/schema.py
+++ b/dapr_agents/tool/mcp/schema.py
@@ -43,7 +43,6 @@ def create_pydantic_model_from_schema(
         required = set(schema.get("required", []))
         fields = {}
 
-
         # Process each property in the schema
         for field_name, field_props in properties.items():
             # --- Handle anyOf/oneOf for nullable/union fields ---
@@ -79,7 +78,10 @@ def create_pydantic_model_from_schema(
             else:
                 default = None
                 # Make optional if not already
-                if not (hasattr(field_type, "__origin__") and field_type.__origin__ is Optional):
+                if not (
+                    hasattr(field_type, "__origin__")
+                    and field_type.__origin__ is Optional
+                ):
                     field_type = Optional[field_type]
 
             field_description = field_props.get("description", "")

--- a/dapr_agents/tool/mcp/schema.py
+++ b/dapr_agents/tool/mcp/schema.py
@@ -43,54 +43,45 @@ def create_pydantic_model_from_schema(
         required = set(schema.get("required", []))
         fields = {}
 
+
         # Process each property in the schema
         for field_name, field_props in properties.items():
-            # Get field type information
-            json_type = field_props.get("type", "string")
-
-            # Handle complex type definitions (arrays, unions, etc.)
-            if isinstance(json_type, list):
-                # Process union types (e.g., ["string", "null"])
-                has_null = "null" in json_type
-                non_null_types = [t for t in json_type if t != "null"]
-
-                if not non_null_types:
-                    # Only null type specified
-                    field_type = Optional[str]
-                else:
-                    # Use the first non-null type
-                    # TODO: Proper union type handling would be better but more complex
-                    primary_type = non_null_types[0]
+            # --- Handle anyOf/oneOf for nullable/union fields ---
+            if "anyOf" in field_props or "oneOf" in field_props:
+                variants = field_props.get("anyOf") or field_props.get("oneOf")
+                types = [v.get("type", "string") for v in variants]
+                has_null = "null" in types
+                non_null_variants = [v for v in variants if v.get("type") != "null"]
+                if non_null_variants:
+                    primary_type = non_null_variants[0].get("type", "string")
                     field_type = TYPE_MAPPING.get(primary_type, str)
-
-                    # Make optional if null is included
-                    if has_null:
-                        field_type = Optional[field_type]
+                    # Handle array/object with items/properties
+                    if primary_type == "array" and "items" in non_null_variants[0]:
+                        item_type = non_null_variants[0]["items"].get("type", "string")
+                        field_type = List[TYPE_MAPPING.get(item_type, str)]
+                    elif primary_type == "object":
+                        field_type = dict
+                else:
+                    field_type = str
+                if has_null:
+                    field_type = Optional[field_type]
             else:
-                # Simple type
+                # --- Fallback to "type" ---
+                json_type = field_props.get("type", "string")
                 field_type = TYPE_MAPPING.get(json_type, str)
-
-            # Handle arrays with item type information
-            if json_type == "array" or (
-                isinstance(json_type, list) and "array" in json_type
-            ):
-                # Get the items type if specified
-                if "items" in field_props:
-                    items_type = field_props["items"].get("type", "string")
-                    if isinstance(items_type, str):
-                        item_py_type = TYPE_MAPPING.get(items_type, str)
-                        field_type = List[item_py_type]
+                if json_type == "array" and "items" in field_props:
+                    item_type = field_props["items"].get("type", "string")
+                    field_type = List[TYPE_MAPPING.get(item_type, str)]
 
             # Set default value based on required status
             if field_name in required:
-                default = ...  # Required field
+                default = ...
             else:
                 default = None
                 # Make optional if not already
-                if not isinstance(field_type, type(Optional)):
+                if not (hasattr(field_type, "__origin__") and field_type.__origin__ is Optional):
                     field_type = Optional[field_type]
 
-            # Add field with description and default value
             field_description = field_props.get("description", "")
             fields[field_name] = (
                 field_type,

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -37,6 +37,7 @@ dependencies = [
     "numpy>=2.2.2,<3.0.0",
     "mcp>=1.7.1,<2.0.0",
     "pip-tools>=7.4.1,<8.0.0",
+    "posthog<6.0.0",
 ]
 classifiers = [
     "Development Status :: 2 - Pre-Alpha",
@@ -74,7 +75,6 @@ vectorstore = [
     "torch>=2.7.0",
     "sentence-transformers>=4.1.0,<5.0.0",
     "chromadb>=0.4.22,<2.0.0",
-    "posthog<6.0.0",
 ]
 
 [project.urls]


### PR DESCRIPTION
This PR updates the schema conversion logic in `dapr_agents.tool.mcp.schema` to properly handle `anyOf` and `oneOf` constructs in JSON Schema. This ensures that nullable and union fields (such as those generated by MCP tool definitions) are mapped to the correct Python types (e.g., `Optional[int]`, `Optional[dict]`) in the generated Pydantic models. As a result, runtime validation and type checking for tool arguments are now accurate and robust, matching the intended schema semantics.

- Fixes validation errors for optional/nullable fields.
- Improves developer experience and correctness for agent tool argument validation.