### PR TITLE
fix: add back deps to run pytest

### DIFF
--- a/.github/workflows/integration-tests.yaml
+++ b/.github/workflows/integration-tests.yaml
@@ -93,12 +93,20 @@ jobs:
       uses: astral-sh/setup-uv@v3
       with:
         version: "latest"
-        
+
+    - name: Install dependencies
+      run: |
+        uv venv
+        source .venv/bin/activate
+        uv pip install -e .
+        uv pip install -e ".[test]"
+
     - name: Run Integration Tests
       env:
         OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
       run: |
-        pytest -m integration -v tests/integration/quickstarts/test_01_*.py tests/integration/quickstarts/test_02_*.py
+        
+        uv run pytest -m integration -v tests/integration/quickstarts/test_01_*.py tests/integration/quickstarts/test_02_*.py
         # Run all integration tests in parallel (one file per quickstart directory)
         # -n auto uses all available CPUs, or specify -n 4 for fixed number
         # pytest -m integration -v -n auto tests/integration/quickstarts/


### PR DESCRIPTION
i thought i could remove the deps part bc the tests create venvs per quickstart but  i do need deps installed in ci step to run pytest
tldr fixes:
```
/home/runner/work/_temp/6ff91793-035b-466f-b01b-d5eee8feae6e.sh: line 1: pytest: command not found

```