### PR TITLE
fix: use existing gh action instead for this

### DIFF
--- a/.github/workflows/integration-tests.yaml
+++ b/.github/workflows/integration-tests.yaml
@@ -11,8 +11,6 @@ permissions:
   contents: read
   pull-requests: read
   issues: write
-  members: read
-  organization: read
 
 jobs:
   integration-tests:
@@ -30,44 +28,32 @@ jobs:
       github.event_name == 'pull_request' ||
       github.event_name == 'workflow_dispatch'
     steps:
-    - name: Verify team membership for PR comments to run tests
+    - name: Check team membership - maintainers-dapr-agents
       if: github.event_name == 'issue_comment'
-      uses: actions/github-script@v7
+      id: check_maintainers
+      uses: tspascoal/get-user-teams-membership@v2
       with:
-        script: |
-          const username = context.payload.comment.user.login;
-          const allowedTeams = ['maintainers-dapr-agents', 'approvers-dapr-agent'];
-          const org = context.repo.owner;
-          
-          let isTeamMember = false;
-          for (const teamSlug of allowedTeams) {
-            try {
-              await github.rest.teams.getMembershipForUserInOrg({
-                org: org,
-                team_slug: teamSlug,
-                username: username,
-              });
-              
-              console.log(`User ${username} is a member of team ${teamSlug}`);
-              isTeamMember = true;
-              break;
-            } catch (error) {
-              // User is not a member of this team, continue checking other teams
-              if (error.status === 404) {
-                console.log(`User ${username} is not a member of team ${teamSlug}`);
-                continue;
-              } else {
-                // Unexpected error, log but continue
-                console.log(`Error checking team ${teamSlug} membership: ${error.message}`);
-                continue;
-              }
-            }
-          }
-          
-          if (!isTeamMember) {
-            core.setFailed(`User ${username} is not authorized to run this workflow. Must be a member of one of these teams: ${allowedTeams.join(', ')}`);
-            return;
-          }
+        username: ${{ github.event.comment.user.login }}
+        organization: ${{ github.repository_owner }}
+        team: maintainers-dapr-agents
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+    
+    - name: Check team membership - approvers-dapr-agent
+      if: github.event_name == 'issue_comment'
+      id: check_approvers
+      uses: tspascoal/get-user-teams-membership@v2
+      with:
+        username: ${{ github.event.comment.user.login }}
+        organization: ${{ github.repository_owner }}
+        team: approvers-dapr-agent
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+    
+    - name: Verify user is authorized
+      if: github.event_name == 'issue_comment' && steps.check_maintainers.outputs.isTeamMember != 'true' && steps.check_approvers.outputs.isTeamMember != 'true'
+      run: |
+        echo "User ${{ github.event.comment.user.login }} is not authorized to run this workflow."
+        echo "Must be a member of one of these teams: maintainers-dapr-agents, approvers-dapr-agent"
+        exit 1
     
     - name: Get PR details
       if: github.event_name == 'issue_comment'


### PR DESCRIPTION
swap my custom stuff to use an existing github action to verify that an end user putting the "/ok-to-test" comment has perms to do so (ie is an approver or maintainer)