### PR TITLE
docs: fix typos in README and schema descriptions

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,7 +84,7 @@ As a part of **CNCF**, Dapr Agents is vendor-neutral, eliminating concerns about
 
 Check the [project view](https://github.com/orgs/dapr/projects/92) for some of the major features we're working on:
 
-For a complete list of issue (including bug fixes) please check out our [GitHub issues](https://github.com/dapr/dapr-agents/issues).
+For a complete list of issues (including bug fixes) please check out our [GitHub issues](https://github.com/dapr/dapr-agents/issues).
 
 ### Language Support
 

--- a/schemas/agent-metadata/latest.json
+++ b/schemas/agent-metadata/latest.json
@@ -346,7 +346,7 @@
             }
           ],
           "default": null,
-          "description": "Dapr resource name backing the registry (e.g. state store component)",
+          "description": "Dapr resource name backing the registry (e.g., state store component)",
           "title": "Resource Name"
         },
         "name": {


### PR DESCRIPTION
Fixed minor typos found while reading through the documentation.