### PR TITLE
fix: correct path on docker compose file and use python3 over 3.10 (user has to manage their 3 version)

### DIFF
--- a/quickstarts/05-multi-agent-workflow-k8s/docker-compose.yaml
+++ b/quickstarts/05-multi-agent-workflow-k8s/docker-compose.yaml
@@ -1,27 +1,26 @@
-version: "3.9"
 services:
   workflow-llm:
     image: localhost:5001/workflow-llm:latest
     build:
       context: ../
-      dockerfile: ./quickstarts/05-multi-agent-workflow-k8s/services/workflow-llm/Dockerfile
+      dockerfile: ./05-multi-agent-workflow-k8s/services/workflow-llm/Dockerfile
   frodo:
     image: localhost:5001/frodo:latest
     build:
       context: ../
-      dockerfile: ./quickstarts/05-multi-agent-workflow-k8s/services/frodo/Dockerfile
+      dockerfile: ./05-multi-agent-workflow-k8s/services/frodo/Dockerfile
   sam:
     image: localhost:5001/sam:latest
     build:
       context: ../
-      dockerfile: ./quickstarts/05-multi-agent-workflow-k8s/services/sam/Dockerfile
+      dockerfile: ./05-multi-agent-workflow-k8s/services/sam/Dockerfile
   gandalf:
     image: localhost:5001/gandalf:latest
     build:
       context: ../
-      dockerfile: ./quickstarts/05-multi-agent-workflow-k8s/services/gandalf/Dockerfile
+      dockerfile: ./05-multi-agent-workflow-k8s/services/gandalf/Dockerfile
   legolas:
     image: localhost:5001/legolas:latest
     build:
       context: ../
-      dockerfile: ./quickstarts/05-multi-agent-workflow-k8s/services/legolas/Dockerfile
+      dockerfile: ./05-multi-agent-workflow-k8s/services/legolas/Dockerfile

--- a/quickstarts/05-multi-agent-workflow-k8s/install.sh
+++ b/quickstarts/05-multi-agent-workflow-k8s/install.sh
@@ -122,5 +122,5 @@ kubectl port-forward -n default svc/workflow-llm 8004:80 &>/dev/null &
 echo "### Port forwarded the workflow-llm pod... ###"
 
 echo "### Trigger workflow... ###"
-python3.10 -m pip install -r "${BASE_DIR}/services/client/requirements.txt" &>/dev/null
-python3.10 "${BASE_DIR}/services/client/k8s_http_client.py"
+python3 -m pip install -r "${BASE_DIR}/services/client/requirements.txt" &>/dev/null
+python3 "${BASE_DIR}/services/client/k8s_http_client.py"


### PR DESCRIPTION
# Description

Correct path in the docker compose file & narrow from python3.10 to 3 so the user can use different versions. We can't assume 3.10.

## Issue reference

We strive to have all PR being opened based on an issue, where the problem or feature have been discussed prior to implementation.

Please reference the issue this PR will close: N/A

## Checklist

Please make sure you've completed the relevant tasks for this PR, out of the following list:

* [X] Created/updated tests
* [X] Tested this change against all the quickstarts
* [X] Extended the documentation
    * [X] Created the [dapr/docs](https://github.com/dapr/docs) PR: N/A
**Note:** We expect contributors to open a corresponding documentation PR in the [dapr/docs](https://github.com/dapr/docs/) repository. As the implementer, you are the best person to document your work! Implementation PRs will not be merged until the documentation PR is opened and ready for review.

None of the above relevant here. The quickstarter wouldn't run.