### PR TITLE
fix: update perms to comment back + more tests to run

### DIFF
--- a/.github/workflows/integration-tests.yaml
+++ b/.github/workflows/integration-tests.yaml
@@ -90,35 +90,13 @@ jobs:
         source .venv/bin/activate
         uv pip install -e .
         uv pip install -e ".[test]"
-    
-    - name: Verify secrets are available
-      run: |
-        if [ -z "${{ secrets.OPENAI_API_KEY }}" ]; then
-          echo "OPENAI_API_KEY secret is not available"
-          echo "This is expected for PRs from forks (GitHub doesn't expose secrets to forks for security)"
-          echo "For PRs from the same repository, check that secrets are configured in repository settings"
-        else
-          echo "OPENAI_API_KEY is available"
-        fi
-        
-        if [ -z "${{ secrets.ELEVENLABS_API_KEY }}" ]; then
-          echo "ELEVENLABS_API_KEY secret is not available"
-        else
-          echo "ELEVENLABS_API_KEY is available"
-        fi
-        
-        if [ -z "${{ secrets.NVIDIA_API_KEY }}" ]; then
-          echo "NVIDIA_API_KEY secret is not available"
-        else
-          echo "NVIDIA_API_KEY is available"
-        fi
-    
+
     - name: Run Integration Tests
       env:
         OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
       run: |
         source .venv/bin/activate
-        pytest -m integration -v tests/integration/quickstarts/test_01_hello_world.py::TestHelloWorldQuickstart::test_basic_llm
+        pytest -m integration -v tests/integration/quickstarts/test_01_*.py tests/integration/quickstarts/test_02_*.py
         # Run all integration tests in parallel (one file per quickstart directory)
         # -n auto uses all available CPUs, or specify -n 4 for fixed number
         # pytest -m integration -v -n auto tests/integration/quickstarts/
@@ -128,12 +106,19 @@ jobs:
     needs: integration-tests
     runs-on: ubuntu-latest
     if: always() && github.event_name == 'issue_comment'
+    permissions:
+      pull-requests: write
+      actions: read
     steps:
     - name: Comment PR with test results summary
       uses: actions/github-script@v7
       with:
         script: |
           const prNumber = context.payload.issue.number;
+          if (!context.payload.issue.pull_request) {
+            core.setFailed('This is not a pull request');
+            return;
+          }
           const { data: jobs } = await github.rest.actions.listJobsForWorkflowRun({
             owner: context.repo.owner,
             repo: context.repo.repo,


### PR DESCRIPTION
fix to allow CI to comment back on integration test run status on PR after "/ok-to-test" comment as well as add one more test file for me to see how it runs in ci