### PR TITLE
Fix location for llm provider

### DIFF
--- a/quickstarts/README.md
+++ b/quickstarts/README.md
@@ -48,11 +48,11 @@ uv sync --active
 > Warning
 > These examples require an OpenAI API key.
 
-The quickstart uses an OpenAI conversation component located in the `resources` directory. You can replace the provider with Anthropic, Ollama, or others. [See here how to configure another component](https://docs.dapr.io/reference/components-reference/supported-conversation/)
+The quickstart uses an OpenAI conversation component located in the `components` directory. You can replace the provider with Anthropic, Ollama, or others. [See here how to configure another component](https://docs.dapr.io/reference/components-reference/supported-conversation/)
 
 ### Component Configuration
 
-Update `resources/llm-provider.yaml`:
+Update `components/llm-provider.yaml`:
 
 ```yaml
 metadata:


### PR DESCRIPTION
First contribution :)

# Description

Wrong location for llm-provider.yaml file

## Issue reference

We strive to have all PR being opened based on an issue, where the problem or feature have been discussed prior to implementation.

Please reference the issue this PR closes: #_[issue number]_

## Checklist

Please make sure you've completed the relevant tasks for this PR, out of the following list:

* [ ] Created/updated tests
* [ ] Tested this change against all the quickstarts
* [ ] Extended the documentation
    * [ ] Created the [dapr/docs](https://github.com/dapr/docs) PR: <insert PR link here>

**Note:** We expect contributors to open a corresponding documentation PR in the [dapr/docs](https://github.com/dapr/docs/) repository. As the implementer, you are the best person to document your work! Implementation PRs will not be merged until the documentation PR is opened and ready for review.
