### PR TITLE
Quickstart fix: Rename 'agents-registry' to 'agent-registry' to match component name

### DIFF
--- a/quickstarts/01-dapr-agents-fundamentals/07_durable_agent_pubsub.py
+++ b/quickstarts/01-dapr-agents-fundamentals/07_durable_agent_pubsub.py
@@ -44,7 +44,7 @@ async def main() -> None:
         ),
         # This is where the agent registry is found
         registry=AgentRegistryConfig(
-            store=StateStoreService(store_name="agents-registry"),
+            store=StateStoreService(store_name="agent-registry"),
         ),
     )
 


### PR DESCRIPTION
# Description

Renamed a component name in one of the Dapr Agent quickstarts since it had a typo and couldn't find the agent registry.

[Link to the component name](https://github.com/dapr/dapr-agents/blob/ecea1cd908da6c9858ff45a0ead54ca08ec4cb8d/quickstarts/01-dapr-agents-fundamentals/resources/agent-registry.yaml#L4)

## Issue reference

We strive to have all PR being opened based on an issue, where the problem or feature have been discussed prior to implementation.

Please reference the issue this PR closes: #_[issue number]_

## Checklist

Please make sure you've completed the relevant tasks for this PR, out of the following list:

* [ ] Created/updated tests
* [ ] Tested this change against all the quickstarts
* [ ] Extended the documentation
    * [ ] Created the [dapr/docs](https://github.com/dapr/docs) PR: <insert PR link here>

**Note:** We expect contributors to open a corresponding documentation PR in the [dapr/docs](https://github.com/dapr/docs/) repository. As the implementer, you are the best person to document your work! Implementation PRs will not be merged until the documentation PR is opened and ready for review.