### PR TITLE
Awaiting upstream PR - [1.18] fix: remove pgNotifyChannel workaround

### DIFF
--- a/dapr_agents/agents/base.py
+++ b/dapr_agents/agents/base.py
@@ -617,16 +617,13 @@ class AgentBase:
 
         self._load_initial_configuration(keys)
 
-        subscribe_metadata = dict(self.configuration.metadata)
-        subscribe_metadata.setdefault("pgNotifyChannel", "config")
-
         try:
             self._config_client = DaprClient()
             self._subscription_id = self._config_client.subscribe_configuration(
                 store_name=self.configuration.store_name,
                 keys=keys,
                 handler=self._config_handler,
-                config_metadata=subscribe_metadata,
+                config_metadata=dict(self.configuration.metadata),
             )
             logger.info(
                 "Agent %s subscribed to configuration store '%s' for keys %s (ID: %s)",

--- a/examples/09-durable-agent-hot-reload/README.md
+++ b/examples/09-durable-agent-hot-reload/README.md
@@ -69,8 +69,8 @@ CREATE TABLE IF NOT EXISTS configuration (
 );
 
 -- Trigger function that fires a pg_notify on every INSERT or UPDATE.
--- The channel name MUST match the pgNotifyChannel in the
--- RuntimeSubscriptionConfig metadata dict (default: "config").
+-- The channel name must match the pgNotifyChannel configured in the
+-- Dapr component spec (configstore-postgres.yaml).
 CREATE OR REPLACE FUNCTION notify_event()
 RETURNS TRIGGER AS $$
 DECLARE

--- a/examples/09-durable-agent-hot-reload/resources/configstore-postgres.yaml
+++ b/examples/09-durable-agent-hot-reload/resources/configstore-postgres.yaml
@@ -12,3 +12,5 @@ spec:
     value: "configuration"
   - name: connMaxIdleTime
     value: "15s"
+  - name: pgNotifyChannel
+    value: "config"

--- a/tests/agents/test_hot_reload.py
+++ b/tests/agents/test_hot_reload.py
@@ -258,9 +258,33 @@ class TestSetupConfigurationSubscription:
             store_name="runtime-config",
             keys=["agent_role", "agent_goal"],
             handler=agent._config_handler,
-            config_metadata={"pgNotifyChannel": "config"},
+            config_metadata={},
         )
         assert agent._subscription_id == "sub-123"
+
+    def test_passes_user_provided_metadata(self, mock_llm_client):
+        """User-supplied metadata must pass through unchanged; no automatic injection."""
+        agent = ConcreteAgentBase(
+            name="MetadataAgent",
+            llm=mock_llm_client,
+            configuration=RuntimeSubscriptionConfig(
+                store_name="runtime-config",
+                keys=["agent_role"],
+                metadata={"pgNotifyChannel": "my-channel"},
+            ),
+        )
+        mock_client = MagicMock()
+        mock_client.subscribe_configuration.return_value = "sub-789"
+
+        with patch("dapr_agents.agents.base.DaprClient", return_value=mock_client):
+            agent._setup_configuration_subscription()
+
+        mock_client.subscribe_configuration.assert_called_once_with(
+            store_name="runtime-config",
+            keys=["agent_role"],
+            handler=agent._config_handler,
+            config_metadata={"pgNotifyChannel": "my-channel"},
+        )
 
     def test_defaults_keys_to_agent_name(self, mock_llm_client):
         agent = ConcreteAgentBase(
@@ -460,7 +484,7 @@ class TestLoadInitialConfiguration:
         assert agent.profile.role == "Loaded Role"
 
     def test_get_configuration_does_not_pass_metadata(self, mock_llm_client):
-        """Metadata (e.g. pgNotifyChannel) must NOT be passed to get_configuration."""
+        """Subscription metadata must NOT be passed to get_configuration (initial load)."""
         agent = ConcreteAgentBase(
             name="MetaAgent",
             role="Default",


### PR DESCRIPTION
# Description
This PR removes the pgNotifyChannel workaround that was previously introduced in dapr-agents to compensate for PostgreSQL configuration behavior in components-contrib.
After dapr/components-contrib#4241, the PostgreSQL configuration component now reads pgNotifyChannel directly from the component specification metadata. Client applications should no longer inject this value during subscription setup.

## Issue reference
- Removed automatic pgNotifyChannel injection from _setup_configuration_subscription() in AgentBase
- Ensured only user-provided RuntimeSubscriptionConfig.metadata is passed through
- Updated test_hot_reload.py to reflect the new expected behavior (no default channel injection)
- Added test coverage to confirm explicit user-provided metadata is preserved
- Added pgNotifyChannel to configstore-postgres.yaml, where it now belongs

Closes #454 

## Checklist

Please make sure you've completed the relevant tasks for this PR, out of the following list:

* [x] Created/updated tests
* [ ] Tested this change against all the quickstarts
* [ ] Extended the documentation
    * [ ] Created the [dapr/docs](https://github.com/dapr/docs) PR: <insert PR link here>

**Note:** We expect contributors to open a corresponding documentation PR in the [dapr/docs](https://github.com/dapr/docs/) repository. As the implementer, you are the best person to document your work! Implementation PRs will not be merged until the documentation PR is opened and ready for review.
