### PR TITLE
chore: Update to working devcontainer image, remove unused docs dependencies

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -3,10 +3,9 @@
 {
 	"name": "Python 3",
 	// Or use a Dockerfile or Docker Compose file. More info: https://containers.dev/guide/dockerfile
-	"image": "mcr.microsoft.com/devcontainers/python:1-3.12-bullseye",
+	"image": "mcr.microsoft.com/devcontainers/python:3-3.12-bookworm",
 	"features": {
-		"ghcr.io/devcontainers/features/docker-in-docker:2": {},
-		"ghcr.io/dapr/cli/dapr-cli:0": {}
+		"ghcr.io/devcontainers/features/docker-in-docker:2": {}
 	},
 
 	// Use 'forwardPorts' to make a list of ports inside the container available locally.

--- a/.devcontainer/post-create.sh
+++ b/.devcontainer/post-create.sh
@@ -11,10 +11,11 @@
 # limitations under the License.
 #
 
+curl -fsSL https://raw.githubusercontent.com/dapr/cli/master/install/install.sh | /bin/bash
+
 dapr uninstall
 dapr init
+
 pip install --upgrade pip
-pip install mkdocs
-pip install mkdocs-material
-pip install "mkdocs-material[imaging]"
-pip install mkdocs-jupyter
+
+curl -LsSf https://astral.sh/uv/install.sh | sh


### PR DESCRIPTION
# Description

The current devcontainer image was not working anymore.
- Update image
- Updated script to install Dapr CLI, install uv CLI, remove obsolete docs dependencies


## Issue reference

We strive to have all PR being opened based on an issue, where the problem or feature have been discussed prior to implementation.

Please reference the issue this PR closes: #_[issue number]_

## Checklist

Please make sure you've completed the relevant tasks for this PR, out of the following list:

* [ ] Created/updated tests
* [ ] Tested this change against all the quickstarts
* [ ] Extended the documentation
    * [ ] Created the [dapr/docs](https://github.com/dapr/docs) PR: <insert PR link here>

**Note:** We expect contributors to open a corresponding documentation PR in the [dapr/docs](https://github.com/dapr/docs/) repository. As the implementer, you are the best person to document your work! Implementation PRs will not be merged until the documentation PR is opened and ready for review.
