### PR TITLE
feat: add quickstart showcasing workflow retry config

### DIFF
--- a/quickstarts/README.md
+++ b/quickstarts/README.md
@@ -411,7 +411,7 @@ The agent starts with its initial role (`Original Role`) and subscribes to the D
 This example shows how to configure a `WorkflowRetryPolicy` on a durable agent so that every workflow activity — LLM calls, tool calls, and state writes — is automatically retried with exponential backoff when a transient failure occurs. This is essential for production workloads where network hiccups, rate limits, or temporary provider outages should not crash the workflow.
 
 ```bash
-uv run dapr run --app-id durable-agent-retry --resources-path resources -- python durable_agent_retry.py
+uv run dapr run --app-id durable-agent-retry --resources-path resources -- python 12_durable_agent_retry.py
 ```
 
 ## Expected Behavior

--- a/quickstarts/README.md
+++ b/quickstarts/README.md
@@ -15,6 +15,7 @@ You will learn how to:
 9. **[Orchestrate multiple agents inside a workflow](#9-workflow-with-agent-activities)**
 10. **[Enable distributed tracing for agents with Zipkin](#10-durable-agent-trace-zipkin)**
 11. **[Hot-reload agent configuration at runtime](#11-durable-agent-hot-reload)**
+12. **[Configure retry policies for durable agents](#12-durable-agent-with-retry-policy)**
 
 These examples form the foundation of the Dapr Agents programming model and illustrate how LLM reasoning, tool execution, durable workflows, and agent coordination fit together.
 
@@ -389,6 +390,42 @@ The agent starts with its initial role (`Original Role`) and subscribes to the D
 * Update multiple keys at once by setting a JSON object as the configuration value.
 * Add additional keys for LLM settings (`llm_model`, `llm_provider`) to swap models at runtime.
 * For the full list of supported configuration keys, see the [hot-reload example README](../examples/09-durable-agent-hot-reload/README.md).
+
+---
+
+# 12. Durable Agent with Retry Policy
+
+This example shows how to configure a `WorkflowRetryPolicy` on a durable agent so that every workflow activity — LLM calls, tool calls, and state writes — is automatically retried with exponential backoff when a transient failure occurs. This is essential for production workloads where network hiccups, rate limits, or temporary provider outages should not crash the workflow.
+
+```bash
+uv run dapr run --app-id durable-agent-retry --resources-path resources -- python durable_agent_retry.py
+```
+
+## Expected Behavior
+
+The agent runs the same weather workflow as earlier examples, but with a custom retry policy attached. If any activity fails transiently, the workflow engine retries it according to the configured backoff schedule. Under normal conditions the output looks identical to Example 6; the difference is visible when a transient failure occurs — the workflow retries automatically instead of failing.
+
+## How This Works
+
+1. A `WorkflowRetryPolicy` is created with explicit values for all five retry knobs:
+
+   | Parameter | Default | Example Value | Description |
+   |---|---|---|---|
+   | `max_attempts` | 1 | 3 | Total attempts per activity (1 = no retries) |
+   | `initial_backoff_seconds` | 5 | 2 | Seconds before the first retry |
+   | `max_backoff_seconds` | 30 | 30 | Upper limit on the backoff interval |
+   | `backoff_multiplier` | 1.5 | 2.0 | Multiplier applied after each retry |
+   | `retry_timeout` | None | 120 | Overall timeout (seconds) for all retries |
+
+2. The policy is passed to `DurableAgent(retry_policy=...)`, which converts it into a Dapr Workflow `RetryPolicy` and attaches it to every `ctx.call_activity()` invocation inside the agent workflow.
+
+3. You can override `max_attempts` at deploy time without changing code by setting the environment variable `DAPR_API_MAX_RETRIES`. If set, its value takes precedence.
+
+## How to Extend This Example
+
+* Combine retry policies with the tracing quickstart (Example 10) to observe retry spans in Zipkin.
+* Set `DAPR_API_MAX_RETRIES=5` before running to verify the environment variable override.
+* Lower `retry_timeout` to a very small value and observe the workflow fail fast after the timeout elapses.
 
 ---
 

--- a/quickstarts/durable_agent_retry.py
+++ b/quickstarts/durable_agent_retry.py
@@ -1,0 +1,93 @@
+"""Quickstart 12 — Durable Agent with Retry Policy.
+
+Demonstrates how to configure a WorkflowRetryPolicy on a DurableAgent so that
+every workflow activity (LLM calls, tool calls, state writes) is automatically
+retried with exponential backoff on transient failures.
+
+The five knobs exposed by WorkflowRetryPolicy are:
+
+    max_attempts             – total number of attempts (1 = no retries)
+    initial_backoff_seconds  – wait before the first retry
+    max_backoff_seconds      – upper bound on the backoff interval
+    backoff_multiplier       – multiplier applied after each retry
+    retry_timeout            – optional overall timeout across all retries
+
+You can also override max_attempts at deploy time by setting the environment
+variable DAPR_API_MAX_RETRIES, which takes precedence over the value in code.
+"""
+
+import asyncio
+import logging
+
+from dapr_agents.llm import DaprChatClient
+
+from dapr_agents import DurableAgent
+from dapr_agents.agents.configs import (
+    AgentMemoryConfig,
+    AgentStateConfig,
+    WorkflowRetryPolicy,
+)
+from dapr_agents.memory import ConversationDaprStateMemory
+from dapr_agents.storage.daprstores.stateservice import StateStoreService
+from dapr_agents.workflow.runners import AgentRunner
+from function_tools import slow_weather_func
+
+logging.basicConfig(level=logging.INFO)
+logger = logging.getLogger(__name__)
+
+
+async def main() -> None:
+    # Define an explicit retry policy.
+    # These values are intentionally non-default so every field is visible in
+    # the quickstart.
+    retry = WorkflowRetryPolicy(
+        max_attempts=3,                # retry up to 3 times per activity
+        initial_backoff_seconds=2,     # first retry after 2 s
+        max_backoff_seconds=30,        # cap backoff at 30 s
+        backoff_multiplier=2.0,        # double the wait each retry
+        retry_timeout=120,             # give up after 120 s total
+    )
+
+    weather_agent = DurableAgent(
+        name="WeatherAgent",
+        role="Weather Assistant",
+        instructions=["Help users with weather information"],
+        tools=[slow_weather_func],
+        # Configure this agent to use the Dapr Conversation API.
+        llm=DaprChatClient(component_name="llm-provider"),
+        # Configure the agent to use Dapr State Store for conversation history.
+        memory=AgentMemoryConfig(
+            store=ConversationDaprStateMemory(
+                store_name="agent-memory",
+            )
+        ),
+        # This is where the execution state is stored.
+        state=AgentStateConfig(
+            store=StateStoreService(store_name="agent-workflow"),
+        ),
+        # Attach the retry policy — every workflow activity now uses it.
+        retry_policy=retry,
+    )
+
+    logger.info(
+        "RetryPolicy configured: max_attempts=%s, backoff=%s→%ss (×%.1f), timeout=%ss",
+        retry.max_attempts,
+        retry.initial_backoff_seconds,
+        retry.max_backoff_seconds,
+        retry.backoff_multiplier,
+        retry.retry_timeout,
+    )
+
+    runner = AgentRunner()
+    try:
+        prompt = "What is the weather in London?"
+        await runner.run(weather_agent, payload={"task": prompt})
+    finally:
+        runner.shutdown(weather_agent)
+
+
+if __name__ == "__main__":
+    try:
+        asyncio.run(main())
+    except KeyboardInterrupt:
+        print("\nInterrupted by user. Exiting gracefully...")

--- a/tests/integration/quickstarts/test_01_dapr_agents_fundamentals.py
+++ b/tests/integration/quickstarts/test_01_dapr_agents_fundamentals.py
@@ -279,3 +279,27 @@ class TestHelloWorldQuickstart:
             f"STDERR:\n{result.stderr}"
         )
         assert len(result.stdout) > 0 or len(result.stderr) > 0
+
+    def test_12_durable_agent_retry(self, dapr_runtime):  # noqa: ARG002
+        """Test durable agent retry policy example (durable_agent_retry.py).
+
+        Note: dapr_runtime parameter ensures Dapr is initialized before this test runs.
+        The fixture is needed for setup, even though we don't use the value directly.
+        """
+        script_path = self.quickstart_dir / "durable_agent_retry.py"
+        result = run_quickstart_or_examples_script(
+            script_path,
+            cwd=self.quickstart_dir,
+            env=self.env,
+            timeout=180,
+            use_dapr=True,
+            app_id="durable-agent-retry",
+            resources_path=self.quickstart_dir / "resources",
+        )
+
+        assert result.returncode == 0, (
+            f"Quickstart script '{script_path}' failed with return code {result.returncode}.\n"
+            f"STDOUT:\n{result.stdout}\n"
+            f"STDERR:\n{result.stderr}"
+        )
+        assert len(result.stdout) > 0 or len(result.stderr) > 0


### PR DESCRIPTION

Adds a new quickstart ([quickstarts/durable_agent_retry.py](cci:7://file:///c:/Users/aroky/OneDrive/Desktop/dapr-agents/quickstarts/durable_agent_retry.py:0:0-0:0)) that demonstrates how to configure a [WorkflowRetryPolicy](cci:2://file:///c:/Users/aroky/OneDrive/Desktop/dapr-agents/dapr_agents/agents/configs.py:354:0-371:52) on a [DurableAgent](cci:2://file:///c:/Users/aroky/OneDrive/Desktop/dapr-agents/dapr_agents/agents/durable.py:87:0-1998:71), addressing #472.

### Changes

| File | Action | Purpose |
|---|---|---|
| [quickstarts/durable_agent_retry.py](cci:7://file:///c:/Users/aroky/OneDrive/Desktop/dapr-agents/quickstarts/durable_agent_retry.py:0:0-0:0) | **New** | Quickstart showcasing all 5 retry policy fields |
| [quickstarts/README.md](cci:7://file:///c:/Users/aroky/OneDrive/Desktop/dapr-agents/quickstarts/README.md:0:0-0:0) | Modified | Added TOC entry + section #12 with parameter table and run instructions |
| [tests/integration/quickstarts/test_01_dapr_agents_fundamentals.py](cci:7://file:///c:/Users/aroky/OneDrive/Desktop/dapr-agents/tests/integration/quickstarts/test_01_dapr_agents_fundamentals.py:0:0-0:0) | Modified | Added [test_12_durable_agent_retry](cci:1://file:///c:/Users/aroky/OneDrive/Desktop/dapr-agents/tests/integration/quickstarts/test_01_dapr_agents_fundamentals.py:282:4-304:63) integration test |

### Retry policy fields demonstrated

```python
WorkflowRetryPolicy(
    max_attempts=3,
    initial_backoff_seconds=2,
    max_backoff_seconds=30,
    backoff_multiplier=2.0,
    retry_timeout=120,
)
```
### how to verify
```python
cd quickstarts
uv run dapr run --app-id durable-agent-retry --resources-path resources -- python durable_agent_retry.py
```
All tests passing.
Closes #472 