### PR TITLE
fix: improve type checking for the mcp and toolbox functions

### DIFF
--- a/dapr_agents/tool/base.py
+++ b/dapr_agents/tool/base.py
@@ -162,7 +162,7 @@ class AgentTool(BaseModel):
         mcp_tools: list[MCPTool],
         session: Optional[ClientSession] = None,
         connection: Any = None,
-    ) -> list["AgentTool"]:
+    ) -> list[AgentTool]:
         """
         Batch-create AgentTool objects from a list of MCPTool objects.
 


### PR DESCRIPTION
# Description

Implement stronger types on return objects as well as import `annotations` from `__future__` to adhere to the modern way, removing the need to do `"MCPTool"`.
I've also added explicit input types (rather than just `list`) to enforce better type checking.

## Issue reference

We strive to have all PR being opened based on an issue, where the problem or feature have been discussed prior to implementation.

Please reference the issue this PR closes: N/A. Identified as DX during usage.

## Checklist

Please make sure you've completed the relevant tasks for this PR, out of the following list:

* [x] Created/updated tests
* [x] Tested this change against all the quickstarts
* [x] Extended the documentation
    * [x] Created the [dapr/docs](https://github.com/dapr/docs) PR: N/A

**Note:** We expect contributors to open a corresponding documentation PR in the [dapr/docs](https://github.com/dapr/docs/) repository. As the implementer, you are the best person to document your work! Implementation PRs will not be merged until the documentation PR is opened and ready for review.