### PR TITLE
fix: allow us to run daprd at edge version

### DIFF
--- a/dapr_agents/llm/dapr/chat.py
+++ b/dapr_agents/llm/dapr/chat.py
@@ -332,10 +332,10 @@ class DaprChatClient(DaprInferenceClientBase, ChatClientBase):
             if dapr_runtime_version is not None:
                 # Allow only versions >=1.16.0 and <2.0.0 for Alpha2 Chat Client
                 if not is_version_supported(
-                    str(dapr_runtime_version), ">=1.16.0, <2.0.0"
+                    str(dapr_runtime_version), ">=1.16.0, edge, <2.0.0"
                 ):
                     raise DaprRuntimeVersionNotSupportedError(
-                        f"!!!!! Dapr Runtime Version {dapr_runtime_version} is not supported with Alpha2 Dapr Chat Client. Only Dapr runtime versions >=1.16.0 and <2.0.0 are supported."
+                        f"!!!!! Dapr Runtime Version {dapr_runtime_version} is not supported with Alpha2 Dapr Chat Client. Only Dapr runtime versions >=1.16.0, edge,and <2.0.0 are supported."
                     )
 
             raw = self.client.chat_completion_alpha2(

--- a/dapr_agents/utils/semver.py
+++ b/dapr_agents/utils/semver.py
@@ -63,6 +63,8 @@ def is_version_supported(version: str, constraints: str) -> bool:
       - Each token supports operators: ==, !=, >=, <=, >, <
       - Missing operator defaults to ==
     """
+    if version == "edge":
+        return True
     v = Version.parse(version)
     for group in constraints.split("||"):
         group = group.strip()


### PR DESCRIPTION
was testing dapr/dapr changes, so we do need to support runtime at edge for our own testing :) otherwise you get
```
/dapr/chat.py”, line 337, in generate
    raise DaprRuntimeVersionNotSupportedError(
        f”!!!!! Dapr Runtime Version {dapr_runtime_version} is not supported with Alpha2 Dapr Chat Client. Only Dapr runtime versions >=1.16.0 and <2.0.0 are supported.”
    )
dapr_agents.types.exceptions.DaprRuntimeVersionNotSupportedError: !!!!! Dapr Runtime Version edge is not supported with Alpha2 Dapr Chat Client. Only Dapr runtime versions >=1.16.0 and <2.0.0 are supported.

The above exception was the direct cause of the following exception:

Traceback (most recent call last):
  File “/Users/samcoyle/go/src/github.com/dapr-agents/dapr_agents/workflow/task.py”, line 140, in __call__
    validated = await self._validate_output(raw)
                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File “/Users/samcoyle/go/src/github.com/dapr-agents/dapr_agents/workflow/task.py”, line 279, in _validate_output
    result = await result
             ^^^^^^^^^^^^
  File “/Users/samcoyle/go/src/github.com/dapr-agents/dapr_agents/agents/durableagent/agent.py”, line 550, in call_llm
    raise AgentError(export
```