### PR TITLE
fix: use teams for codeowners instead of git handles

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,3 +1,2 @@
 # These owners are the maintainers and approvers of this repo
-# TODO: we need official teams in dapr github https://github.com/orgs/dapr/teams
-* @yaron2 @Cyb3rWard0g
+*       @dapr/maintainers-dapr-agents @dapr/approvers-dapr-agents


### PR DESCRIPTION
# Description

update codeowners file to use the git teams instead of direct github handles

## Issue reference

We strive to have all PR being opened based on an issue, where the problem or feature have been discussed prior to implementation.

Please reference the issue this PR will close: n/a

## Checklist

Please make sure you've completed the relevant tasks for this PR, out of the following list:

* [ ] Created/updated tests
* [ ] Tested this change against all the quickstarts
* [ ] Extended the documentation
    * [ ] Created the [dapr/docs](https://github.com/dapr/docs) PR: <insert PR link here>

**Note:** We expect contributors to open a corresponding documentation PR in the [dapr/docs](https://github.com/dapr/docs/) repository. As the implementer, you are the best person to document your work! Implementation PRs will not be merged until the documentation PR is opened and ready for review.