### PR TITLE
Removed reference to a .NET implementation of agents

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,7 +88,6 @@ For more details about these features and other planned work, please check out o
 | Language | Current Status | Development Status | Stable Status |
 |----------|---------------|-------------|--------|
 | Python   | In Development | Q2 2025 | Q3 2025 |
-| .NET     | Planning | Q3 2025 | Q4 2025 |
 | Other Languages | Coming Soon | TBD | TBD |
 
 ## Documentation


### PR DESCRIPTION
For some reason, the README referenced a future implementation of this agentic package in a .NET package. After a couple of questions about it on Discord, I'm removing it as this isn't something anyone is working on to my knowledge.