### PR TITLE
fix: pip -> uv for ci space/time

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -65,7 +65,7 @@ jobs:
         version: "latest"
     - name: Install dependencies
       run: |
-        uv sync --extra=test,dev
+        uv sync --extra test --extra dev
     - name: Check Typing
       run: |
         uv run tox -e type


### PR DESCRIPTION
# Description

Casper's PRs see 
```
ERROR: Could not install packages due to an OSError: [Errno 28] No space left on device`
```
https://github.com/dapr/dapr-agents/actions/runs/20825726250/job/59858750809?pr=316

Pip -> UV should help. If not we can combine steps to prevent multiple installs in a follwo up effort.

## Issue reference

We strive to have all PR being opened based on an issue, where the problem or feature have been discussed prior to implementation.

Please reference the issue this PR closes: #_[issue number]_

## Checklist

Please make sure you've completed the relevant tasks for this PR, out of the following list:

* [ ] Created/updated tests
* [ ] Tested this change against all the quickstarts
* [ ] Extended the documentation
    * [ ] Created the [dapr/docs](https://github.com/dapr/docs) PR: <insert PR link here>

**Note:** We expect contributors to open a corresponding documentation PR in the [dapr/docs](https://github.com/dapr/docs/) repository. As the implementer, you are the best person to document your work! Implementation PRs will not be merged until the documentation PR is opened and ready for review.