### PR TITLE
feat: simplify durable agent wf def

### DIFF
--- a/dapr_agents/agents/base.py
+++ b/dapr_agents/agents/base.py
@@ -134,20 +134,20 @@ Your role is {role}.
         return values
 
     @model_validator(mode="after")
-    def validate_llm(cls, values):
+    def validate_llm(self):
         """Validate that LLM is properly configured."""
-        if hasattr(values, "llm"):
-            if values.llm is None:
+        if hasattr(self, "llm"):
+            if self.llm is None:
                 logger.warning("LLM client is None, some functionality may be limited.")
             else:
                 try:
                     # Validate LLM is properly configured by accessing it as this is required to be set.
-                    _ = values.llm
+                    _ = self.llm
                 except Exception as e:
                     logger.error(f"Failed to initialize LLM: {e}")
-                    values.llm = None
+                    self.llm = None
 
-        return values
+        return self
 
     def model_post_init(self, __context: Any) -> None:
         """

--- a/dapr_agents/agents/durableagent/agent.py
+++ b/dapr_agents/agents/durableagent/agent.py
@@ -29,7 +29,6 @@ from .schemas import (
 from .state import (
     DurableAgentMessage,
     DurableAgentWorkflowEntry,
-    DurableAgentWorkflowState,
 )
 
 logger = logging.getLogger(__name__)

--- a/dapr_agents/agents/durableagent/agent.py
+++ b/dapr_agents/agents/durableagent/agent.py
@@ -90,22 +90,22 @@ class DurableAgent(AgenticWorkflow, AgentBase):
             self.state["chat_history"] = []
 
         # Load the current workflow instance ID from state if it exists
-        logger.info(f"State after loading: {self.state}")
+        logger.debug(f"State after loading: {self.state}")
         if self.state and "instances" in self.state:
-            logger.info(f"Found {len(self.state['instances'])} instances in state")
+            logger.debug(f"Found {len(self.state['instances'])} instances in state")
             for instance_id, instance_data in self.state["instances"].items():
                 stored_workflow_name = instance_data.get("workflow_name")
-                logger.info(
+                logger.debug(
                     f"Instance {instance_id}: workflow_name={stored_workflow_name}, current_workflow_name={self._workflow_name}"
                 )
                 if stored_workflow_name == self._workflow_name:
                     self.workflow_instance_id = instance_id
-                    logger.info(
+                    logger.debug(
                         f"Loaded current workflow instance ID from state: {instance_id}"
                     )
                     break
         else:
-            logger.info("No instances found in state or state is empty")
+            logger.debug("No instances found in state or state is empty")
 
         # Sync workflow state with Dapr runtime after loading
         # This ensures our database reflects the actual state of resumed workflows
@@ -156,7 +156,7 @@ class DurableAgent(AgenticWorkflow, AgentBase):
             )
             return result
         except asyncio.CancelledError:
-            logger.info("Workflow execution was cancelled")
+            logger.warning("Workflow execution was cancelled")
             raise
         finally:
             # Clean up runtime
@@ -178,7 +178,7 @@ class DurableAgent(AgenticWorkflow, AgentBase):
         Returns:
             Dict[str, Any]: The final response message when the workflow completes, or None if continuing to the next iteration.
         """
-        # Step 1: pull out task + metadata + span context
+        # Step 1: pull out task + metadata + span context from workflow input through .start, .run(), pubsub invocation
         if isinstance(message, dict):
             task = message.get("task", None)
             metadata = message.get("_message_metadata", {}) or {}
@@ -189,7 +189,7 @@ class DurableAgent(AgenticWorkflow, AgentBase):
                 metadata["triggering_workflow_instance_id"] = message[
                     "workflow_instance_id"
                 ]
-        else:
+        else: # This is for if triggered by an orchestrator
             task = getattr(message, "task", None)
             metadata = getattr(message, "_message_metadata", {}) or {}
             # Extract OpenTelemetry span context if present
@@ -199,16 +199,14 @@ class DurableAgent(AgenticWorkflow, AgentBase):
                 metadata["triggering_workflow_instance_id"] = getattr(
                     message, "workflow_instance_id"
                 )
+            # Extract source from TriggerAction if present from orchestrator
+            if hasattr(message, "source"):
+                metadata["source"] = getattr(message, "source")
 
-        workflow_instance_id = ctx.instance_id
         triggering_workflow_instance_id = metadata.get(
             "triggering_workflow_instance_id"
         )
-        source = metadata.get("source")
-
-        # Set default source if not provided (for direct run() calls)
-        if not source:
-            source = "direct"
+        source = self.get_source_or_default(metadata.get("source"))
 
         # Store workflow instance ID for observability layer to use
         # The observability layer will handle AGENT span creation for resumed workflows
@@ -216,82 +214,41 @@ class DurableAgent(AgenticWorkflow, AgentBase):
             # New workflow - store the provided span context (observability layer handles this)
             from dapr_agents.observability.context_storage import store_workflow_context
 
-            instance_context_key = f"__workflow_context_{workflow_instance_id}__"
+            instance_context_key = f"__workflow_context_{ctx.instance_id}__"
             store_workflow_context(instance_context_key, otel_span_context)
 
         # Load the latest state from database to ensure we have up-to-date instance data
         self.load_state()
 
-        # Check if this instance already exists in state (from previous runs)
-        is_resumed_workflow = workflow_instance_id in self.state.get("instances", {})
-        if not is_resumed_workflow:
-            # This is a new instance, create a minimal entry
-            instance_entry = {
-                "input": task,
-                "output": "",
-                "messages": [],
-                # TODO(@Sicoyle): update to leverage deterministic time for replays.
-                "start_time": datetime.now(timezone.utc).isoformat(),
-                "end_time": None,  # Will be set when workflow completes
-                "source": source,
-                "workflow_instance_id": workflow_instance_id,
-                "triggering_workflow_instance_id": triggering_workflow_instance_id,
-                "workflow_name": self._workflow_name,
-                "status": DaprWorkflowStatus.RUNNING.value,
-                "trace_context": otel_span_context,  # Store original trace context for resumption
-            }
-            self.state.setdefault("instances", {})[
-                workflow_instance_id
-            ] = instance_entry
-            logger.debug(f"Created new instance entry: {workflow_instance_id}")
-
-            # Immediately save state so graceful shutdown can capture this instance
-            self.save_state()
-        else:
-            logger.debug(
-                f"Found existing instance entry for workflow {workflow_instance_id}"
-            )
-        final_message: Optional[Dict[str, Any]] = None
-
         if not ctx.is_replaying:
             logger.debug(f"Initial message from {source} -> {self.name}")
 
+        yield ctx.call_activity(
+            self.record_initial_entry,
+            input={
+                "instance_id": ctx.instance_id,
+                "input": task or "Triggered without input.",
+                "source": source,
+                "triggering_workflow_instance_id": triggering_workflow_instance_id,
+                "start_time": ctx.current_utc_datetime.isoformat(),
+                "trace_context": otel_span_context,
+            },
+        )
+
         try:
-            # Loop up to max_iterations
             for turn in range(1, self.max_iterations + 1):
                 if not ctx.is_replaying:
                     logger.debug(
-                        f"Workflow turn {turn}/{self.max_iterations} (Instance ID: {workflow_instance_id})"
+                        f"Workflow turn {turn}/{self.max_iterations} (Instance ID: {ctx.instance_id})"
                     )
 
-                # Step 2: On turn 1, record the initial entry
-                if turn == 1:
-                    yield ctx.call_activity(
-                        self.record_initial_entry,
-                        input={
-                            "instance_id": workflow_instance_id,
-                            "input": task or "Triggered without input.",
-                            "source": source,
-                            "triggering_workflow_instance_id": triggering_workflow_instance_id,
-                            "output": "",
-                        },
-                    )
-                # Step 4: Generate Response with LLM
+                # Generate Response with LLM and atomically save the assistant's response message
                 response_message: dict = yield ctx.call_activity(
-                    self.generate_response,
-                    input={"task": task, "instance_id": workflow_instance_id},
+                    self.generate_llm_response,
+                    input={"task": task, "instance_id": ctx.instance_id, "time": ctx.current_utc_datetime.isoformat()},
                 )
 
-                # Step 5: Add the assistant's response message to the chat history
-                yield ctx.call_activity(
-                    self.append_assistant_message,
-                    input={
-                        "instance_id": workflow_instance_id,
-                        "message": response_message,
-                    },
-                )
-
-                # Step 6: Handle tool calls response
+                # Handle tool calls response
                 tool_calls = response_message.get("tool_calls") or []
                 if tool_calls:
                     if not ctx.is_replaying:
@@ -300,58 +257,48 @@ class DurableAgent(AgenticWorkflow, AgentBase):
                         )
                     # fan‑out parallel tool executions
                     parallel = [
-                        ctx.call_activity(self.run_tool, input={"tool_call": tc})
+                        ctx.call_activity(
+                            self.run_tool, 
+                            input={
+                                "tool_call": tc,
+                                "instance_id": ctx.instance_id,
+                                "time": ctx.current_utc_datetime.isoformat(),
+                            }
+                        )
                         for tc in tool_calls
                     ]
-                    tool_results: List[Dict[str, Any]] = yield self.when_all(parallel)
-                    # Add tool results for the next iteration
-                    for tr in tool_results:
-                        yield ctx.call_activity(
-                            self.append_tool_message,
-                            input={
-                                "instance_id": workflow_instance_id,
-                                "tool_result": tr,
-                            },
-                        )
-                    # 🔴 If this was the last turn, stop here—even though there were tool calls
-                    if turn == self.max_iterations:
-                        final_message = response_message
-                        # Make sure content exists and is a string
-                        final_message["content"] = final_message.get("content") or ""
-                        final_message[
-                            "content"
-                        ] += "\n\n⚠️ Stopped: reached max iterations."
-                        break
-
-                    # Otherwise, prepare for next turn: clear task so that generate_response() uses memory/history
+                    yield self.when_all(parallel)
+                    
+                    # Prepare for next turn: clear task so that generate_llm_response() uses memory/history
                     task = None
                     continue  # bump to next turn
 
                 # No tool calls → this is your final answer
-                final_message = response_message
-
-                # 🔴 If it happened to be the last turn, banner it
-                if turn == self.max_iterations:
-                    # Again, ensure content is never None
-                    final_message["content"] = final_message.get("content") or ""
-                    final_message["content"] += "\n\n⚠️ Stopped: reached max iterations."
-
-                break  # exit loop with final_message
+                break  # exit loop
             else:
                 raise AgentError("Workflow ended without producing a final response")
 
         except Exception as e:
             logger.exception("Workflow error", exc_info=e)
-            final_message = {
+            err_msg = {
                 "role": "assistant",
                 "content": f"⚠️ Unexpected error: {e}",
             }
+            self._save_assistant_message(ctx.instance_id, err_msg)
 
-        # Step 7: Broadcast the final response if a broadcast topic is set
+        # Get the last message from state (this will be the final response)
+        final_msg = self._get_last_message_from_state(ctx.instance_id)
+        if not final_msg:
+            final_msg = {
+                "role": "assistant", 
+                "content": "No response generated"
+            }
+
+        # Broadcast the final response if a broadcast topic is set
         if self.broadcast_topic_name:
             yield ctx.call_activity(
                 self.broadcast_message_to_agents,
-                input={"message": final_message},
+                input={"message": final_msg},
             )
 
         # Respond to source agent if available
@@ -359,7 +306,7 @@ class DurableAgent(AgenticWorkflow, AgentBase):
             yield ctx.call_activity(
                 self.send_response_back,
                 input={
-                    "response": final_message,
+                    "response": final_msg,
                     "target_agent": source,
                     "target_instance_id": triggering_workflow_instance_id,
                 },
@@ -368,8 +315,10 @@ class DurableAgent(AgenticWorkflow, AgentBase):
         yield ctx.call_activity(
             self.finalize_workflow,
             input={
-                "instance_id": workflow_instance_id,
-                "final_output": final_message["content"],
+                "instance_id": ctx.instance_id,
+                "final_output": final_msg.get("content", ""),
+                "time": ctx.current_utc_datetime.isoformat(),
+                "triggering_workflow_instance_id": triggering_workflow_instance_id,
             },
         )
 
@@ -378,10 +327,18 @@ class DurableAgent(AgenticWorkflow, AgentBase):
             verdict = (
                 "max_iterations_reached" if turn == self.max_iterations else "completed"
             )
-            logger.info(f"Workflow {workflow_instance_id} finalized: {verdict}")
+            logger.info(f"Workflow {ctx.instance_id} finalized: {verdict}")
 
         # Return the final response message
-        return final_message
+        return final_msg
+    
+    def get_source_or_default(self,
+        source: str
+    ):
+        # Set default source if not provided (for direct run() calls)
+        if not source:
+            source = "direct"
+        return source
 
     @task
     def record_initial_entry(
@@ -390,7 +347,9 @@ class DurableAgent(AgenticWorkflow, AgentBase):
         input: str,
         source: Optional[str],
         triggering_workflow_instance_id: Optional[str],
+        start_time: str, # required to be passed in using the workflow context for deterministic timestamp
         output: str = "",
+        trace_context: Optional[Dict[str, Any]] = None,
     ):
         """
         Records the initial workflow entry for a new workflow instance.
@@ -400,14 +359,18 @@ class DurableAgent(AgenticWorkflow, AgentBase):
             source (Optional[str]): The source of the workflow trigger.
             triggering_workflow_instance_id (Optional[str]): The workflow instance ID of the triggering workflow.
             output (str): The output for the workflow entry (default: "").
+            start_time (Optional[str]): The start time in ISO format (default: None, will use current time).
+            trace_context (Optional[Dict[str, Any]]): OpenTelemetry trace context for workflow resumption.
         """
         entry = DurableAgentWorkflowEntry(
             input=input,
             source=source,
             workflow_instance_id=instance_id,
             triggering_workflow_instance_id=triggering_workflow_instance_id,
-            output=output,
             workflow_name=self._workflow_name,
+            start_time=start_time,
+            trace_context=trace_context,
+            status=DaprWorkflowStatus.RUNNING.value,
         )
         self.state.setdefault("instances", {})[instance_id] = entry.model_dump(
             mode="json"
@@ -442,15 +405,106 @@ class DurableAgent(AgenticWorkflow, AgentBase):
             }
         raise AgentError(f"No workflow entry found for instance_id={instance_id}")
 
+    # Note: This is only really needed bc of the in-memory storage solutions.
+    # With persistent storage, this is not needed as we rehydrate the conversation state from the database upon app restart.
+    def _ensure_instance_exists(self, instance_id: str, 
+                              triggering_workflow_instance_id: Optional[str] = None, 
+                              time: str = None) -> None:
+        """Ensure the instance entry exists in the state."""
+        if instance_id not in self.state["instances"]:
+            self.state["instances"][instance_id] = {
+                "messages": [],
+                "start_time": time,
+                "source": "user_input",
+                "workflow_instance_id": instance_id,
+                "triggering_workflow_instance_id": triggering_workflow_instance_id,
+                "workflow_name": self._workflow_name,
+            }
+
+    def _process_user_message(
+        self, 
+        instance_id: str, 
+        task: Optional[Union[str, Dict[str, Any]]], 
+        user_message_copy: Optional[Dict[str, Any]]
+    ) -> None:
+        """Process and save user message to memory and state."""
+        if not (task and user_message_copy):
+            return
+            
+        user_msg = UserMessage(content=user_message_copy.get("content", ""))
+        self.memory.add_message(user_msg)
+        
+        msg_object = DurableAgentMessage(**user_message_copy)
+        inst: dict = self.state["instances"][instance_id]
+        inst.setdefault("messages", []).append(msg_object.model_dump(mode="json"))
+        inst["last_message"] = msg_object.model_dump(mode="json")
+        self.save_state()
+
+    def _generate_llm_response(self, messages: List[Dict[str, Any]]) -> Dict[str, Any]:
+        """Generate LLM response and return the assistant message."""
+        response: LLMChatResponse = self.llm.generate(
+            messages=messages,
+            tools=self.get_llm_tools(),
+            **(
+                {"tool_choice": self.tool_choice}
+                if self.tool_choice is not None
+                else {}
+            ),
+        )
+        response_message = response.get_message()
+        if response_message is None:
+            raise AgentError("LLM returned no assistant message")
+        
+        return response_message.model_dump()
+
+    def _save_assistant_message(
+        self, 
+        instance_id: str, 
+        assistant_message: Dict[str, Any]
+    ) -> None:
+        """Save assistant message to state with idempotency check."""
+        assistant_message["name"] = self.name
+        msg_object = DurableAgentMessage(**assistant_message)
+        
+        inst: dict = self.state["instances"][instance_id]
+        message_dict = msg_object.model_dump(mode="json")
+        messages_list = inst.setdefault("messages", [])
+
+        # Check for duplicate by message ID (idempotent for workflow replay)
+        message_exists = any(
+            msg.get("id") == message_dict.get("id") for msg in messages_list
+        )
+        if not message_exists:
+            messages_list.append(message_dict)
+            inst["last_message"] = message_dict
+            self.memory.add_message(AssistantMessage(**assistant_message))
+            self.save_state()
+
+    def _print_llm_interaction_messages(
+        self, 
+        user_message_copy: Optional[Dict[str, Any]], 
+        assistant_message: Dict[str, Any]
+    ) -> None:
+        """Print user and assistant messages for context."""
+        # Print user message
+        if user_message_copy is not None:
+            self.text_formatter.print_message(
+                {str(k): v for k, v in user_message_copy.items()}
+            )
+        
+        # Print assistant message
+        self.text_formatter.print_message(assistant_message)
+
     @task
-    async def generate_response(
-        self, instance_id: str, task: Optional[Union[str, Dict[str, Any]]] = None
+    async def generate_llm_response(
+        self, instance_id: str, time: str, task: Optional[Union[str, Dict[str, Any]]] = None,
     ) -> Dict[str, Any]:
         """
         Ask the LLM for the assistant's next message.
 
         Args:
             instance_id (str): The workflow instance ID.
+            time (str): The time of the message.
             task: The user's query for this turn (either a string or a dict),
                   or None if this is a follow-up iteration.
 
@@ -459,7 +513,7 @@ class DurableAgent(AgenticWorkflow, AgentBase):
             Pydantic models are `.model_dump()`-ed; any other object is coerced via `dict()`.
         """
         # Construct messages using instance-specific chat history instead of global memory
-        # This ensures proper message sequence for tool calls
+        # This ensures proper message sequence for tool calls and ensures formatting/structure
         messages: List[Dict[str, Any]] = self._construct_messages_with_instance_history(
             instance_id, task or {}
         )
@@ -470,78 +524,126 @@ class DurableAgent(AgenticWorkflow, AgentBase):
             dict(user_message) if user_message else None
         )
 
-        if task and user_message_copy:
-            # Add the new user message to memory only if input_data is provided and user message exists
-            user_msg = UserMessage(content=user_message_copy.get("content", ""))
-            self.memory.add_message(user_msg)
-            # Define DurableAgentMessage object for state persistence
-            msg_object = DurableAgentMessage(**user_message_copy)
-            # Ensure the instance entry exists
-            if instance_id not in self.state["instances"]:
-                self.state["instances"][instance_id] = {
-                    "messages": [],
-                    "start_time": datetime.now(timezone.utc).isoformat(),
-                    "source": "user_input",
-                    "workflow_instance_id": instance_id,
-                    "triggering_workflow_instance_id": None,
-                    "workflow_name": self._workflow_name,
-                }
-            inst: dict = self.state["instances"][instance_id]
-            inst.setdefault("messages", []).append(msg_object.model_dump(mode="json"))
-            inst["last_message"] = msg_object.model_dump(mode="json")
-            # Note: Do not use global chat_history update to prevent cross-instance contamination
-            # Save the state after appending the user message
-            self.save_state()
+        self._ensure_instance_exists(instance_id, time=time)
+        self._process_user_message(instance_id, task, user_message_copy)
 
-        # Always print the last user message for context, even if no input_data is provided
-        if user_message_copy is not None:
-            # Ensure keys are str for mypy
-            self.text_formatter.print_message(
-                {str(k): v for k, v in user_message_copy.items()}
-            )
-
-        # Generate response using the LLM
+        # Generate LLM response and atomically save assistant message
         try:
-            response: LLMChatResponse = self.llm.generate(
-                messages=messages,
-                tools=self.get_llm_tools(),
-                **(
-                    {"tool_choice": self.tool_choice}
-                    if self.tool_choice is not None
-                    else {}
-                ),
-            )
-            # Get the first candidate from the response
-            response_message = response.get_message()
-            # Check if the response contains an assistant message
-            if response_message is None:
-                raise AgentError("LLM returned no assistant message")
-            # Convert the response message to a dict to work with JSON serialization
-            assistant_message = response_message.model_dump()
+            assistant_message = self._generate_llm_response(messages)
+            self._save_assistant_message(instance_id, assistant_message)
+            self._print_llm_interaction_messages(user_message_copy, assistant_message)
+            
             return assistant_message
         except Exception as e:
             error_type = type(e).__name__
             error_msg = str(e)
 
-            logger.error(
+            logger.exception(
                 f"LLM generation failed in workflow {instance_id}: {error_type} - {error_msg}"
             )
-            logger.error(f"Task: {task}")
-            logger.error(f"Messages count: {len(messages)}")
-            logger.error(f"Tools available: {len(self.get_llm_tools())}")
-            logger.error("Full error details:", exc_info=True)
+            logger.exception(f"Task: {task}")
+            logger.exception(f"Messages count: {len(messages)}")
+            logger.exception(f"Tools available: {len(self.get_llm_tools())}")
+            logger.exception("Full error details:", exc_info=True)
 
             raise AgentError(
                 f"LLM generation failed in workflow {instance_id}: {error_type} - {error_msg}"
             ) from e
 
     @task
-    async def run_tool(self, tool_call: Dict[str, Any]) -> Dict[str, Any]:
+    def _create_tool_message_objects(self, tool_result: Dict[str, Any]) -> tuple:
         """
-        Executes a tool call by invoking the specified function with the provided arguments.
+        Create ToolMessage and DurableAgentMessage objects from tool result.
+        
+        Args:
+            tool_result: Dictionary containing tool execution details
+            
+        Returns:
+            Tuple of (tool_msg, agent_msg, tool_history_entry)
+        """
+        tool_msg = ToolMessage(
+            tool_call_id=tool_result["tool_call_id"],
+            name=tool_result["tool_name"],
+            content=tool_result["execution_result"],
+        )
+        agent_msg = DurableAgentMessage(**tool_msg.model_dump())
+        tool_history_entry = ToolExecutionRecord(**tool_result)
+        
+        return tool_msg, agent_msg, tool_history_entry
+
+
+    def _append_tool_message_to_instance(self, instance_id: str, agent_msg: DurableAgentMessage, 
+                                       tool_history_entry: ToolExecutionRecord) -> None:
+        """
+        Append tool message and history to the instance state.
+        
+        Args:
+            instance_id: The workflow instance ID
+            agent_msg: The DurableAgentMessage object
+            tool_history_entry: The ToolExecutionRecord object
+        """
+        wf_instance = self.state["instances"][instance_id]
+        
+        # Check if message already exists (idempotent operation for workflow replay)
+        agent_messages = agent_msg.model_dump(mode="json")
+        wf_messages = wf_instance.setdefault("messages", [])
+
+        # Check for duplicate by message ID (idempotent for workflow replay)
+        message_exists = any(
+            msg.get("id") == agent_messages.get("id") for msg in wf_messages
+        )
+        if not message_exists:
+            wf_messages.append(agent_messages)
+
+        # Check for duplicate tool history entry by tool_call_id
+        tool_history_dict = tool_history_entry.model_dump(mode="json")
+        tool_history = wf_instance.setdefault("tool_history", [])
+
+        tool_exists = any(
+            th.get("tool_call_id") == tool_history_dict.get("tool_call_id")
+            for th in tool_history
+        )
+        if not tool_exists:
+            tool_history.append(tool_history_dict)
+
+    def _update_agent_memory_and_history(self, tool_message: ToolMessage, 
+                                       tool_history_entry: ToolExecutionRecord) -> None:
+        """
+        Update agent's memory and tool history.
+        
+        Args:
+            tool_message: The ToolMessage object
+            tool_history_entry: The ToolExecutionRecord object
+        """
+        # Update tool history and memory of agent (only if new)
+        # Note: Memory updates are handled at workflow level to avoid replay issues
+        self.tool_history.append(tool_history_entry)
+        # Add the tool message to the agent's memory
+        self.memory.add_message(tool_message)
+
+    def _get_last_message_from_state(self, instance_id: str) -> Optional[Dict[str, Any]]:
+        """
+        Get the last message from the instance state.
+        
+        Args:
+            instance_id: The workflow instance ID
+            
+        Returns:
+            The last message dict or None if not found
+        """
+        instance_data = self.state.get("instances", {}).get(instance_id, {})
+        return instance_data.get("last_message")
+
+    @task
+    async def run_tool(self, tool_call: Dict[str, Any], instance_id: str, time: str) -> Dict[str, Any]:
+        """
+        Executes a tool call atomically by invoking the specified function with the provided arguments
+        and immediately persisting the result to the agent's state and memory.
 
         Args:
             tool_call (Dict[str, Any]): A dictionary containing tool execution details, including the function name and arguments.
+            instance_id (str): The workflow instance ID for state persistence.
+            time (str): The current time for state persistence.
 
         Returns:
             Dict[str, Any]: A dictionary containing the tool call ID, function name, function arguments
@@ -564,16 +666,26 @@ class DurableAgent(AgenticWorkflow, AgentBase):
         try:
             result = await self.tool_executor.run_tool(fn_name, **args)
         except Exception as e:
-            logger.error(f"Error executing tool '{fn_name}': {e}", exc_info=True)
+            logger.exception(f"Error executing tool '{fn_name}': {e}", exc_info=True)
             raise AgentError(f"Error executing tool '{fn_name}': {e}") from e
 
-        # Return the plain payload for later persistence
-        return {
+        # Create the tool result payload
+        tool_result = {
             "tool_call_id": tool_call["id"],
             "tool_name": fn_name,
             "tool_args": args,
             "execution_result": str(result) if result is not None else "",
         }
+
+        # Atomically persist the tool execution result
+        self._ensure_instance_exists(instance_id, time=time)
+        tool_msg, agent_msg, tool_history_entry = self._create_tool_message_objects(tool_result)
+        self._append_tool_message_to_instance(instance_id, agent_msg, tool_history_entry)
+        self._update_agent_memory_and_history(tool_msg, tool_history_entry)
+        self.save_state()
+        self.text_formatter.print_message(tool_msg)
+
+        return tool_result
 
     @task
     async def broadcast_message_to_agents(self, message: Dict[str, Any]):
@@ -606,7 +718,6 @@ class DurableAgent(AgenticWorkflow, AgentBase):
         Raises:
             ValidationError: If the response does not match the expected structure for `AgentTaskResponse`.
         """
-        # Format Response
         response["role"] = "user"
         response["name"] = self.name
         response["workflow_instance_id"] = target_instance_id
@@ -616,130 +727,17 @@ class DurableAgent(AgenticWorkflow, AgentBase):
         await self.send_message_to_agent(name=target_agent, message=agent_response)
 
     @task
-    def append_assistant_message(
-        self, instance_id: str, message: Dict[str, Any]
-    ) -> None:
-        """
-        Append an assistant message into the workflow state.
-
-        Args:
-            instance_id (str): The workflow instance ID.
-            message (Dict[str, Any]): The assistant message to append.
-        """
-        message["name"] = self.name
-        # Convert the message to a DurableAgentMessage object
-        msg_object = DurableAgentMessage(**message)
-        # Ensure the instance entry exists
-        if instance_id not in self.state["instances"]:
-            self.state["instances"][instance_id] = {
-                "messages": [],
-                "start_time": datetime.now(timezone.utc).isoformat(),
-                "source": "user_input",
-                "workflow_instance_id": instance_id,
-                "triggering_workflow_instance_id": None,
-                "workflow_name": self._workflow_name,
-            }
-        inst: dict = self.state["instances"][instance_id]
-        # Check if message already exists (idempotent operation for workflow replay)
-        message_dict = msg_object.model_dump(mode="json")
-        messages = inst.setdefault("messages", [])
-
-        # Check for duplicate by message ID (idempotent for workflow replay)
-        message_exists = any(
-            msg.get("id") == message_dict.get("id") for msg in messages
-        )
-        if not message_exists:
-            messages.append(message_dict)
-            inst["last_message"] = message_dict
-            # Add the assistant message to memory (only if new)
-            # Note: Memory updates are handled at workflow level to avoid replay issues
-            self.memory.add_message(AssistantMessage(**message))
-            # Save the state after appending the assistant message
-            self.save_state()
-        # Print the assistant message
-        self.text_formatter.print_message(message)
-
-    @task
-    def append_tool_message(
-        self, instance_id: str, tool_result: Dict[str, Any]
-    ) -> None:
-        """
-        Append a tool-execution record to both the per-instance history and the agent's tool_history.
-        """
-        # Define a ToolMessage object from the tool result
-        tool_message = ToolMessage(
-            tool_call_id=tool_result["tool_call_id"],
-            name=tool_result["tool_name"],
-            content=tool_result["execution_result"],
-        )
-        # Define DurableAgentMessage object for state persistence
-        msg_object = DurableAgentMessage(**tool_message.model_dump())
-        # Define a ToolExecutionRecord object
-        # to store the tool execution details in the workflow state
-        tool_history_entry = ToolExecutionRecord(**tool_result)
-        # Ensure the instance entry exists
-        if instance_id not in self.state["instances"]:
-            self.state["instances"][instance_id] = {
-                "messages": [],
-                "start_time": datetime.now(timezone.utc).isoformat(),
-                "source": "user_input",
-                "workflow_instance_id": instance_id,
-                "triggering_workflow_instance_id": None,
-                "workflow_name": self._workflow_name,
-            }
-        inst: dict = self.state["instances"][instance_id]
-        # Check if message already exists (idempotent operation for workflow replay)
-        message_dict = msg_object.model_dump(mode="json")
-        messages = inst.setdefault("messages", [])
-
-        # Check for duplicate by message ID (idempotent for workflow replay)
-        message_exists = any(
-            msg.get("id") == message_dict.get("id") for msg in messages
-        )
-        if not message_exists:
-            messages.append(message_dict)
-
-        # Check for duplicate tool history entry by tool_call_id
-        tool_history_dict = tool_history_entry.model_dump(mode="json")
-        tool_history = inst.setdefault("tool_history", [])
-
-        tool_exists = any(
-            th.get("tool_call_id") == tool_history_dict.get("tool_call_id")
-            for th in tool_history
-        )
-        if not tool_exists:
-            tool_history.append(tool_history_dict)
-            # Update tool history and memory of agent (only if new)
-            # Note: Memory updates are handled at workflow level to avoid replay issues
-            self.tool_history.append(tool_history_entry)
-            # Add the tool message to the agent's memory
-            self.memory.add_message(tool_message)
-        # Save the state after appending the tool message
-        self.save_state()
-        # Print the tool message
-        self.text_formatter.print_message(tool_message)
-
-    @task
-    def finalize_workflow(self, instance_id: str, final_output: str) -> None:
+    def finalize_workflow(self, instance_id: str, final_output: str, time: str, 
+                         triggering_workflow_instance_id: Optional[str] = None) -> None:
         """
         Record the final output and end_time in the workflow state.
         """
-        end_time = datetime.now(timezone.utc)
-        end_time_str = end_time.isoformat()
         # Ensure the instance entry exists
-        if instance_id not in self.state["instances"]:
-            self.state["instances"][instance_id] = {
-                "messages": [],
-                "start_time": datetime.now(timezone.utc).isoformat(),
-                "source": "user_input",
-                "workflow_instance_id": instance_id,
-                "triggering_workflow_instance_id": None,
-                "workflow_name": self._workflow_name,
-            }
-        inst: dict = self.state["instances"][instance_id]
-        inst["output"] = final_output
-        inst["end_time"] = end_time_str
-        inst["status"] = DaprWorkflowStatus.COMPLETED.value  # Mark as completed
+        self._ensure_instance_exists(instance_id, triggering_workflow_instance_id, time)
+        instance = self.state["instances"][instance_id]
+        instance["output"] = final_output
+        instance["end_time"] = time
+        instance["status"] = DaprWorkflowStatus.COMPLETED.value  # Mark as completed
         logger.info(f"Workflow {instance_id} completed successfully")
         self.save_state()
 
@@ -773,7 +771,7 @@ class DurableAgent(AgenticWorkflow, AgentBase):
             )
             # Ignore messages sent by this agent
             if source == self.name:
-                logger.info(
+                logger.debug(
                     f"{self.name} ignored its own broadcast message of type '{message_type}'."
                 )
                 return

--- a/dapr_agents/agents/durableagent/agent.py
+++ b/dapr_agents/agents/durableagent/agent.py
@@ -741,6 +741,7 @@ class DurableAgent(AgenticWorkflow, AgentBase):
         # Send the message to the target agent
         await self.send_message_to_agent(name=target_agent, message=agent_response)
 
+    # TODO: add metrics on workflow run in future here?
     @task
     def finalize_workflow(
         self,

--- a/dapr_agents/agents/durableagent/state.py
+++ b/dapr_agents/agents/durableagent/state.py
@@ -1,6 +1,7 @@
 from pydantic import BaseModel, Field
 from typing import List, Optional, Dict, Any
 from dapr_agents.types import MessageContent, ToolExecutionRecord
+from dapr_agents.types.workflow import DaprWorkflowStatus
 from datetime import datetime
 import uuid
 
@@ -59,6 +60,10 @@ class DurableAgentWorkflowEntry(BaseModel):
     trace_context: Optional[Dict[str, Any]] = Field(
         default=None,
         description="OpenTelemetry trace context for workflow resumption.",
+    )
+    status: str = Field(
+        default=DaprWorkflowStatus.RUNNING.value,
+        description="Current status of the workflow.",
     )
 
 

--- a/dapr_agents/observability/context_storage.py
+++ b/dapr_agents/observability/context_storage.py
@@ -125,7 +125,7 @@ class WorkflowContextStorage:
 
             # Create AGENT span with proper agent name for resumed workflow
             agent_display_name = agent_name or "DurableAgent"
-            span_name = f"{agent_display_name}.ToolCallingWorkflow"
+            span_name = f"{agent_display_name}.AgenticWorkflow"
             with tracer.start_as_current_span(span_name) as span:
                 # Set AGENT span attributes
                 from .constants import OPENINFERENCE_SPAN_KIND

--- a/dapr_agents/observability/wrappers/workflow.py
+++ b/dapr_agents/observability/wrappers/workflow.py
@@ -329,7 +329,7 @@ class WorkflowMonitorWrapper:
         workflow_name = (
             workflow
             if isinstance(workflow, str)
-            else getattr(workflow, "__name__", "ToolCallingWorkflow")
+            else getattr(workflow, "__name__", "AgenticWorkflow")
         )
         return workflow_name
 

--- a/dapr_agents/observability/wrappers/workflow_task.py
+++ b/dapr_agents/observability/wrappers/workflow_task.py
@@ -677,13 +677,11 @@ class WorkflowTaskWrapper:
         """
         if task_name in ["record_initial_entry", "get_workflow_entry_info"]:
             return "initialization"
-        elif task_name in ["append_assistant_message", "append_tool_message"]:
-            return "state_management"
         elif task_name in ["finalize_workflow", "finish_workflow"]:
             return "finalization"
         elif task_name in ["broadcast_message_to_agents", "send_response_back"]:
             return "communication"
-        elif task_name == "generate_response":
+        elif task_name == "generate_llm_response":
             return "llm_generation"
         elif task_name == "run_tool":
             return "tool_execution"

--- a/dapr_agents/observability/wrappers/workflow_task.py
+++ b/dapr_agents/observability/wrappers/workflow_task.py
@@ -194,7 +194,7 @@ class WorkflowTaskWrapper:
             attributes["resource.workflow.instance_id"] = instance_id
             attributes[
                 "resource.workflow.name"
-            ] = "ToolCallingWorkflow"  # Could be dynamic
+            ] = "AgenticWorkflow"  # Could be dynamic
 
             # Log the trace context for debugging (expected to be disconnected for Dapr Workflows)
             from opentelemetry import trace
@@ -323,7 +323,7 @@ class WorkflowTaskWrapper:
             logger.debug(f"Creating AGENT span for resumed workflow {instance_id}")
 
             agent_name = getattr(instance, "name", "DurableAgent")
-            workflow_name = instance_data.get("workflow_name", "ToolCallingWorkflow")
+            workflow_name = instance_data.get("workflow_name", "AgenticWorkflow")
             span_name = f"{agent_name}.{workflow_name}"
             attributes = {
                 "openinference.span.kind": "AGENT",
@@ -681,7 +681,7 @@ class WorkflowTaskWrapper:
             return "finalization"
         elif task_name in ["broadcast_message_to_agents", "send_response_back"]:
             return "communication"
-        elif task_name == "generate_llm_response":
+        elif task_name == "call_llm":
             return "llm_generation"
         elif task_name == "run_tool":
             return "tool_execution"

--- a/dapr_agents/observability/wrappers/workflow_task.py
+++ b/dapr_agents/observability/wrappers/workflow_task.py
@@ -675,7 +675,7 @@ class WorkflowTaskWrapper:
         Returns:
             str: Semantic category for the task type
         """
-        if task_name in ["record_initial_entry", "get_workflow_entry_info"]:
+        if task_name in ["record_initial_entry"]:
             return "initialization"
         elif task_name in ["finalize_workflow", "finish_workflow"]:
             return "finalization"

--- a/dapr_agents/observability/wrappers/workflow_task.py
+++ b/dapr_agents/observability/wrappers/workflow_task.py
@@ -192,9 +192,7 @@ class WorkflowTaskWrapper:
 
             # Add resource-level attributes for Phoenix UI grouping
             attributes["resource.workflow.instance_id"] = instance_id
-            attributes[
-                "resource.workflow.name"
-            ] = "AgenticWorkflow"  # Could be dynamic
+            attributes["resource.workflow.name"] = "AgenticWorkflow"  # Could be dynamic
 
             # Log the trace context for debugging (expected to be disconnected for Dapr Workflows)
             from opentelemetry import trace

--- a/dapr_agents/tool/base.py
+++ b/dapr_agents/tool/base.py
@@ -141,7 +141,8 @@ class AgentTool(BaseModel):
                 tool_args_model = create_pydantic_model_from_schema(
                     mcp_tool.inputSchema, f"{tool_name}Args"
                 )
-            except Exception:
+            except Exception as e:
+                logger.warning(f"Failed to create schema for tool '{tool_name}': {e}")
                 pass
 
         return cls(

--- a/dapr_agents/workflow/base.py
+++ b/dapr_agents/workflow/base.py
@@ -362,7 +362,7 @@ class WorkflowApp(BaseModel, SignalHandlingMixin):
             # Don't reregister tasks that are already registered
             if task_name in self.tasks:
                 continue
-            
+
             llm = self._choose_llm_for(method)
             logger.debug(
                 f"Registering task '{task_name}' with llm={getattr(llm, '__class__', None)}"
@@ -452,6 +452,7 @@ class WorkflowApp(BaseModel, SignalHandlingMixin):
             # Don't reregister workflows that are already registered
             if wf_name in self.workflows:
                 continue
+
             # Use a closure helper to avoid late-binding capture issues.
             def make_wrapped(meth: Callable) -> Callable:
                 @functools.wraps(meth)
@@ -538,7 +539,7 @@ class WorkflowApp(BaseModel, SignalHandlingMixin):
             self._monitor_resumed_workflows()
         else:
             logger.debug("Workflow runtime already running; skipping.")
-        
+
         self._ensure_activities_registered()
 
     def _ensure_activities_registered(self):

--- a/dapr_agents/workflow/base.py
+++ b/dapr_agents/workflow/base.py
@@ -833,7 +833,7 @@ class WorkflowApp(BaseModel, SignalHandlingMixin):
                 tracer = trace.get_tracer(__name__)
                 agent_name = getattr(self, "name", "DurableAgent")
                 workflow_name = instance_data.get(
-                    "workflow_name", "ToolCallingWorkflow"
+                    "workflow_name", "AgenticWorkflow"
                 )
                 span_name = f"{agent_name}.{workflow_name}"
 

--- a/dapr_agents/workflow/mixins/state.py
+++ b/dapr_agents/workflow/mixins/state.py
@@ -37,7 +37,7 @@ class StateManagementMixin:
 
             if not isinstance(self.state, dict):
                 raise TypeError(
-                    f"Invalid state type: {type(self.state)}. Expected dict or Pydantic model."
+                    f"Invalid state type: {type(self.state)}. Expected dict."
                 )
 
             logger.debug(f"Workflow state initialized with {len(self.state)} key(s).")

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -35,6 +35,7 @@ dependencies = [
     "cloudevents>=1.11.0,<2.0.0",
     "numpy>=2.2.2,<3.0.0",
     "mcp>=1.7.1,<2.0.0",
+    "websockets>=15.0.0,<16.0.0",
     "python-dotenv>=1.1.1,<2.0.0",
     "posthog<6.0.0",
     "nltk>=3.8.0,<4.0.0",

--- a/tests/agents/durableagent/test_durable_agent.py
+++ b/tests/agents/durableagent/test_durable_agent.py
@@ -46,7 +46,7 @@ def patch_dapr_check(monkeypatch):
         self.wf_client = Mock()
         self.client = Mock()
         self.tasks = {}
-        self.workflows["ToolCallingWorkflow"] = getattr(
+        self.workflows["AgenticWorkflow"] = getattr(
             self, "tool_calling_workflow", None
         )
 
@@ -79,7 +79,7 @@ def patch_dapr_check(monkeypatch):
             "pubsub_name": getattr(self, "message_bus_name", "testpubsub"),
             "orchestrator": False,
         }
-        self._workflow_name = "ToolCallingWorkflow"
+        self._workflow_name = "AgenticWorkflow"
         self._is_running = False
         self._shutdown_event = asyncio.Event()
         self._subscriptions = {}
@@ -307,8 +307,8 @@ class TestDurableAgent:
         assert instance_data.triggering_workflow_instance_id == "parent-instance-123"
 
     @pytest.mark.asyncio
-    async def test_generate_llm_response_activity(self, basic_durable_agent):
-        """Test that generate_llm_response unwraps an LLMChatResponse properly."""
+    async def test_call_llm_activity(self, basic_durable_agent):
+        """Test that call_llm unwraps an LLMChatResponse properly."""
 
         # create a fake LLMChatResponse with one choice
         fake_response = LLMChatResponse(
@@ -337,7 +337,7 @@ class TestDurableAgent:
         test_time = datetime.fromisoformat(
             "2024-01-01T00:00:00Z".replace("Z", "+00:00")
         )
-        assistant_dict = await basic_durable_agent.generate_llm_response(
+        assistant_dict = await basic_durable_agent.call_llm(
             instance_id, test_time, "Test task"
         )
         # The dict dumped from AssistantMessage should have our content
@@ -481,7 +481,7 @@ class TestDurableAgent:
         )
         # start_time is parsed as datetime by Pydantic, so we need to compare the string representation
         assert instance_data.start_time.isoformat() == "2024-01-01T00:00:00+00:00"
-        assert instance_data.workflow_name == "ToolCallingWorkflow"
+        assert instance_data.workflow_name == "AgenticWorkflow"
         assert instance_data.status == "running"
 
     def test_ensure_instance_exists(self, basic_durable_agent):
@@ -506,7 +506,7 @@ class TestDurableAgent:
         )
         # start_time is parsed as datetime by Pydantic, so we need to compare the string representation
         assert instance_data.start_time.isoformat() == "2024-01-01T00:00:00+00:00"
-        assert instance_data.workflow_name == "ToolCallingWorkflow"
+        assert instance_data.workflow_name == "AgenticWorkflow"
 
         # Test that existing instance is not overwritten
         original_input = "Original input"
@@ -762,7 +762,7 @@ class TestDurableAgent:
 
     def test_durable_agent_workflow_name(self, basic_durable_agent):
         """Test that the workflow name is set correctly."""
-        assert basic_durable_agent._workflow_name == "ToolCallingWorkflow"
+        assert basic_durable_agent._workflow_name == "AgenticWorkflow"
 
     def test_durable_agent_state_initialization(self, basic_durable_agent):
         """Test that the agent state is properly initialized."""

--- a/tests/agents/durableagent/test_durable_agent.py
+++ b/tests/agents/durableagent/test_durable_agent.py
@@ -382,7 +382,9 @@ class TestDurableAgent:
             }
         }
 
-        basic_durable_agent.finalize_workflow(instance_id, final_output, "2024-01-01T00:00:00Z")
+        basic_durable_agent.finalize_workflow(
+            instance_id, final_output, "2024-01-01T00:00:00Z"
+        )
         instance_data = basic_durable_agent.state["instances"][instance_id]
         assert instance_data["output"] == final_output
         assert "end_time" in instance_data
@@ -411,7 +413,9 @@ class TestDurableAgent:
         }
 
         basic_durable_agent._save_assistant_message(instance_id, message)
-        basic_durable_agent.finalize_workflow(instance_id, final_output, "2024-01-01T00:00:00Z")
+        basic_durable_agent.finalize_workflow(
+            instance_id, final_output, "2024-01-01T00:00:00Z"
+        )
 
         instance_data = basic_durable_agent.state["instances"][instance_id]
         assert len(instance_data["messages"]) == 1  # Only assistant message

--- a/tests/agents/durableagent/test_durable_agent.py
+++ b/tests/agents/durableagent/test_durable_agent.py
@@ -295,8 +295,8 @@ class TestDurableAgent:
         assert instance_data.triggering_workflow_instance_id == "parent-instance-123"
 
     @pytest.mark.asyncio
-    async def test_generate_response_activity(self, basic_durable_agent):
-        """Test that generate_response unwraps an LLMChatResponse properly."""
+    async def test_generate_llm_response_activity(self, basic_durable_agent):
+        """Test that generate_llm_response unwraps an LLMChatResponse properly."""
         from dapr_agents.types import (
             AssistantMessage,
             LLMChatCandidate,
@@ -328,8 +328,8 @@ class TestDurableAgent:
             }
         }
 
-        assistant_dict = await basic_durable_agent.generate_response(
-            instance_id, "Test task"
+        assistant_dict = await basic_durable_agent.generate_llm_response(
+            instance_id, "2024-01-01T00:00:00Z", "Test task"
         )
         # The dict dumped from AssistantMessage should have our content
         assert assistant_dict["content"] == "Test response"
@@ -382,7 +382,7 @@ class TestDurableAgent:
             }
         }
 
-        basic_durable_agent.finalize_workflow(instance_id, final_output)
+        basic_durable_agent.finalize_workflow(instance_id, final_output, "2024-01-01T00:00:00Z")
         instance_data = basic_durable_agent.state["instances"][instance_id]
         assert instance_data["output"] == final_output
         assert "end_time" in instance_data
@@ -410,13 +410,11 @@ class TestDurableAgent:
             }
         }
 
-        basic_durable_agent.append_assistant_message(instance_id, message)
-        basic_durable_agent.append_tool_message(instance_id, tool_execution_record)
-        basic_durable_agent.finalize_workflow(instance_id, final_output)
+        basic_durable_agent._save_assistant_message(instance_id, message)
+        basic_durable_agent.finalize_workflow(instance_id, final_output, "2024-01-01T00:00:00Z")
 
         instance_data = basic_durable_agent.state["instances"][instance_id]
-        assert len(instance_data["messages"]) == 2
-        assert len(instance_data["tool_history"]) == 1
+        assert len(instance_data["messages"]) == 1  # Only assistant message
         assert instance_data["output"] == final_output
 
     @pytest.mark.asyncio

--- a/tests/agents/durableagent/test_durable_agent.py
+++ b/tests/agents/durableagent/test_durable_agent.py
@@ -390,17 +390,21 @@ class TestDurableAgent:
         assert "end_time" in instance_data
 
     @pytest.mark.asyncio
-    async def test_update_workflow_state(self, basic_durable_agent):
-        """Test updating workflow state via activities."""
+    async def test_run_tool(self, basic_durable_agent, mock_tool):
+        """Test that run_tool atomically executes and persists tool results."""
         instance_id = "test-instance-123"
-        message = {"content": "Test message", "role": "assistant"}
-        tool_execution_record = {
-            "tool_call_id": "call_123",
-            "tool_name": "test_tool",
-            "execution_result": "tool_result",
+        tool_call = {
+            "id": "call_123",
+            "function": {
+                "name": "test_tool",
+                "arguments": '{"arg1": "value1"}'
+            }
         }
-        final_output = "Final output"
-
+        
+        # Mock the tool executor
+        basic_durable_agent.tool_executor.run_tool = AsyncMock(return_value="tool_result")
+        
+        # Set up instance state
         basic_durable_agent.state["instances"] = {
             instance_id: {
                 "input": "Test task",
@@ -412,14 +416,286 @@ class TestDurableAgent:
             }
         }
 
-        basic_durable_agent._save_assistant_message(instance_id, message)
-        basic_durable_agent.finalize_workflow(
-            instance_id, final_output, "2024-01-01T00:00:00Z"
+        result = await basic_durable_agent.run_tool(
+            tool_call, instance_id, "2024-01-01T00:00:00Z"
         )
-
+        
+        # Verify tool was executed and result was returned
+        assert result["tool_call_id"] == "call_123"
+        assert result["tool_name"] == "test_tool"
+        assert result["execution_result"] == "tool_result"
+        
+        # Verify state was updated atomically
         instance_data = basic_durable_agent.state["instances"][instance_id]
-        assert len(instance_data["messages"]) == 1  # Only assistant message
-        assert instance_data["output"] == final_output
+        assert len(instance_data["messages"]) == 1  # Tool message added
+        assert len(instance_data["tool_history"]) == 1  # Tool execution record added
+        
+        # Verify tool execution record in tool_history
+        tool_history_entry = instance_data["tool_history"][0]
+        assert tool_history_entry["tool_call_id"] == "call_123"
+        assert tool_history_entry["tool_name"] == "test_tool"
+        assert tool_history_entry["execution_result"] == "tool_result"
+        
+        # Verify agent-level tool_history was also updated
+        assert len(basic_durable_agent.tool_history) == 1
+
+    def test_get_source_or_default(self, basic_durable_agent):
+        """Test get_source_or_default helper method."""
+        # Test with valid source
+        assert basic_durable_agent.get_source_or_default("test_source") == "test_source"
+        
+        # Test with None source
+        assert basic_durable_agent.get_source_or_default(None) == "direct"
+        
+        # Test with empty string
+        assert basic_durable_agent.get_source_or_default("") == "direct"
+
+    def test_record_initial_entry(self, basic_durable_agent):
+        """Test record_initial_entry helper method."""
+        instance_id = "test-instance-123"
+        input_data = "Test task"
+        source = "test_source"
+        triggering_workflow_instance_id = "parent-instance-123"
+        start_time = "2024-01-01T00:00:00Z"
+        
+        basic_durable_agent.record_initial_entry(
+            instance_id, input_data, source, triggering_workflow_instance_id, start_time
+        )
+        
+        # Verify instance was created
+        assert instance_id in basic_durable_agent.state["instances"]
+        instance_data = basic_durable_agent.state["instances"][instance_id]
+        assert instance_data["input"] == input_data
+        assert instance_data["source"] == source
+        assert instance_data["triggering_workflow_instance_id"] == triggering_workflow_instance_id
+        assert instance_data["start_time"] == start_time
+        assert instance_data["workflow_name"] == "ToolCallingWorkflow"
+        assert instance_data["status"] == "running"
+
+    def test_ensure_instance_exists(self, basic_durable_agent):
+        """Test _ensure_instance_exists helper method."""
+        instance_id = "test-instance-123"
+        triggering_workflow_instance_id = "parent-instance-123"
+        time = "2024-01-01T00:00:00Z"
+        
+        # Test creating new instance
+        basic_durable_agent._ensure_instance_exists(
+            instance_id, triggering_workflow_instance_id, time
+        )
+        
+        assert instance_id in basic_durable_agent.state["instances"]
+        instance_data = basic_durable_agent.state["instances"][instance_id]
+        assert instance_data["triggering_workflow_instance_id"] == triggering_workflow_instance_id
+        assert instance_data["start_time"] == time
+        assert instance_data["workflow_name"] == "ToolCallingWorkflow"
+        
+        # Test that existing instance is not overwritten
+        original_input = "Original input"
+        basic_durable_agent.state["instances"][instance_id]["input"] = original_input
+        
+        basic_durable_agent._ensure_instance_exists(
+            instance_id, "different-parent", "2024-01-02T00:00:00Z"
+        )
+        
+        # Input should remain unchanged
+        assert basic_durable_agent.state["instances"][instance_id]["input"] == original_input
+
+    def test_process_user_message(self, basic_durable_agent):
+        """Test _process_user_message helper method."""
+        instance_id = "test-instance-123"
+        task = "Hello, world!"
+        user_message_copy = {"role": "user", "content": "Hello, world!"}
+        
+        # Set up instance
+        basic_durable_agent.state["instances"][instance_id] = {
+            "input": "Test task",
+            "source": "test_source",
+            "triggering_workflow_instance_id": None,
+            "messages": [],
+            "tool_history": [],
+            "output": None,
+        }
+        
+        # Mock memory.add_message
+        with patch.object(basic_durable_agent.memory, 'add_message') as mock_add_message:
+            basic_durable_agent._process_user_message(instance_id, task, user_message_copy)
+        
+        # Verify message was added to instance
+        instance_data = basic_durable_agent.state["instances"][instance_id]
+        assert len(instance_data["messages"]) == 1
+        assert instance_data["messages"][0]["role"] == "user"
+        assert instance_data["messages"][0]["content"] == "Hello, world!"
+        assert instance_data["last_message"]["role"] == "user"
+
+    def test_save_assistant_message(self, basic_durable_agent):
+        """Test _save_assistant_message helper method."""
+        instance_id = "test-instance-123"
+        assistant_message = {"role": "assistant", "content": "Hello back!"}
+        
+        # Set up instance
+        basic_durable_agent.state["instances"][instance_id] = {
+            "input": "Test task",
+            "source": "test_source",
+            "triggering_workflow_instance_id": None,
+            "messages": [],
+            "tool_history": [],
+            "output": None,
+        }
+        
+        # Mock memory.add_message
+        with patch.object(basic_durable_agent.memory, 'add_message') as mock_add_message:
+            basic_durable_agent._save_assistant_message(instance_id, assistant_message)
+        
+        # Verify message was added to instance
+        instance_data = basic_durable_agent.state["instances"][instance_id]
+        assert len(instance_data["messages"]) == 1
+        assert instance_data["messages"][0]["role"] == "assistant"
+        assert instance_data["messages"][0]["content"] == "Hello back!"
+        assert instance_data["last_message"]["role"] == "assistant"
+
+    def test_get_last_message_from_state(self, basic_durable_agent):
+        """Test _get_last_message_from_state helper method."""
+        instance_id = "test-instance-123"
+        last_message = {"role": "assistant", "content": "Last message"}
+        
+        # Set up instance with last_message
+        basic_durable_agent.state["instances"][instance_id] = {
+            "input": "Test task",
+            "source": "test_source",
+            "triggering_workflow_instance_id": None,
+            "messages": [],
+            "tool_history": [],
+            "output": None,
+            "last_message": last_message,
+        }
+        
+        result = basic_durable_agent._get_last_message_from_state(instance_id)
+        assert result == last_message
+        
+        # Test with non-existent instance
+        result = basic_durable_agent._get_last_message_from_state("non-existent")
+        assert result is None
+
+    def test_create_tool_message_objects(self, basic_durable_agent):
+        """Test _create_tool_message_objects helper method."""
+        tool_result = {
+            "tool_call_id": "call_123",
+            "tool_name": "test_tool",
+            "tool_args": {"arg1": "value1"},
+            "execution_result": "tool_result",
+        }
+        
+        tool_msg, agent_msg, tool_history_entry = basic_durable_agent._create_tool_message_objects(tool_result)
+        
+        # Verify tool message
+        assert tool_msg.tool_call_id == "call_123"
+        assert tool_msg.name == "test_tool"
+        assert tool_msg.content == "tool_result"
+        
+        # Verify agent message (DurableAgentMessage)
+        assert agent_msg.role == "tool"
+        assert agent_msg.tool_call_id == "call_123"
+        assert agent_msg.content == "tool_result"
+        
+        # Verify tool history entry (ToolExecutionRecord)
+        assert tool_history_entry.tool_call_id == "call_123"
+        assert tool_history_entry.tool_name == "test_tool"
+        assert tool_history_entry.tool_args == {"arg1": "value1"}
+        assert tool_history_entry.execution_result == "tool_result"
+
+    def test_append_tool_message_to_instance(self, basic_durable_agent):
+        """Test _append_tool_message_to_instance helper method."""
+        instance_id = "test-instance-123"
+        
+        # Set up instance
+        basic_durable_agent.state["instances"][instance_id] = {
+            "input": "Test task",
+            "source": "test_source",
+            "triggering_workflow_instance_id": None,
+            "messages": [],
+            "tool_history": [],
+            "output": None,
+        }
+        
+        # Create mock objects
+        from dapr_agents.agents.durableagent.state import DurableAgentMessage
+        from dapr_agents.types import ToolExecutionRecord
+        
+        agent_msg = DurableAgentMessage(role="assistant", content="Tool result")
+        tool_history_entry = ToolExecutionRecord(
+            tool_call_id="call_123",
+            tool_name="test_tool",
+            execution_result="tool_result"
+        )
+        
+        basic_durable_agent._append_tool_message_to_instance(
+            instance_id, agent_msg, tool_history_entry
+        )
+        
+        # Verify instance was updated
+        instance_data = basic_durable_agent.state["instances"][instance_id]
+        assert len(instance_data["messages"]) == 1
+        assert instance_data["messages"][0]["role"] == "assistant"
+        assert len(instance_data["tool_history"]) == 1
+        assert instance_data["tool_history"][0]["tool_call_id"] == "call_123"
+
+    def test_update_agent_memory_and_history(self, basic_durable_agent):
+        """Test _update_agent_memory_and_history helper method."""
+        from dapr_agents.types import ToolMessage, ToolExecutionRecord
+        
+        tool_msg = ToolMessage(
+            tool_call_id="call_123",
+            name="test_tool",
+            content="Tool result"
+        )
+        tool_history_entry = ToolExecutionRecord(
+            tool_call_id="call_123",
+            tool_name="test_tool",
+            execution_result="tool_result"
+        )
+        
+        # Mock the memory add_message method
+        with patch.object(basic_durable_agent.memory, 'add_message') as mock_add_message:
+            basic_durable_agent._update_agent_memory_and_history(tool_msg, tool_history_entry)
+            
+            # Verify memory was updated
+            mock_add_message.assert_called_once_with(tool_msg)
+        
+        # Verify agent-level tool_history was updated
+        assert len(basic_durable_agent.tool_history) == 1
+        assert basic_durable_agent.tool_history[0].tool_call_id == "call_123"
+
+    def test_construct_messages_with_instance_history(self, basic_durable_agent):
+        """Test _construct_messages_with_instance_history helper method."""
+        instance_id = "test-instance-123"
+        input_data = "Test input"
+        
+        # Set up instance with messages
+        basic_durable_agent.state["instances"][instance_id] = {
+            "input": "Test task",
+            "source": "test_source",
+            "triggering_workflow_instance_id": None,
+            "messages": [
+                {"role": "user", "content": "Hello"},
+                {"role": "assistant", "content": "Hi there!"},
+            ],
+            "tool_history": [],
+            "output": None,
+        }
+        
+        # Mock prompt template
+        basic_durable_agent.prompt_template = Mock()
+        basic_durable_agent.prompt_template.format_prompt.return_value = [
+            {"role": "system", "content": "System prompt"}
+        ]
+        
+        messages = basic_durable_agent._construct_messages_with_instance_history(instance_id, input_data)
+        
+        # Should include system message + user input
+        assert len(messages) == 2  # system + user input
+        assert messages[0]["role"] == "system"
+        assert messages[1]["role"] == "user"
+        assert messages[1]["content"] == "Test input"
 
     @pytest.mark.asyncio
     async def test_broadcast_message(self, basic_durable_agent):

--- a/tests/agents/durableagent/test_durable_agent.py
+++ b/tests/agents/durableagent/test_durable_agent.py
@@ -46,9 +46,7 @@ def patch_dapr_check(monkeypatch):
         self.wf_client = Mock()
         self.client = Mock()
         self.tasks = {}
-        self.workflows["AgenticWorkflow"] = getattr(
-            self, "tool_calling_workflow", None
-        )
+        self.workflows["AgenticWorkflow"] = getattr(self, "tool_calling_workflow", None)
 
         try:
             super(base.WorkflowApp, self).model_post_init(__context)
@@ -284,9 +282,7 @@ class TestDurableAgent:
             "stop",
         ]
 
-        basic_durable_agent.state["instances"][
-            "test-instance-123"
-        ] = {
+        basic_durable_agent.state["instances"]["test-instance-123"] = {
             "input": "Test task",
             "source": None,
             "triggering_workflow_instance_id": "parent-instance-123",
@@ -464,7 +460,9 @@ class TestDurableAgent:
             # Verify state was updated atomically
             instance_data = basic_durable_agent.state["instances"][instance_id]
             assert len(instance_data["messages"]) == 1  # Tool message added
-            assert len(instance_data["tool_history"]) == 1  # Tool execution record added
+            assert (
+                len(instance_data["tool_history"]) == 1
+            )  # Tool execution record added
 
             # Verify tool execution record in tool_history
             tool_history_entry = instance_data["tool_history"][0]
@@ -545,7 +543,10 @@ class TestDurableAgent:
         )
 
         # Input should remain unchanged
-        assert basic_durable_agent.state["instances"][instance_id]["input"] == original_input
+        assert (
+            basic_durable_agent.state["instances"][instance_id]["input"]
+            == original_input
+        )
 
     def test_process_user_message(self, basic_durable_agent):
         """Test _process_user_message helper method."""
@@ -626,7 +627,9 @@ class TestDurableAgent:
             "tool_history": [],
             "end_time": None,
             "trace_context": None,
-            "last_message": DurableAgentMessage(role="assistant", content="Last message").model_dump(mode='json'),
+            "last_message": DurableAgentMessage(
+                role="assistant", content="Last message"
+            ).model_dump(mode="json"),
         }
 
         result = basic_durable_agent._get_last_message_from_state(instance_id)
@@ -747,8 +750,12 @@ class TestDurableAgent:
             "workflow_name": "AgenticWorkflow",
             "status": "RUNNING",
             "messages": [
-                DurableAgentMessage(role="user", content="Hello").model_dump(mode='json'),
-                DurableAgentMessage(role="assistant", content="Hi there!").model_dump(mode='json'),
+                DurableAgentMessage(role="user", content="Hello").model_dump(
+                    mode="json"
+                ),
+                DurableAgentMessage(role="assistant", content="Hi there!").model_dump(
+                    mode="json"
+                ),
             ],
             "tool_history": [],
             "end_time": None,

--- a/tests/agents/durableagent/test_durable_agent.py
+++ b/tests/agents/durableagent/test_durable_agent.py
@@ -533,9 +533,7 @@ class TestDurableAgent:
         )
 
         # Mock memory.add_message
-        with patch.object(
-            type(basic_durable_agent.memory), "add_message"
-        ):
+        with patch.object(type(basic_durable_agent.memory), "add_message"):
             basic_durable_agent._process_user_message(
                 instance_id, task, user_message_copy
             )
@@ -560,9 +558,7 @@ class TestDurableAgent:
         )
 
         # Mock memory.add_message
-        with patch.object(
-            type(basic_durable_agent.memory), "add_message"
-        ):
+        with patch.object(type(basic_durable_agent.memory), "add_message"):
             basic_durable_agent._save_assistant_message(instance_id, assistant_message)
 
         # Verify message was added to instance

--- a/tests/agents/durableagent/test_durable_agent.py
+++ b/tests/agents/durableagent/test_durable_agent.py
@@ -535,7 +535,7 @@ class TestDurableAgent:
         # Mock memory.add_message
         with patch.object(
             type(basic_durable_agent.memory), "add_message"
-        ) as mock_add_message:
+        ):
             basic_durable_agent._process_user_message(
                 instance_id, task, user_message_copy
             )
@@ -562,7 +562,7 @@ class TestDurableAgent:
         # Mock memory.add_message
         with patch.object(
             type(basic_durable_agent.memory), "add_message"
-        ) as mock_add_message:
+        ):
             basic_durable_agent._save_assistant_message(instance_id, assistant_message)
 
         # Verify message was added to instance
@@ -575,7 +575,6 @@ class TestDurableAgent:
     def test_get_last_message_from_state(self, basic_durable_agent):
         """Test _get_last_message_from_state helper method."""
         instance_id = "test-instance-123"
-        last_message = {"role": "assistant", "content": "Last message"}
 
         # Set up instance with last_message
         basic_durable_agent.state.instances[instance_id] = DurableAgentWorkflowEntry(

--- a/tests/agents/durableagent/test_durable_agent.py
+++ b/tests/agents/durableagent/test_durable_agent.py
@@ -284,13 +284,20 @@ class TestDurableAgent:
             "stop",
         ]
 
-        basic_durable_agent.state.instances[
+        basic_durable_agent.state["instances"][
             "test-instance-123"
-        ] = DurableAgentWorkflowEntry(
-            input="Test task",
-            source=None,
-            triggering_workflow_instance_id="parent-instance-123",
-        )
+        ] = {
+            "input": "Test task",
+            "source": None,
+            "triggering_workflow_instance_id": "parent-instance-123",
+            "workflow_instance_id": "test-instance-123",
+            "workflow_name": "AgenticWorkflow",
+            "status": "RUNNING",
+            "messages": [],
+            "tool_history": [],
+            "end_time": None,
+            "trace_context": None,
+        }
 
         workflow_gen = basic_durable_agent.tool_calling_workflow(
             mock_workflow_context, message
@@ -300,11 +307,11 @@ class TestDurableAgent:
         except StopAsyncIteration:
             pass
 
-        assert "test-instance-123" in basic_durable_agent.state.instances
-        instance_data = basic_durable_agent.state.instances["test-instance-123"]
-        assert instance_data.input == "Test task"
-        assert instance_data.source is None
-        assert instance_data.triggering_workflow_instance_id == "parent-instance-123"
+        assert "test-instance-123" in basic_durable_agent.state["instances"]
+        instance_data = basic_durable_agent.state["instances"]["test-instance-123"]
+        assert instance_data["input"] == "Test task"
+        assert instance_data["source"] is None
+        assert instance_data["triggering_workflow_instance_id"] == "parent-instance-123"
 
     @pytest.mark.asyncio
     async def test_call_llm_activity(self, basic_durable_agent):
@@ -324,12 +331,19 @@ class TestDurableAgent:
 
         instance_id = "test-instance-123"
         # set up a minimal instance record
-        basic_durable_agent.state.instances = {
-            instance_id: DurableAgentWorkflowEntry(
-                input="Test task",
-                source="test_source",
-                triggering_workflow_instance_id=None,
-            )
+        basic_durable_agent.state["instances"] = {
+            instance_id: {
+                "input": "Test task",
+                "source": "test_source",
+                "triggering_workflow_instance_id": None,
+                "workflow_instance_id": instance_id,
+                "workflow_name": "AgenticWorkflow",
+                "status": "RUNNING",
+                "messages": [],
+                "tool_history": [],
+                "end_time": None,
+                "trace_context": None,
+            }
         }
 
         from datetime import datetime
@@ -380,20 +394,27 @@ class TestDurableAgent:
         """Test finishing workflow activity."""
         instance_id = "test-instance-123"
         final_output = "Final response"
-        basic_durable_agent.state.instances = {
-            instance_id: DurableAgentWorkflowEntry(
-                input="Test task",
-                source="test_source",
-                triggering_workflow_instance_id=None,
-            )
+        basic_durable_agent.state["instances"] = {
+            instance_id: {
+                "input": "Test task",
+                "source": "test_source",
+                "triggering_workflow_instance_id": None,
+                "workflow_instance_id": instance_id,
+                "workflow_name": "AgenticWorkflow",
+                "status": "RUNNING",
+                "messages": [],
+                "tool_history": [],
+                "end_time": None,
+                "trace_context": None,
+            }
         }
 
         basic_durable_agent.finalize_workflow(
             instance_id, final_output, "2024-01-01T00:00:00Z"
         )
-        instance_data = basic_durable_agent.state.instances[instance_id]
-        assert instance_data.output == final_output
-        assert instance_data.end_time is not None
+        instance_data = basic_durable_agent.state["instances"][instance_id]
+        assert instance_data["output"] == final_output
+        assert instance_data["end_time"] is not None
 
     @pytest.mark.asyncio
     async def test_run_tool(self, basic_durable_agent, mock_tool):
@@ -411,12 +432,19 @@ class TestDurableAgent:
             mock_run_tool.return_value = "tool_result"
 
             # Set up instance state
-            basic_durable_agent.state.instances = {
-                instance_id: DurableAgentWorkflowEntry(
-                    input="Test task",
-                    source="test_source",
-                    triggering_workflow_instance_id=None,
-                )
+            basic_durable_agent.state["instances"] = {
+                instance_id: {
+                    "input": "Test task",
+                    "source": "test_source",
+                    "triggering_workflow_instance_id": None,
+                    "workflow_instance_id": instance_id,
+                    "workflow_name": "AgenticWorkflow",
+                    "status": "RUNNING",
+                    "messages": [],
+                    "tool_history": [],
+                    "end_time": None,
+                    "trace_context": None,
+                }
             }
 
             from datetime import datetime
@@ -434,15 +462,15 @@ class TestDurableAgent:
             assert result["execution_result"] == "tool_result"
 
             # Verify state was updated atomically
-            instance_data = basic_durable_agent.state.instances[instance_id]
-            assert len(instance_data.messages) == 1  # Tool message added
-            assert len(instance_data.tool_history) == 1  # Tool execution record added
+            instance_data = basic_durable_agent.state["instances"][instance_id]
+            assert len(instance_data["messages"]) == 1  # Tool message added
+            assert len(instance_data["tool_history"]) == 1  # Tool execution record added
 
             # Verify tool execution record in tool_history
-            tool_history_entry = instance_data.tool_history[0]
-            assert tool_history_entry.tool_call_id == "call_123"
-            assert tool_history_entry.tool_name == "test_tool"
-            assert tool_history_entry.execution_result == "tool_result"
+            tool_history_entry = instance_data["tool_history"][0]
+            assert tool_history_entry["tool_call_id"] == "call_123"
+            assert tool_history_entry["tool_name"] == "test_tool"
+            assert tool_history_entry["execution_result"] == "tool_result"
 
             # Verify agent-level tool_history was also updated
             assert len(basic_durable_agent.tool_history) == 1
@@ -471,18 +499,18 @@ class TestDurableAgent:
         )
 
         # Verify instance was created
-        assert instance_id in basic_durable_agent.state.instances
-        instance_data = basic_durable_agent.state.instances[instance_id]
-        assert instance_data.input == input_data
-        assert instance_data.source == source
+        assert instance_id in basic_durable_agent.state["instances"]
+        instance_data = basic_durable_agent.state["instances"][instance_id]
+        assert instance_data["input"] == input_data
+        assert instance_data["source"] == source
         assert (
-            instance_data.triggering_workflow_instance_id
+            instance_data["triggering_workflow_instance_id"]
             == triggering_workflow_instance_id
         )
-        # start_time is parsed as datetime by Pydantic, so we need to compare the string representation
-        assert instance_data.start_time.isoformat() == "2024-01-01T00:00:00+00:00"
-        assert instance_data.workflow_name == "AgenticWorkflow"
-        assert instance_data.status == "running"
+        # start_time is stored as string in dict format
+        assert instance_data["start_time"] == "2024-01-01T00:00:00Z"
+        assert instance_data["workflow_name"] == "AgenticWorkflow"
+        assert instance_data["status"] == "running"
 
     def test_ensure_instance_exists(self, basic_durable_agent):
         """Test _ensure_instance_exists helper method."""
@@ -498,26 +526,26 @@ class TestDurableAgent:
             instance_id, "Test input", triggering_workflow_instance_id, test_time
         )
 
-        assert instance_id in basic_durable_agent.state.instances
-        instance_data = basic_durable_agent.state.instances[instance_id]
+        assert instance_id in basic_durable_agent.state["instances"]
+        instance_data = basic_durable_agent.state["instances"][instance_id]
         assert (
-            instance_data.triggering_workflow_instance_id
+            instance_data["triggering_workflow_instance_id"]
             == triggering_workflow_instance_id
         )
-        # start_time is parsed as datetime by Pydantic, so we need to compare the string representation
-        assert instance_data.start_time.isoformat() == "2024-01-01T00:00:00+00:00"
-        assert instance_data.workflow_name == "AgenticWorkflow"
+        # start_time is stored as string in dict format
+        assert instance_data["start_time"] == "2024-01-01T00:00:00+00:00"
+        assert instance_data["workflow_name"] == "AgenticWorkflow"
 
         # Test that existing instance is not overwritten
         original_input = "Original input"
-        basic_durable_agent.state.instances[instance_id].input = original_input
+        basic_durable_agent.state["instances"][instance_id]["input"] = original_input
 
         basic_durable_agent._ensure_instance_exists(
             instance_id, "different-parent", "2024-01-02T00:00:00Z"
         )
 
         # Input should remain unchanged
-        assert basic_durable_agent.state.instances[instance_id].input == original_input
+        assert basic_durable_agent.state["instances"][instance_id]["input"] == original_input
 
     def test_process_user_message(self, basic_durable_agent):
         """Test _process_user_message helper method."""
@@ -526,11 +554,18 @@ class TestDurableAgent:
         user_message_copy = {"role": "user", "content": "Hello, world!"}
 
         # Set up instance
-        basic_durable_agent.state.instances[instance_id] = DurableAgentWorkflowEntry(
-            input="Test task",
-            source="test_source",
-            triggering_workflow_instance_id=None,
-        )
+        basic_durable_agent.state["instances"][instance_id] = {
+            "input": "Test task",
+            "source": "test_source",
+            "triggering_workflow_instance_id": None,
+            "workflow_instance_id": instance_id,
+            "workflow_name": "AgenticWorkflow",
+            "status": "RUNNING",
+            "messages": [],
+            "tool_history": [],
+            "end_time": None,
+            "trace_context": None,
+        }
 
         # Mock memory.add_message
         with patch.object(type(basic_durable_agent.memory), "add_message"):
@@ -539,11 +574,11 @@ class TestDurableAgent:
             )
 
         # Verify message was added to instance
-        instance_data = basic_durable_agent.state.instances[instance_id]
-        assert len(instance_data.messages) == 1
-        assert instance_data.messages[0].role == "user"
-        assert instance_data.messages[0].content == "Hello, world!"
-        assert instance_data.last_message.role == "user"
+        instance_data = basic_durable_agent.state["instances"][instance_id]
+        assert len(instance_data["messages"]) == 1
+        assert instance_data["messages"][0]["role"] == "user"
+        assert instance_data["messages"][0]["content"] == "Hello, world!"
+        assert instance_data["last_message"]["role"] == "user"
 
     def test_save_assistant_message(self, basic_durable_agent):
         """Test _save_assistant_message helper method."""
@@ -551,38 +586,52 @@ class TestDurableAgent:
         assistant_message = {"role": "assistant", "content": "Hello back!"}
 
         # Set up instance
-        basic_durable_agent.state.instances[instance_id] = DurableAgentWorkflowEntry(
-            input="Test task",
-            source="test_source",
-            triggering_workflow_instance_id=None,
-        )
+        basic_durable_agent.state["instances"][instance_id] = {
+            "input": "Test task",
+            "source": "test_source",
+            "triggering_workflow_instance_id": None,
+            "workflow_instance_id": instance_id,
+            "workflow_name": "AgenticWorkflow",
+            "status": "RUNNING",
+            "messages": [],
+            "tool_history": [],
+            "end_time": None,
+            "trace_context": None,
+        }
 
         # Mock memory.add_message
         with patch.object(type(basic_durable_agent.memory), "add_message"):
             basic_durable_agent._save_assistant_message(instance_id, assistant_message)
 
         # Verify message was added to instance
-        instance_data = basic_durable_agent.state.instances[instance_id]
-        assert len(instance_data.messages) == 1
-        assert instance_data.messages[0].role == "assistant"
-        assert instance_data.messages[0].content == "Hello back!"
-        assert instance_data.last_message.role == "assistant"
+        instance_data = basic_durable_agent.state["instances"][instance_id]
+        assert len(instance_data["messages"]) == 1
+        assert instance_data["messages"][0]["role"] == "assistant"
+        assert instance_data["messages"][0]["content"] == "Hello back!"
+        assert instance_data["last_message"]["role"] == "assistant"
 
     def test_get_last_message_from_state(self, basic_durable_agent):
         """Test _get_last_message_from_state helper method."""
         instance_id = "test-instance-123"
 
         # Set up instance with last_message
-        basic_durable_agent.state.instances[instance_id] = DurableAgentWorkflowEntry(
-            input="Test task",
-            source="test_source",
-            triggering_workflow_instance_id=None,
-            last_message=DurableAgentMessage(role="assistant", content="Last message"),
-        )
+        basic_durable_agent.state["instances"][instance_id] = {
+            "input": "Test task",
+            "source": "test_source",
+            "triggering_workflow_instance_id": None,
+            "workflow_instance_id": instance_id,
+            "workflow_name": "AgenticWorkflow",
+            "status": "RUNNING",
+            "messages": [],
+            "tool_history": [],
+            "end_time": None,
+            "trace_context": None,
+            "last_message": DurableAgentMessage(role="assistant", content="Last message").model_dump(mode='json'),
+        }
 
         result = basic_durable_agent._get_last_message_from_state(instance_id)
-        assert result.role == "assistant"
-        assert result.content == "Last message"
+        assert result["role"] == "assistant"
+        assert result["content"] == "Last message"
 
         # Test with non-existent instance
         result = basic_durable_agent._get_last_message_from_state("non-existent")
@@ -624,11 +673,18 @@ class TestDurableAgent:
         instance_id = "test-instance-123"
 
         # Set up instance
-        basic_durable_agent.state.instances[instance_id] = DurableAgentWorkflowEntry(
-            input="Test task",
-            source="test_source",
-            triggering_workflow_instance_id=None,
-        )
+        basic_durable_agent.state["instances"][instance_id] = {
+            "input": "Test task",
+            "source": "test_source",
+            "triggering_workflow_instance_id": None,
+            "workflow_instance_id": instance_id,
+            "workflow_name": "AgenticWorkflow",
+            "status": "RUNNING",
+            "messages": [],
+            "tool_history": [],
+            "end_time": None,
+            "trace_context": None,
+        }
 
         # Create mock objects
 
@@ -644,11 +700,11 @@ class TestDurableAgent:
         )
 
         # Verify instance was updated
-        instance_data = basic_durable_agent.state.instances[instance_id]
-        assert len(instance_data.messages) == 1
-        assert instance_data.messages[0].role == "assistant"
-        assert len(instance_data.tool_history) == 1
-        assert instance_data.tool_history[0].tool_call_id == "call_123"
+        instance_data = basic_durable_agent.state["instances"][instance_id]
+        assert len(instance_data["messages"]) == 1
+        assert instance_data["messages"][0]["role"] == "assistant"
+        assert len(instance_data["tool_history"]) == 1
+        assert instance_data["tool_history"][0]["tool_call_id"] == "call_123"
 
     def test_update_agent_memory_and_history(self, basic_durable_agent):
         """Test _update_agent_memory_and_history helper method."""
@@ -683,15 +739,21 @@ class TestDurableAgent:
         input_data = "Test input"
 
         # Set up instance with messages
-        basic_durable_agent.state.instances[instance_id] = DurableAgentWorkflowEntry(
-            input="Test task",
-            source="test_source",
-            triggering_workflow_instance_id=None,
-            messages=[
-                DurableAgentMessage(role="user", content="Hello"),
-                DurableAgentMessage(role="assistant", content="Hi there!"),
+        basic_durable_agent.state["instances"][instance_id] = {
+            "input": "Test task",
+            "source": "test_source",
+            "triggering_workflow_instance_id": None,
+            "workflow_instance_id": instance_id,
+            "workflow_name": "AgenticWorkflow",
+            "status": "RUNNING",
+            "messages": [
+                DurableAgentMessage(role="user", content="Hello").model_dump(mode='json'),
+                DurableAgentMessage(role="assistant", content="Hi there!").model_dump(mode='json'),
             ],
-        )
+            "tool_history": [],
+            "end_time": None,
+            "trace_context": None,
+        }
 
         # Mock prompt template
         basic_durable_agent.prompt_template = Mock()
@@ -770,5 +832,5 @@ class TestDurableAgent:
             basic_durable_agent.state
         )
         assert isinstance(validated_state, DurableAgentWorkflowState)
-        assert hasattr(basic_durable_agent.state, "instances")
-        assert basic_durable_agent.state.instances == {}
+        assert "instances" in basic_durable_agent.state
+        assert basic_durable_agent.state["instances"] == {}

--- a/tests/agents/durableagent/test_mcp_streamable_http.py
+++ b/tests/agents/durableagent/test_mcp_streamable_http.py
@@ -161,12 +161,19 @@ def durable_agent_with_mcp_tool(mock_mcp_tool, mock_mcp_session):
 async def test_execute_tool_activity_with_mcp_tool(durable_agent_with_mcp_tool):
     # Test the mocked MCP tool (add) with DurableAgent
     instance_id = "test-instance-123"
-    workflow_entry = DurableAgentWorkflowEntry(
-        input="What is 2 plus 2?",
-        source=None,
-        triggering_workflow_instance_id=None,
-    )
-    durable_agent_with_mcp_tool.state.instances[instance_id] = workflow_entry
+    workflow_entry = {
+        "input": "What is 2 plus 2?",
+        "source": None,
+        "triggering_workflow_instance_id": None,
+        "workflow_instance_id": instance_id,
+        "workflow_name": "AgenticWorkflow",
+        "status": "RUNNING",
+        "messages": [],
+        "tool_history": [],
+        "end_time": None,
+        "trace_context": None,
+    }
+    durable_agent_with_mcp_tool.state["instances"][instance_id] = workflow_entry
 
     # Print available tool names for debugging
     tool_names = [t.name for t in durable_agent_with_mcp_tool.tool_executor.tools]
@@ -184,12 +191,12 @@ async def test_execute_tool_activity_with_mcp_tool(durable_agent_with_mcp_tool):
     await durable_agent_with_mcp_tool.run_tool(
         tool_call, instance_id, "2024-01-01T00:00:00Z"
     )
-    instance_data = durable_agent_with_mcp_tool.state.instances[instance_id]
-    assert len(instance_data.tool_history) == 1
-    tool_entry = instance_data.tool_history[0]
-    assert tool_entry.tool_call_id == "call_123"
-    assert tool_entry.tool_name == tool_name
-    assert tool_entry.execution_result == "4"
+    instance_data = durable_agent_with_mcp_tool.state["instances"][instance_id]
+    assert len(instance_data["tool_history"]) == 1
+    tool_entry = instance_data["tool_history"][0]
+    assert tool_entry["tool_call_id"] == "call_123"
+    assert tool_entry["tool_name"] == tool_name
+    assert tool_entry["execution_result"] == "4"
 
 
 # Shared fixture to start the math server with streamable HTTP
@@ -261,12 +268,19 @@ async def test_durable_agent_with_real_server_http(start_math_server_http):
     )
     agent.__pydantic_private__["_tool_executor"] = tool_executor
     instance_id = "test-instance-456"
-    workflow_entry = DurableAgentWorkflowEntry(
-        input="What is 2 plus 2?",
-        source=None,
-        triggering_workflow_instance_id=None,
-    )
-    agent.state.instances[instance_id] = workflow_entry
+    workflow_entry = {
+        "input": "What is 2 plus 2?",
+        "source": None,
+        "triggering_workflow_instance_id": None,
+        "workflow_instance_id": instance_id,
+        "workflow_name": "AgenticWorkflow",
+        "status": "RUNNING",
+        "messages": [],
+        "tool_history": [],
+        "end_time": None,
+        "trace_context": None,
+    }
+    agent.state["instances"][instance_id] = workflow_entry
     # Print available tool names
     tool_names = [t.name for t in agent.tool_executor.tools]
     print("Available tool names (integration test):", tool_names)
@@ -279,9 +293,9 @@ async def test_durable_agent_with_real_server_http(start_math_server_http):
         "function": {"name": tool_name, "arguments": '{"a": 2, "b": 2}'},
     }
     await agent.run_tool(tool_call, instance_id, "2024-01-01T00:00:00Z")
-    instance_data = agent.state.instances[instance_id]
-    assert len(instance_data.tool_history) == 1
-    tool_entry = instance_data.tool_history[0]
-    assert tool_entry.tool_call_id == "call_456"
-    assert tool_entry.tool_name == tool_name
-    assert tool_entry.execution_result == "4"
+    instance_data = agent.state["instances"][instance_id]
+    assert len(instance_data["tool_history"]) == 1
+    tool_entry = instance_data["tool_history"][0]
+    assert tool_entry["tool_call_id"] == "call_456"
+    assert tool_entry["tool_name"] == tool_name
+    assert tool_entry["execution_result"] == "4"

--- a/tests/agents/durableagent/test_mcp_streamable_http.py
+++ b/tests/agents/durableagent/test_mcp_streamable_http.py
@@ -181,7 +181,9 @@ async def test_execute_tool_activity_with_mcp_tool(durable_agent_with_mcp_tool):
         "function": {"name": tool_name, "arguments": '{"a": 2, "b": 2}'},
     }
 
-    result = await durable_agent_with_mcp_tool.run_tool(tool_call, instance_id, "2024-01-01T00:00:00Z")
+    result = await durable_agent_with_mcp_tool.run_tool(
+        tool_call, instance_id, "2024-01-01T00:00:00Z"
+    )
     instance_data = durable_agent_with_mcp_tool.state["instances"][instance_id]
     assert len(instance_data.tool_history) == 1
     tool_entry = instance_data.tool_history[0]

--- a/tests/agents/durableagent/test_mcp_streamable_http.py
+++ b/tests/agents/durableagent/test_mcp_streamable_http.py
@@ -166,7 +166,7 @@ async def test_execute_tool_activity_with_mcp_tool(durable_agent_with_mcp_tool):
         source=None,
         triggering_workflow_instance_id=None,
     )
-    durable_agent_with_mcp_tool.state["instances"] = {instance_id: workflow_entry}
+    durable_agent_with_mcp_tool.state.instances[instance_id] = workflow_entry
 
     # Print available tool names for debugging
     tool_names = [t.name for t in durable_agent_with_mcp_tool.tool_executor.tools]
@@ -184,7 +184,7 @@ async def test_execute_tool_activity_with_mcp_tool(durable_agent_with_mcp_tool):
     await durable_agent_with_mcp_tool.run_tool(
         tool_call, instance_id, "2024-01-01T00:00:00Z"
     )
-    instance_data = durable_agent_with_mcp_tool.state["instances"][instance_id]
+    instance_data = durable_agent_with_mcp_tool.state.instances[instance_id]
     assert len(instance_data.tool_history) == 1
     tool_entry = instance_data.tool_history[0]
     assert tool_entry.tool_call_id == "call_123"
@@ -266,7 +266,7 @@ async def test_durable_agent_with_real_server_http(start_math_server_http):
         source=None,
         triggering_workflow_instance_id=None,
     )
-    agent.state["instances"] = {instance_id: workflow_entry}
+    agent.state.instances[instance_id] = workflow_entry
     # Print available tool names
     tool_names = [t.name for t in agent.tool_executor.tools]
     print("Available tool names (integration test):", tool_names)
@@ -279,7 +279,7 @@ async def test_durable_agent_with_real_server_http(start_math_server_http):
         "function": {"name": tool_name, "arguments": '{"a": 2, "b": 2}'},
     }
     await agent.run_tool(tool_call, instance_id, "2024-01-01T00:00:00Z")
-    instance_data = agent.state["instances"][instance_id]
+    instance_data = agent.state.instances[instance_id]
     assert len(instance_data.tool_history) == 1
     tool_entry = instance_data.tool_history[0]
     assert tool_entry.tool_call_id == "call_456"

--- a/tests/agents/durableagent/test_mcp_streamable_http.py
+++ b/tests/agents/durableagent/test_mcp_streamable_http.py
@@ -181,14 +181,13 @@ async def test_execute_tool_activity_with_mcp_tool(durable_agent_with_mcp_tool):
         "function": {"name": tool_name, "arguments": '{"a": 2, "b": 2}'},
     }
 
-    result = await durable_agent_with_mcp_tool.run_tool(tool_call)
+    result = await durable_agent_with_mcp_tool.run_tool(tool_call, instance_id, "2024-01-01T00:00:00Z")
     instance_data = durable_agent_with_mcp_tool.state["instances"][instance_id]
-    instance_data.tool_history.append(result)
     assert len(instance_data.tool_history) == 1
     tool_entry = instance_data.tool_history[0]
-    assert tool_entry["tool_call_id"] == "call_123"
-    assert tool_entry["tool_name"] == tool_name
-    assert tool_entry["execution_result"] == "4"
+    assert tool_entry.tool_call_id == "call_123"
+    assert tool_entry.tool_name == tool_name
+    assert tool_entry.execution_result == "4"
 
 
 # Shared fixture to start the math server with streamable HTTP
@@ -277,11 +276,10 @@ async def test_durable_agent_with_real_server_http(start_math_server_http):
         "id": "call_456",
         "function": {"name": tool_name, "arguments": '{"a": 2, "b": 2}'},
     }
-    result = await agent.run_tool(tool_call)
+    result = await agent.run_tool(tool_call, instance_id, "2024-01-01T00:00:00Z")
     instance_data = agent.state["instances"][instance_id]
-    instance_data.tool_history.append(result)
     assert len(instance_data.tool_history) == 1
     tool_entry = instance_data.tool_history[0]
-    assert tool_entry["tool_call_id"] == "call_456"
-    assert tool_entry["tool_name"] == tool_name
-    assert tool_entry["execution_result"] == "4"
+    assert tool_entry.tool_call_id == "call_456"
+    assert tool_entry.tool_name == tool_name
+    assert tool_entry.execution_result == "4"

--- a/tests/agents/durableagent/test_mcp_streamable_http.py
+++ b/tests/agents/durableagent/test_mcp_streamable_http.py
@@ -181,7 +181,7 @@ async def test_execute_tool_activity_with_mcp_tool(durable_agent_with_mcp_tool):
         "function": {"name": tool_name, "arguments": '{"a": 2, "b": 2}'},
     }
 
-    result = await durable_agent_with_mcp_tool.run_tool(
+    await durable_agent_with_mcp_tool.run_tool(
         tool_call, instance_id, "2024-01-01T00:00:00Z"
     )
     instance_data = durable_agent_with_mcp_tool.state["instances"][instance_id]
@@ -278,7 +278,7 @@ async def test_durable_agent_with_real_server_http(start_math_server_http):
         "id": "call_456",
         "function": {"name": tool_name, "arguments": '{"a": 2, "b": 2}'},
     }
-    result = await agent.run_tool(tool_call, instance_id, "2024-01-01T00:00:00Z")
+    await agent.run_tool(tool_call, instance_id, "2024-01-01T00:00:00Z")
     instance_data = agent.state["instances"][instance_id]
     assert len(instance_data.tool_history) == 1
     tool_entry = instance_data.tool_history[0]

--- a/uv.lock
+++ b/uv.lock
@@ -743,6 +743,7 @@ dependencies = [
     { name = "requests" },
     { name = "rich" },
     { name = "uvicorn" },
+    { name = "websockets" },
 ]
 
 [package.optional-dependencies]
@@ -758,6 +759,7 @@ observability = [
     { name = "opentelemetry-api" },
     { name = "opentelemetry-exporter-otlp" },
     { name = "opentelemetry-instrumentation-requests" },
+    { name = "opentelemetry-proto" },
     { name = "wrapt" },
 ]
 test = [
@@ -797,12 +799,13 @@ requires-dist = [
     { name = "openapi-pydantic", specifier = ">=0.5.0,<0.6.0" },
     { name = "openinference-instrumentation", marker = "extra == 'observability'", specifier = ">=0.1.0,<1.0.0" },
     { name = "openinference-semantic-conventions", marker = "extra == 'observability'", specifier = ">=0.1.0,<1.0.0" },
-    { name = "opentelemetry-api", marker = "extra == 'observability'", specifier = ">=1.12.0,<1.35.0" },
-    { name = "opentelemetry-exporter-otlp", marker = "extra == 'observability'", specifier = ">=1.32.1,<1.35.0" },
-    { name = "opentelemetry-instrumentation-requests", marker = "extra == 'observability'", specifier = ">=0.53b1,<0.56b0" },
+    { name = "opentelemetry-api", marker = "extra == 'observability'", specifier = ">=1.35.0,<2.0.0" },
+    { name = "opentelemetry-exporter-otlp", marker = "extra == 'observability'", specifier = ">=1.35.0,<2.0.0" },
+    { name = "opentelemetry-instrumentation-requests", marker = "extra == 'observability'", specifier = ">=0.56b0,<0.57b0" },
+    { name = "opentelemetry-proto", marker = "extra == 'observability'", specifier = ">=1.35.0,<2.0.0" },
     { name = "pip-tools", marker = "extra == 'dev'", specifier = ">=7.4.1,<8.0.0" },
     { name = "posthog", specifier = "<6.0.0" },
-    { name = "protobuf", specifier = ">=5.29.0,<7.0.0" },
+    { name = "protobuf", specifier = ">=6.31.0,<7.0.0" },
     { name = "pydantic", specifier = ">=2.11.3,<3.0.0" },
     { name = "pytest", marker = "extra == 'test'", specifier = ">=7.0.0,<8.0.0" },
     { name = "pytest-asyncio", marker = "extra == 'test'", specifier = ">=0.23.0,<1.0.0" },
@@ -817,6 +820,7 @@ requires-dist = [
     { name = "torch", marker = "extra == 'vectorstore'", specifier = ">=2.7.0" },
     { name = "tox", marker = "extra == 'dev'", specifier = ">=4.0.0,<5.0.0" },
     { name = "uvicorn", specifier = ">=0.27.0,<1.0.0" },
+    { name = "websockets", specifier = ">=15.0.0,<16.0.0" },
     { name = "wrapt", marker = "extra == 'observability'", specifier = ">=1.14.0,<2.0.0" },
 ]
 provides-extras = ["test", "dev", "observability", "vectorstore"]
@@ -1128,16 +1132,16 @@ wheels = [
 
 [[package]]
 name = "grpcio-status"
-version = "1.71.2"
+version = "1.75.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "googleapis-common-protos" },
     { name = "grpcio" },
     { name = "protobuf" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/fd/d1/b6e9877fedae3add1afdeae1f89d1927d296da9cf977eca0eb08fb8a460e/grpcio_status-1.71.2.tar.gz", hash = "sha256:c7a97e176df71cdc2c179cd1847d7fc86cca5832ad12e9798d7fed6b7a1aab50", size = 13677, upload-time = "2025-06-28T04:24:05.426Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/ca/8a/2e45ec0512d4ce9afa136c6e4186d063721b5b4c192eec7536ce6b7ba615/grpcio_status-1.75.0.tar.gz", hash = "sha256:69d5b91be1b8b926f086c1c483519a968c14640773a0ccdd6c04282515dbedf7", size = 13646, upload-time = "2025-09-16T09:24:51.069Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/67/58/317b0134129b556a93a3b0afe00ee675b5657f0155509e22fcb853bafe2d/grpcio_status-1.71.2-py3-none-any.whl", hash = "sha256:803c98cb6a8b7dc6dbb785b1111aed739f241ab5e9da0bba96888aa74704cfd3", size = 14424, upload-time = "2025-06-28T04:23:42.136Z" },
+    { url = "https://files.pythonhosted.org/packages/2b/24/d536f0a0fda3a3eeb334893e5fb9d567c2777de6a5384413f71b35cfd0e5/grpcio_status-1.75.0-py3-none-any.whl", hash = "sha256:de62557ef97b7e19c3ce6da19793a12c5f6c1fbbb918d233d9671aba9d9e1d78", size = 14424, upload-time = "2025-09-16T09:23:33.843Z" },
 ]
 
 [[package]]
@@ -2272,45 +2276,45 @@ wheels = [
 
 [[package]]
 name = "opentelemetry-api"
-version = "1.34.1"
+version = "1.35.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "importlib-metadata" },
     { name = "typing-extensions" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/4d/5e/94a8cb759e4e409022229418294e098ca7feca00eb3c467bb20cbd329bda/opentelemetry_api-1.34.1.tar.gz", hash = "sha256:64f0bd06d42824843731d05beea88d4d4b6ae59f9fe347ff7dfa2cc14233bbb3", size = 64987, upload-time = "2025-06-10T08:55:19.818Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/99/c9/4509bfca6bb43220ce7f863c9f791e0d5001c2ec2b5867d48586008b3d96/opentelemetry_api-1.35.0.tar.gz", hash = "sha256:a111b959bcfa5b4d7dffc2fbd6a241aa72dd78dd8e79b5b1662bda896c5d2ffe", size = 64778, upload-time = "2025-07-11T12:23:28.804Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/a5/3a/2ba85557e8dc024c0842ad22c570418dc02c36cbd1ab4b832a93edf071b8/opentelemetry_api-1.34.1-py3-none-any.whl", hash = "sha256:b7df4cb0830d5a6c29ad0c0691dbae874d8daefa934b8b1d642de48323d32a8c", size = 65767, upload-time = "2025-06-10T08:54:56.717Z" },
+    { url = "https://files.pythonhosted.org/packages/1d/5a/3f8d078dbf55d18442f6a2ecedf6786d81d7245844b2b20ce2b8ad6f0307/opentelemetry_api-1.35.0-py3-none-any.whl", hash = "sha256:c4ea7e258a244858daf18474625e9cc0149b8ee354f37843415771a40c25ee06", size = 65566, upload-time = "2025-07-11T12:23:07.944Z" },
 ]
 
 [[package]]
 name = "opentelemetry-exporter-otlp"
-version = "1.34.1"
+version = "1.35.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "opentelemetry-exporter-otlp-proto-grpc" },
     { name = "opentelemetry-exporter-otlp-proto-http" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/44/ba/786b4de7e39d88043622d901b92c4485835f43e0be76c2824d2687911bc2/opentelemetry_exporter_otlp-1.34.1.tar.gz", hash = "sha256:71c9ad342d665d9e4235898d205db17c5764cd7a69acb8a5dcd6d5e04c4c9988", size = 6173, upload-time = "2025-06-10T08:55:21.595Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/2e/2e/63718faa67b17f449a7fb7efdc7125a408cbe5d8c0bb35f423f2776d60b5/opentelemetry_exporter_otlp-1.35.0.tar.gz", hash = "sha256:f94feff09b3524df867c7876b79c96cef20068106cb5efe55340e8d08192c8a4", size = 6142, upload-time = "2025-07-11T12:23:30.128Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/00/c1/259b8d8391c968e8f005d8a0ccefcb41aeef64cf55905cd0c0db4e22aaee/opentelemetry_exporter_otlp-1.34.1-py3-none-any.whl", hash = "sha256:f4a453e9cde7f6362fd4a090d8acf7881d1dc585540c7b65cbd63e36644238d4", size = 7040, upload-time = "2025-06-10T08:54:59.655Z" },
+    { url = "https://files.pythonhosted.org/packages/cf/db/2da28358d3101ca936c1643becbb4ebd69e9e48acf27f153d735a4813c6b/opentelemetry_exporter_otlp-1.35.0-py3-none-any.whl", hash = "sha256:8e6bb9025f6238db7d69bba7ee37c77e4858d0a1ff22a9e126f7c9e017e83afe", size = 7016, upload-time = "2025-07-11T12:23:10.679Z" },
 ]
 
 [[package]]
 name = "opentelemetry-exporter-otlp-proto-common"
-version = "1.34.1"
+version = "1.35.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "opentelemetry-proto" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/86/f0/ff235936ee40db93360233b62da932d4fd9e8d103cd090c6bcb9afaf5f01/opentelemetry_exporter_otlp_proto_common-1.34.1.tar.gz", hash = "sha256:b59a20a927facd5eac06edaf87a07e49f9e4a13db487b7d8a52b37cb87710f8b", size = 20817, upload-time = "2025-06-10T08:55:22.55Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/56/d1/887f860529cba7fc3aba2f6a3597fefec010a17bd1b126810724707d9b51/opentelemetry_exporter_otlp_proto_common-1.35.0.tar.gz", hash = "sha256:6f6d8c39f629b9fa5c79ce19a2829dbd93034f8ac51243cdf40ed2196f00d7eb", size = 20299, upload-time = "2025-07-11T12:23:31.046Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/72/e8/8b292a11cc8d8d87ec0c4089ae21b6a58af49ca2e51fa916435bc922fdc7/opentelemetry_exporter_otlp_proto_common-1.34.1-py3-none-any.whl", hash = "sha256:8e2019284bf24d3deebbb6c59c71e6eef3307cd88eff8c633e061abba33f7e87", size = 18834, upload-time = "2025-06-10T08:55:00.806Z" },
+    { url = "https://files.pythonhosted.org/packages/5a/2c/e31dd3c719bff87fa77391eb7f38b1430d22868c52312cba8aad60f280e5/opentelemetry_exporter_otlp_proto_common-1.35.0-py3-none-any.whl", hash = "sha256:863465de697ae81279ede660f3918680b4480ef5f69dcdac04f30722ed7b74cc", size = 18349, upload-time = "2025-07-11T12:23:11.713Z" },
 ]
 
 [[package]]
 name = "opentelemetry-exporter-otlp-proto-grpc"
-version = "1.34.1"
+version = "1.35.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "googleapis-common-protos" },
@@ -2321,14 +2325,14 @@ dependencies = [
     { name = "opentelemetry-sdk" },
     { name = "typing-extensions" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/41/f7/bb63837a3edb9ca857aaf5760796874e7cecddc88a2571b0992865a48fb6/opentelemetry_exporter_otlp_proto_grpc-1.34.1.tar.gz", hash = "sha256:7c841b90caa3aafcfc4fee58487a6c71743c34c6dc1787089d8b0578bbd794dd", size = 22566, upload-time = "2025-06-10T08:55:23.214Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/20/de/222e4f2f8cd39250991f84d76b661534aef457cafc6a3eb3fcd513627698/opentelemetry_exporter_otlp_proto_grpc-1.35.0.tar.gz", hash = "sha256:ac4c2c3aa5674642db0df0091ab43ec08bbd91a9be469c8d9b18923eb742b9cc", size = 23794, upload-time = "2025-07-11T12:23:31.662Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/b4/42/0a4dd47e7ef54edf670c81fc06a83d68ea42727b82126a1df9dd0477695d/opentelemetry_exporter_otlp_proto_grpc-1.34.1-py3-none-any.whl", hash = "sha256:04bb8b732b02295be79f8a86a4ad28fae3d4ddb07307a98c7aa6f331de18cca6", size = 18615, upload-time = "2025-06-10T08:55:02.214Z" },
+    { url = "https://files.pythonhosted.org/packages/f4/a6/3f60a77279e6a3dc21fc076dcb51be159a633b0bba5cba9fb804062a9332/opentelemetry_exporter_otlp_proto_grpc-1.35.0-py3-none-any.whl", hash = "sha256:ee31203eb3e50c7967b8fa71db366cc355099aca4e3726e489b248cdb2fd5a62", size = 18846, upload-time = "2025-07-11T12:23:12.957Z" },
 ]
 
 [[package]]
 name = "opentelemetry-exporter-otlp-proto-http"
-version = "1.34.1"
+version = "1.35.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "googleapis-common-protos" },
@@ -2339,14 +2343,14 @@ dependencies = [
     { name = "requests" },
     { name = "typing-extensions" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/19/8f/954bc725961cbe425a749d55c0ba1df46832a5999eae764d1a7349ac1c29/opentelemetry_exporter_otlp_proto_http-1.34.1.tar.gz", hash = "sha256:aaac36fdce46a8191e604dcf632e1f9380c7d5b356b27b3e0edb5610d9be28ad", size = 15351, upload-time = "2025-06-10T08:55:24.657Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/88/7f/7bdc06e84266a5b4b0fefd9790b3859804bf7682ce2daabcba2e22fdb3b2/opentelemetry_exporter_otlp_proto_http-1.35.0.tar.gz", hash = "sha256:cf940147f91b450ef5f66e9980d40eb187582eed399fa851f4a7a45bb880de79", size = 15908, upload-time = "2025-07-11T12:23:32.335Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/79/54/b05251c04e30c1ac70cf4a7c5653c085dfcf2c8b98af71661d6a252adc39/opentelemetry_exporter_otlp_proto_http-1.34.1-py3-none-any.whl", hash = "sha256:5251f00ca85872ce50d871f6d3cc89fe203b94c3c14c964bbdc3883366c705d8", size = 17744, upload-time = "2025-06-10T08:55:03.802Z" },
+    { url = "https://files.pythonhosted.org/packages/d4/71/f118cd90dc26797077931dd598bde5e0cc652519db166593f962f8fcd022/opentelemetry_exporter_otlp_proto_http-1.35.0-py3-none-any.whl", hash = "sha256:9a001e3df3c7f160fb31056a28ed7faa2de7df68877ae909516102ae36a54e1d", size = 18589, upload-time = "2025-07-11T12:23:13.906Z" },
 ]
 
 [[package]]
 name = "opentelemetry-instrumentation"
-version = "0.55b1"
+version = "0.56b0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "opentelemetry-api" },
@@ -2354,14 +2358,14 @@ dependencies = [
     { name = "packaging" },
     { name = "wrapt" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/cb/69/d8995f229ddf4d98b9c85dd126aeca03dd1742f6dc5d3bc0d2f6dae1535c/opentelemetry_instrumentation-0.55b1.tar.gz", hash = "sha256:2dc50aa207b9bfa16f70a1a0571e011e737a9917408934675b89ef4d5718c87b", size = 28552, upload-time = "2025-06-10T08:58:15.312Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/bb/14/964e90f524655aed5c699190dad8dd9a05ed0f5fa334b4b33532237c2b51/opentelemetry_instrumentation-0.56b0.tar.gz", hash = "sha256:d2dbb3021188ca0ec8c5606349ee9a2919239627e8341d4d37f1d21ec3291d11", size = 28551, upload-time = "2025-07-11T12:26:19.305Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/60/7d/8ddfda1506c2fcca137924d5688ccabffa1aed9ec0955b7d0772de02cec3/opentelemetry_instrumentation-0.55b1-py3-none-any.whl", hash = "sha256:cbb1496b42bc394e01bc63701b10e69094e8564e281de063e4328d122cc7a97e", size = 31108, upload-time = "2025-06-10T08:57:14.355Z" },
+    { url = "https://files.pythonhosted.org/packages/26/aa/2328f27200b8e51640d4d7ff5343ba6a81ab7d2650a9f574db016aae4adf/opentelemetry_instrumentation-0.56b0-py3-none-any.whl", hash = "sha256:948967f7c8f5bdc6e43512ba74c9ae14acb48eb72a35b61afe8db9909f743be3", size = 31105, upload-time = "2025-07-11T12:25:22.788Z" },
 ]
 
 [[package]]
 name = "opentelemetry-instrumentation-requests"
-version = "0.55b1"
+version = "0.56b0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "opentelemetry-api" },
@@ -2369,57 +2373,57 @@ dependencies = [
     { name = "opentelemetry-semantic-conventions" },
     { name = "opentelemetry-util-http" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/29/0c/8300ceffd0a41e69590f20ff4854f5c0b2ed5e9453c21c1d710746377cd2/opentelemetry_instrumentation_requests-0.55b1.tar.gz", hash = "sha256:3a04ae7bc90af08acef074b369275cf77c60533b319fa91cad76a380fd035c83", size = 14778, upload-time = "2025-06-10T08:58:42.958Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/e2/e9/e824a8ae2b022dc9c62559c803e5cc489ece7489ef38b6ff7efa74cd5cd9/opentelemetry_instrumentation_requests-0.56b0.tar.gz", hash = "sha256:bd1ed4f49d377108541ec26beb7050c31548073d43796f5d92bb91a3125fb566", size = 15187, upload-time = "2025-07-11T12:26:47.217Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/fc/31/9643d13bb78e07038c96e264a9e75cde93ecde50ff2b0cac7597613074d7/opentelemetry_instrumentation_requests-0.55b1-py3-none-any.whl", hash = "sha256:c9ba0a67850b49aa965e760e87e4b68e52530e5373a0b3c15d290a8997136619", size = 12973, upload-time = "2025-06-10T08:57:58.132Z" },
+    { url = "https://files.pythonhosted.org/packages/3e/36/3a50b898041174b9dc66fb1ede1d605b89e632296f98857887ea8c4df789/opentelemetry_instrumentation_requests-0.56b0-py3-none-any.whl", hash = "sha256:07531147237c8592a1ac1d4d5515e18970ef39c940ebee5cdf96644ac037f793", size = 12966, upload-time = "2025-07-11T12:26:00.087Z" },
 ]
 
 [[package]]
 name = "opentelemetry-proto"
-version = "1.34.1"
+version = "1.35.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "protobuf" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/66/b3/c3158dd012463bb7c0eb7304a85a6f63baeeb5b4c93a53845cf89f848c7e/opentelemetry_proto-1.34.1.tar.gz", hash = "sha256:16286214e405c211fc774187f3e4bbb1351290b8dfb88e8948af209ce85b719e", size = 34344, upload-time = "2025-06-10T08:55:32.25Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/dc/a2/7366e32d9a2bccbb8614942dbea2cf93c209610385ea966cb050334f8df7/opentelemetry_proto-1.35.0.tar.gz", hash = "sha256:532497341bd3e1c074def7c5b00172601b28bb83b48afc41a4b779f26eb4ee05", size = 46151, upload-time = "2025-07-11T12:23:38.797Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/28/ab/4591bfa54e946350ce8b3f28e5c658fe9785e7cd11e9c11b1671a867822b/opentelemetry_proto-1.34.1-py3-none-any.whl", hash = "sha256:eb4bb5ac27f2562df2d6857fc557b3a481b5e298bc04f94cc68041f00cebcbd2", size = 55692, upload-time = "2025-06-10T08:55:14.904Z" },
+    { url = "https://files.pythonhosted.org/packages/00/a7/3f05de580da7e8a8b8dff041d3d07a20bf3bb62d3bcc027f8fd669a73ff4/opentelemetry_proto-1.35.0-py3-none-any.whl", hash = "sha256:98fffa803164499f562718384e703be8d7dfbe680192279a0429cb150a2f8809", size = 72536, upload-time = "2025-07-11T12:23:23.247Z" },
 ]
 
 [[package]]
 name = "opentelemetry-sdk"
-version = "1.34.1"
+version = "1.35.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "opentelemetry-api" },
     { name = "opentelemetry-semantic-conventions" },
     { name = "typing-extensions" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/6f/41/fe20f9036433da8e0fcef568984da4c1d1c771fa072ecd1a4d98779dccdd/opentelemetry_sdk-1.34.1.tar.gz", hash = "sha256:8091db0d763fcd6098d4781bbc80ff0971f94e260739aa6afe6fd379cdf3aa4d", size = 159441, upload-time = "2025-06-10T08:55:33.028Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/9a/cf/1eb2ed2ce55e0a9aa95b3007f26f55c7943aeef0a783bb006bdd92b3299e/opentelemetry_sdk-1.35.0.tar.gz", hash = "sha256:2a400b415ab68aaa6f04e8a6a9f6552908fb3090ae2ff78d6ae0c597ac581954", size = 160871, upload-time = "2025-07-11T12:23:39.566Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/07/1b/def4fe6aa73f483cabf4c748f4c25070d5f7604dcc8b52e962983491b29e/opentelemetry_sdk-1.34.1-py3-none-any.whl", hash = "sha256:308effad4059562f1d92163c61c8141df649da24ce361827812c40abb2a1e96e", size = 118477, upload-time = "2025-06-10T08:55:16.02Z" },
+    { url = "https://files.pythonhosted.org/packages/01/4f/8e32b757ef3b660511b638ab52d1ed9259b666bdeeceba51a082ce3aea95/opentelemetry_sdk-1.35.0-py3-none-any.whl", hash = "sha256:223d9e5f5678518f4842311bb73966e0b6db5d1e0b74e35074c052cd2487f800", size = 119379, upload-time = "2025-07-11T12:23:24.521Z" },
 ]
 
 [[package]]
 name = "opentelemetry-semantic-conventions"
-version = "0.55b1"
+version = "0.56b0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "opentelemetry-api" },
     { name = "typing-extensions" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/5d/f0/f33458486da911f47c4aa6db9bda308bb80f3236c111bf848bd870c16b16/opentelemetry_semantic_conventions-0.55b1.tar.gz", hash = "sha256:ef95b1f009159c28d7a7849f5cbc71c4c34c845bb514d66adfdf1b3fff3598b3", size = 119829, upload-time = "2025-06-10T08:55:33.881Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/32/8e/214fa817f63b9f068519463d8ab46afd5d03b98930c39394a37ae3e741d0/opentelemetry_semantic_conventions-0.56b0.tar.gz", hash = "sha256:c114c2eacc8ff6d3908cb328c811eaf64e6d68623840be9224dc829c4fd6c2ea", size = 124221, upload-time = "2025-07-11T12:23:40.71Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/1a/89/267b0af1b1d0ba828f0e60642b6a5116ac1fd917cde7fc02821627029bd1/opentelemetry_semantic_conventions-0.55b1-py3-none-any.whl", hash = "sha256:5da81dfdf7d52e3d37f8fe88d5e771e191de924cfff5f550ab0b8f7b2409baed", size = 196223, upload-time = "2025-06-10T08:55:17.638Z" },
+    { url = "https://files.pythonhosted.org/packages/c7/3f/e80c1b017066a9d999efffe88d1cce66116dcf5cb7f80c41040a83b6e03b/opentelemetry_semantic_conventions-0.56b0-py3-none-any.whl", hash = "sha256:df44492868fd6b482511cc43a942e7194be64e94945f572db24df2e279a001a2", size = 201625, upload-time = "2025-07-11T12:23:25.63Z" },
 ]
 
 [[package]]
 name = "opentelemetry-util-http"
-version = "0.55b1"
+version = "0.56b0"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/12/f7/3cc23b95921177cdda6d61d3475659b86bac335ed02dd19f994a850ceee3/opentelemetry_util_http-0.55b1.tar.gz", hash = "sha256:29e119c1f6796cccf5fc2aedb55274435cde5976d0ac3fec3ca20a80118f821e", size = 8038, upload-time = "2025-06-10T08:58:53.414Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/ce/c5/80c603e44071d172d4e9c909b13e3d9924b90b08a581eff78a8daf77686e/opentelemetry_util_http-0.56b0.tar.gz", hash = "sha256:9a0c8573a68e3242a2d3e5840476088e63714e6d3e25f67127945ab0c7143074", size = 9404, upload-time = "2025-07-11T12:26:55.365Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/a3/0a/49c5464efc0e6f6aa94a9ec054879efe2a59d7c1f6aacc500665b3d8afdc/opentelemetry_util_http-0.55b1-py3-none-any.whl", hash = "sha256:e134218df8ff010e111466650e5f019496b29c3b4f1b7de0e8ff8ebeafeebdf4", size = 7299, upload-time = "2025-06-10T08:58:11.785Z" },
+    { url = "https://files.pythonhosted.org/packages/05/ca/20763fba2af06e73f0e666e46a32b5cdb9d2d75dcb5fd221f50c818cae43/opentelemetry_util_http-0.56b0-py3-none-any.whl", hash = "sha256:e26dd8c7f71da6806f1e65ac7cde189d389b8f152506146968f59b7a607dc8cf", size = 7645, upload-time = "2025-07-11T12:26:16.106Z" },
 ]
 
 [[package]]
@@ -2780,16 +2784,16 @@ wheels = [
 
 [[package]]
 name = "protobuf"
-version = "5.29.5"
+version = "6.32.1"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/43/29/d09e70352e4e88c9c7a198d5645d7277811448d76c23b00345670f7c8a38/protobuf-5.29.5.tar.gz", hash = "sha256:bc1463bafd4b0929216c35f437a8e28731a2b7fe3d98bb77a600efced5a15c84", size = 425226, upload-time = "2025-05-28T23:51:59.82Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/fa/a4/cc17347aa2897568beece2e674674359f911d6fe21b0b8d6268cd42727ac/protobuf-6.32.1.tar.gz", hash = "sha256:ee2469e4a021474ab9baafea6cd070e5bf27c7d29433504ddea1a4ee5850f68d", size = 440635, upload-time = "2025-09-11T21:38:42.935Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/5f/11/6e40e9fc5bba02988a214c07cf324595789ca7820160bfd1f8be96e48539/protobuf-5.29.5-cp310-abi3-win32.whl", hash = "sha256:3f1c6468a2cfd102ff4703976138844f78ebd1fb45f49011afc5139e9e283079", size = 422963, upload-time = "2025-05-28T23:51:41.204Z" },
-    { url = "https://files.pythonhosted.org/packages/81/7f/73cefb093e1a2a7c3ffd839e6f9fcafb7a427d300c7f8aef9c64405d8ac6/protobuf-5.29.5-cp310-abi3-win_amd64.whl", hash = "sha256:3f76e3a3675b4a4d867b52e4a5f5b78a2ef9565549d4037e06cf7b0942b1d3fc", size = 434818, upload-time = "2025-05-28T23:51:44.297Z" },
-    { url = "https://files.pythonhosted.org/packages/dd/73/10e1661c21f139f2c6ad9b23040ff36fee624310dc28fba20d33fdae124c/protobuf-5.29.5-cp38-abi3-macosx_10_9_universal2.whl", hash = "sha256:e38c5add5a311f2a6eb0340716ef9b039c1dfa428b28f25a7838ac329204a671", size = 418091, upload-time = "2025-05-28T23:51:45.907Z" },
-    { url = "https://files.pythonhosted.org/packages/6c/04/98f6f8cf5b07ab1294c13f34b4e69b3722bb609c5b701d6c169828f9f8aa/protobuf-5.29.5-cp38-abi3-manylinux2014_aarch64.whl", hash = "sha256:fa18533a299d7ab6c55a238bf8629311439995f2e7eca5caaff08663606e9015", size = 319824, upload-time = "2025-05-28T23:51:47.545Z" },
-    { url = "https://files.pythonhosted.org/packages/85/e4/07c80521879c2d15f321465ac24c70efe2381378c00bf5e56a0f4fbac8cd/protobuf-5.29.5-cp38-abi3-manylinux2014_x86_64.whl", hash = "sha256:63848923da3325e1bf7e9003d680ce6e14b07e55d0473253a690c3a8b8fd6e61", size = 319942, upload-time = "2025-05-28T23:51:49.11Z" },
-    { url = "https://files.pythonhosted.org/packages/7e/cc/7e77861000a0691aeea8f4566e5d3aa716f2b1dece4a24439437e41d3d25/protobuf-5.29.5-py3-none-any.whl", hash = "sha256:6cf42630262c59b2d8de33954443d94b746c952b01434fc58a417fdbd2e84bd5", size = 172823, upload-time = "2025-05-28T23:51:58.157Z" },
+    { url = "https://files.pythonhosted.org/packages/c0/98/645183ea03ab3995d29086b8bf4f7562ebd3d10c9a4b14ee3f20d47cfe50/protobuf-6.32.1-cp310-abi3-win32.whl", hash = "sha256:a8a32a84bc9f2aad712041b8b366190f71dde248926da517bde9e832e4412085", size = 424411, upload-time = "2025-09-11T21:38:27.427Z" },
+    { url = "https://files.pythonhosted.org/packages/8c/f3/6f58f841f6ebafe076cebeae33fc336e900619d34b1c93e4b5c97a81fdfa/protobuf-6.32.1-cp310-abi3-win_amd64.whl", hash = "sha256:b00a7d8c25fa471f16bc8153d0e53d6c9e827f0953f3c09aaa4331c718cae5e1", size = 435738, upload-time = "2025-09-11T21:38:30.959Z" },
+    { url = "https://files.pythonhosted.org/packages/10/56/a8a3f4e7190837139e68c7002ec749190a163af3e330f65d90309145a210/protobuf-6.32.1-cp39-abi3-macosx_10_9_universal2.whl", hash = "sha256:d8c7e6eb619ffdf105ee4ab76af5a68b60a9d0f66da3ea12d1640e6d8dab7281", size = 426454, upload-time = "2025-09-11T21:38:34.076Z" },
+    { url = "https://files.pythonhosted.org/packages/3f/be/8dd0a927c559b37d7a6c8ab79034fd167dcc1f851595f2e641ad62be8643/protobuf-6.32.1-cp39-abi3-manylinux2014_aarch64.whl", hash = "sha256:2f5b80a49e1eb7b86d85fcd23fe92df154b9730a725c3b38c4e43b9d77018bf4", size = 322874, upload-time = "2025-09-11T21:38:35.509Z" },
+    { url = "https://files.pythonhosted.org/packages/5c/f6/88d77011b605ef979aace37b7703e4eefad066f7e84d935e5a696515c2dd/protobuf-6.32.1-cp39-abi3-manylinux2014_x86_64.whl", hash = "sha256:b1864818300c297265c83a4982fd3169f97122c299f56a56e2445c3698d34710", size = 322013, upload-time = "2025-09-11T21:38:37.017Z" },
+    { url = "https://files.pythonhosted.org/packages/97/b7/15cc7d93443d6c6a84626ae3258a91f4c6ac8c0edd5df35ea7658f71b79c/protobuf-6.32.1-py3-none-any.whl", hash = "sha256:2601b779fc7d32a866c6b4404f9d42a3f67c5b9f3f15b4db3cccabe06b95c346", size = 169289, upload-time = "2025-09-11T21:38:41.234Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
issue
https://github.com/dapr/dapr-agents/issues/167

I updated the durable agent wf definition to:
- ensure stateful actions were durable by enabling state management aspect to be atomic with the operation. For ex: if a tool is executed, then the results are immediately saved within the same activity.
- make wf runtime task/wf registration atomic so things will only register once (this fixes a race condition where task/wf registrations occurred before runtime was fully up)
- use deterministic time formatting from the wf context
- updated log levels to improve dx and not log so much and also not log on replays of the wf
- create/use helpers in the activities so they're not as large with making state management more atomic

The workflow used to look like this:
<img width="543" height="772" alt="image" src="https://github.com/user-attachments/assets/4c37aac6-2b7c-44dc-8025-b1bc2d8c3d68" />


And now its simplified to this :)
<img width="648" height="633" alt="image" src="https://github.com/user-attachments/assets/832d8d44-f8fc-49c8-b39e-8a06a996413e" />
