### PR TITLE
refactor: skip local healthcheck when use remote endpoint

### DIFF
--- a/dapr_agents/__init__.py
+++ b/dapr_agents/__init__.py
@@ -1,3 +1,11 @@
+import os
+if os.getenv("DAPR_GRPC_ENDPOINT") or os.getenv("DAPR_API_TOKEN"):
+    try:
+        from dapr.clients.health import DaprHealth
+        DaprHealth.wait_until_ready = staticmethod(lambda: None)
+    except ImportError:
+        pass
+
 from dapr_agents.agents.agent import Agent
 from dapr_agents.agents.durableagent import DurableAgent
 from dapr_agents.executors import DockerCodeExecutor, LocalCodeExecutor

--- a/dapr_agents/workflow/agentic.py
+++ b/dapr_agents/workflow/agentic.py
@@ -2,7 +2,12 @@ import asyncio
 import json
 import logging
 import time
+import os
 from typing import Any, Callable, Dict, Optional, Tuple, Type, List
+
+if os.getenv("DAPR_GRPC_ENDPOINT") or os.getenv("DAPR_API_TOKEN"):
+    from dapr.clients.health import DaprHealth
+    DaprHealth.wait_until_ready = staticmethod(lambda: None)
 
 from cloudevents.http.conversion import from_http
 from cloudevents.http.event import CloudEvent


### PR DESCRIPTION
if the remote endpoint is set, then shouldn't force the local health check