### PR TITLE
fix: remove invalid temperature field from component YAML files

### DIFF
--- a/examples/02-durable-agent-tool-call/components/openai.yaml
+++ b/examples/02-durable-agent-tool-call/components/openai.yaml
@@ -10,5 +10,4 @@ spec:
     value: "{{OPENAI_API_KEY}}"
   - name: model
     value: gpt-5-2025-08-07
-  - name: temperature
-    value: 1
+

--- a/examples/02-standalone-agent-tool-call/components/openai.yaml
+++ b/examples/02-standalone-agent-tool-call/components/openai.yaml
@@ -10,5 +10,4 @@ spec:
     value: "{{OPENAI_API_KEY}}"
   - name: model
     value: gpt-5-2025-08-07
-  - name: temperature
-    value: 1
+

--- a/examples/03-agent-based-workflows/components/openai.yaml
+++ b/examples/03-agent-based-workflows/components/openai.yaml
@@ -10,5 +10,4 @@ spec:
     value: "{{OPENAI_API_KEY}}"
   - name: model
     value: gpt-4o-mini
-  - name: temperature
-    value: 1
+

--- a/examples/03-llm-based-workflows/components/openai.yaml
+++ b/examples/03-llm-based-workflows/components/openai.yaml
@@ -10,5 +10,4 @@ spec:
     value: "{{OPENAI_API_KEY}}"
   - name: model
     value: gpt-4o-mini
-  - name: temperature
-    value: 1
+

--- a/examples/03-message-router-workflow/components/openai.yaml
+++ b/examples/03-message-router-workflow/components/openai.yaml
@@ -10,5 +10,4 @@ spec:
     value: "{{OPENAI_API_KEY}}"
   - name: model
     value: gpt-5-mini
-  - name: temperature
-    value: 1
+

--- a/examples/04-multi-agent-workflow-k8s/components/openai.yaml
+++ b/examples/04-multi-agent-workflow-k8s/components/openai.yaml
@@ -12,5 +12,4 @@ spec:
         key: OPENAI_API_KEY
     - name: model
       value: gpt-4o-mini
-    - name: temperature
-      value: "0.8"
+

--- a/examples/04-multi-agent-workflows/components/openai.yaml
+++ b/examples/04-multi-agent-workflows/components/openai.yaml
@@ -10,5 +10,4 @@ spec:
     value: "{{OPENAI_API_KEY}}"
   - name: model
     value: gpt-5-mini
-  - name: temperature
-    value: 1
+

--- a/examples/06-agent-mcp-client-sse/components/openai.yaml
+++ b/examples/06-agent-mcp-client-sse/components/openai.yaml
@@ -10,5 +10,4 @@ spec:
     value: "{{OPENAI_API_KEY}}"
   - name: model
     value: gpt-5-2025-08-07
-  - name: temperature
-    value: 1
+

--- a/examples/06-agent-mcp-client-stdio/components/openai.yaml
+++ b/examples/06-agent-mcp-client-stdio/components/openai.yaml
@@ -10,5 +10,4 @@ spec:
     value: "{{OPENAI_API_KEY}}"
   - name: model
     value: gpt-5-2025-08-07
-  - name: temperature
-    value: 1
+

--- a/examples/06-agent-mcp-client-streamablehttp/components/openai.yaml
+++ b/examples/06-agent-mcp-client-streamablehttp/components/openai.yaml
@@ -10,5 +10,4 @@ spec:
     value: "{{OPENAI_API_KEY}}"
   - name: model
     value: gpt-4o-mini
-  - name: temperature
-    value: 1
+

--- a/examples/07-data-agent-mcp-chainlit/components/openai.yaml
+++ b/examples/07-data-agent-mcp-chainlit/components/openai.yaml
@@ -10,5 +10,4 @@ spec:
     value: "{{OPENAI_API_KEY}}"
   - name: model
     value: gpt-4o-mini
-  - name: temperature
-    value: 1
+

--- a/examples/08-agents-as-activities-observability/components/openai.yaml
+++ b/examples/08-agents-as-activities-observability/components/openai.yaml
@@ -10,5 +10,4 @@ spec:
     value: "{{OPENAI_API_KEY}}"
   - name: model
     value: gpt-4o-mini
-  - name: temperature
-    value: 1
+


### PR DESCRIPTION
## Summary
- Remove `temperature` metadata field from all example component YAML files, as it is not a valid Dapr conversation component field

Fixes #452