### PR TITLE
feat: add human-in-the-loop support

### DIFF
--- a/dapr_agents/__init__.py
+++ b/dapr_agents/__init__.py
@@ -14,6 +14,7 @@
 from importlib.metadata import version, PackageNotFoundError
 from dapr_agents.agents.durable import DurableAgent
 from dapr_agents.agents.configs import (
+    AgentApprovalConfig,
     AgentMetadataSchema,
     AgentMetadata,
     PubSubMetadata,
@@ -22,6 +23,7 @@ from dapr_agents.agents.configs import (
     RegistryMetadata,
     LLMMetadata,
 )
+from dapr_agents.agents.schemas import ApprovalRequiredEvent, ApprovalResponseEvent
 from dapr_agents.executors import DockerCodeExecutor, LocalCodeExecutor
 from dapr_agents.llm.dapr import DaprChatClient
 from dapr_agents.llm.elevenlabs import ElevenLabsSpeechClient
@@ -53,6 +55,9 @@ __all__ = [
     "AgentRunner",
     "call_agent",
     "trigger_agent",
+    "AgentApprovalConfig",
+    "ApprovalRequiredEvent",
+    "ApprovalResponseEvent",
     "AgentMetadataSchema",
     "AgentMetadata",
     "PubSubMetadata",

--- a/dapr_agents/__init__.py
+++ b/dapr_agents/__init__.py
@@ -25,6 +25,8 @@ from dapr_agents.agents.configs import (
 )
 from dapr_agents.agents.schemas import ApprovalRequiredEvent, ApprovalResponseEvent
 from dapr_agents.hooks import (
+    BeforeHook,
+    AfterHook,
     Hooks,
     HookContext,
     HookDecision,

--- a/dapr_agents/__init__.py
+++ b/dapr_agents/__init__.py
@@ -24,6 +24,16 @@ from dapr_agents.agents.configs import (
     LLMMetadata,
 )
 from dapr_agents.agents.schemas import ApprovalRequiredEvent, ApprovalResponseEvent
+from dapr_agents.hooks import (
+    Hooks,
+    HookContext,
+    HookDecision,
+    Proceed,
+    Skip,
+    Modify,
+    RequireApproval,
+    Deny,
+)
 from dapr_agents.executors import DockerCodeExecutor, LocalCodeExecutor
 from dapr_agents.llm.dapr import DaprChatClient
 from dapr_agents.llm.elevenlabs import ElevenLabsSpeechClient
@@ -58,6 +68,14 @@ __all__ = [
     "AgentApprovalConfig",
     "ApprovalRequiredEvent",
     "ApprovalResponseEvent",
+    "Hooks",
+    "HookContext",
+    "HookDecision",
+    "Proceed",
+    "Skip",
+    "Modify",
+    "RequireApproval",
+    "Deny",
     "AgentMetadataSchema",
     "AgentMetadata",
     "PubSubMetadata",

--- a/dapr_agents/agents/configs.py
+++ b/dapr_agents/agents/configs.py
@@ -400,6 +400,29 @@ class OrchestrationMode(StrEnum):
 
 
 @dataclass
+class AgentApprovalConfig:
+    """
+    Configuration for human-in-the-loop approval before tool execution.
+
+    When enabled, any tool decorated with requires_approval=True will pause the
+    workflow and wait for a human decision before running. Tools without that flag
+    are unaffected and execute immediately as usual.
+
+    Attributes:
+        enabled: When False (the default) approval checks are skipped entirely.
+        pubsub_name: Dapr pub/sub component where ApprovalRequiredEvent is published.
+        topic: Topic name for outbound approval requests.
+        default_timeout_seconds: Seconds to wait before auto-denying when a tool does
+            not specify its own approval_timeout_seconds.
+    """
+
+    enabled: bool = False
+    pubsub_name: str = "dapr-agents-pubsub"
+    topic: str = "agent-approval-requests"
+    default_timeout_seconds: int = 300
+
+
+@dataclass
 class AgentExecutionConfig:
     """
     Dials to configure the agent execution.
@@ -411,6 +434,7 @@ class AgentExecutionConfig:
     tool_choice: Optional[str] = "auto"
     tool_execution_mode: ToolExecutionMode = ToolExecutionMode.PARALLEL
     orchestration_mode: Optional[OrchestrationMode] = None
+    approval: AgentApprovalConfig = field(default_factory=AgentApprovalConfig)
 
 
 @dataclass

--- a/dapr_agents/agents/configs.py
+++ b/dapr_agents/agents/configs.py
@@ -404,18 +404,28 @@ class AgentApprovalConfig:
     """
     Infrastructure configuration for human-in-the-loop approval.
 
-    This tells the agent where to publish ApprovalRequiredEvent messages when a
+    This tells the agent how to deliver ApprovalRequiredEvent messages when a
     hook returns RequireApproval. The gate for whether approval runs is the hook
     itself — if no hook returns RequireApproval, this config is never used.
 
+    Delivery modes:
+        - pubsub_name set: publishes the event to the configured Dapr pub/sub topic.
+          Use this when the agent is running in subscribe() or serve() mode and a
+          pub/sub component is available (e.g. a Slack bot or dashboard is listening).
+        - pubsub_name None (default): no pub/sub publish. The event is held in memory
+          and exposed via GET /hitl/approvals when the agent is running in serve() mode.
+          For workflow-only agents, submit responses directly via the Dapr sidecar:
+          POST <sidecar>/v1.0-beta1/workflows/dapr/{instance_id}/raiseEvent/approval_response_{id}
+
     Attributes:
-        pubsub_name: Dapr pub/sub component where ApprovalRequiredEvent is published.
-        topic: Topic name for outbound approval requests.
+        pubsub_name: Optional Dapr pub/sub component for outbound approval events.
+            Set to None (default) to disable pub/sub delivery and use HTTP polling instead.
+        topic: Topic name used when pubsub_name is set.
         default_timeout_seconds: Seconds to wait before auto-denying when a
             RequireApproval decision does not specify its own timeout_seconds.
     """
 
-    pubsub_name: str = "dapr-agents-pubsub"
+    pubsub_name: Optional[str] = None
     topic: str = "agent-approval-requests"
     # None means wait indefinitely — the workflow suspends until a human responds, with no automatic denial. Use a positive int (seconds) to auto-deny after that window elapses when approvers may be unavailable.
     default_timeout_seconds: Optional[int] = 300

--- a/dapr_agents/agents/configs.py
+++ b/dapr_agents/agents/configs.py
@@ -402,21 +402,19 @@ class OrchestrationMode(StrEnum):
 @dataclass
 class AgentApprovalConfig:
     """
-    Configuration for human-in-the-loop approval before tool execution.
+    Infrastructure configuration for human-in-the-loop approval.
 
-    When enabled, any tool decorated with requires_approval=True will pause the
-    workflow and wait for a human decision before running. Tools without that flag
-    are unaffected and execute immediately as usual.
+    This tells the agent where to publish ApprovalRequiredEvent messages when a
+    hook returns RequireApproval. The gate for whether approval runs is the hook
+    itself — if no hook returns RequireApproval, this config is never used.
 
     Attributes:
-        enabled: When False (the default) approval checks are skipped entirely.
         pubsub_name: Dapr pub/sub component where ApprovalRequiredEvent is published.
         topic: Topic name for outbound approval requests.
-        default_timeout_seconds: Seconds to wait before auto-denying when a tool does
-            not specify its own approval_timeout_seconds.
+        default_timeout_seconds: Seconds to wait before auto-denying when a
+            RequireApproval decision does not specify its own timeout_seconds.
     """
 
-    enabled: bool = False
     pubsub_name: str = "dapr-agents-pubsub"
     topic: str = "agent-approval-requests"
     default_timeout_seconds: int = 300

--- a/dapr_agents/agents/configs.py
+++ b/dapr_agents/agents/configs.py
@@ -417,7 +417,8 @@ class AgentApprovalConfig:
 
     pubsub_name: str = "dapr-agents-pubsub"
     topic: str = "agent-approval-requests"
-    default_timeout_seconds: int = 300
+    # None means wait indefinitely — the workflow suspends until a human responds, with no automatic denial. Use a positive int (seconds) to auto-deny after that window elapses when approvers may be unavailable.
+    default_timeout_seconds: Optional[int] = 300
 
 
 @dataclass

--- a/dapr_agents/agents/durable.py
+++ b/dapr_agents/agents/durable.py
@@ -53,6 +53,7 @@ from dapr_agents.agents.base import AgentBase
 from dapr_agents.agents.configs import (
     OrchestrationMode,
     ToolExecutionMode,
+    AgentApprovalConfig,
     AgentExecutionConfig,
     AgentMemoryConfig,
     AgentPubSubConfig,
@@ -66,6 +67,8 @@ from dapr_agents.agents.configs import (
 from dapr_agents.agents.prompting import AgentProfileConfig
 from dapr_agents.agents.schemas import (
     AgentWorkflowMessage,
+    ApprovalRequiredEvent,
+    ApprovalResponseEvent,
     BroadcastMessage,
     TriggerAction,
 )
@@ -507,6 +510,35 @@ class DurableAgent(AgentBase):
                                 turn,
                             )
 
+                        # approval pass:
+                        # for each tool that requires approval, pause the workflow
+                        # and collect the human decision before we build any task lists.
+                        # approvals are processed one at a time because each blocks
+                        # until a human responds (or the timeout elapses).
+                        approval_decisions: Dict[str, bool] = {}
+                        if self.execution.approval.enabled:
+                            for tc in tool_calls:
+                                fn_name_check = tc["function"]["name"]
+                                check_obj = self.tool_executor.get_tool(fn_name_check)
+                                if check_obj and getattr(
+                                    check_obj, "requires_approval", False
+                                ):
+                                    approved = yield from self._request_approval(
+                                        ctx, ctx.instance_id, tc
+                                    )
+                                    approval_decisions[tc["id"]] = approved
+                                    if not ctx.is_replaying:
+                                        logger.debug(
+                                            "Approval for tool '%s': %s (instance=%s)",
+                                            fn_name_check,
+                                            "approved" if approved else "not approved",
+                                            ctx.instance_id,
+                                        )
+
+                        ordered: List[Optional[Dict[str, Any]]] = [None] * len(
+                            tool_calls
+                        )
+
                         workflow_tasks: List[Any] = []
                         workflow_meta: List[Dict[str, Any]] = []
                         activity_tasks: List[Any] = []
@@ -514,6 +546,31 @@ class DurableAgent(AgentBase):
 
                         for idx, tc in enumerate(tool_calls):
                             fn_name = tc["function"]["name"]
+
+                            # inject denial message and skip execution for any tool
+                            # whose approval was not granted or timed out
+                            if (
+                                tc["id"] in approval_decisions
+                                and not approval_decisions[tc["id"]]
+                            ):
+                                denial_msg = ToolMessage(
+                                    content=(
+                                        f"Tool '{fn_name}' was not executed: "
+                                        "approval was not granted."
+                                    ),
+                                    role="tool",
+                                    name=fn_name,
+                                    tool_call_id=tc["id"],
+                                )
+                                ordered[idx] = denial_msg.model_dump()
+                                if not ctx.is_replaying:
+                                    logger.info(
+                                        "Skipping tool '%s': approval was not granted (instance=%s)",
+                                        fn_name,
+                                        ctx.instance_id,
+                                    )
+                                continue
+
                             tool_obj = self.tool_executor.get_tool(fn_name)
 
                             # WorkflowContextInjectedTool instances get executed inline as workflow tasks so they can receive the workflow context.
@@ -591,10 +648,6 @@ class DurableAgent(AgentBase):
                         else:
                             results: List[Any] = yield wf.when_all(all_tasks)
 
-                        ordered: List[Optional[Dict[str, Any]]] = [None] * len(
-                            tool_calls
-                        )
-
                         for meta, res in zip(
                             workflow_meta, results[: len(workflow_tasks)]
                         ):
@@ -634,6 +687,18 @@ class DurableAgent(AgentBase):
                                 for meta in activity_meta
                             }
                         )
+                        # include denied tool calls so save_tool_results can log them
+                        # in tool_history for observability
+                        for tc in tool_calls:
+                            if (
+                                tc["id"] in approval_decisions
+                                and not approval_decisions[tc["id"]]
+                            ):
+                                tool_calls_by_id[tc["id"]] = {
+                                    "tool_call": tc,
+                                    "is_agent_call": False,
+                                    "dispatch_time": ctx.current_utc_datetime.isoformat(),
+                                }
                         yield ctx.call_activity(
                             self.save_tool_results,
                             input={
@@ -725,6 +790,140 @@ class DurableAgent(AgentBase):
             ) from _workflow_exc
 
         return final_message
+
+    # human-in-the-loop helpers
+    def _request_approval(
+        self,
+        ctx: wf.DaprWorkflowContext,
+        instance_id: str,
+        tool_call: Dict[str, Any],
+    ):
+        """
+        Pause the workflow and wait for a human to approve or deny a tool call.
+
+        This generator is called with ``yield from`` from agent_workflow. It publishes
+        an ApprovalRequiredEvent the first time it runs for a given tool_call_id, then
+        suspends the workflow via wait_for_external_event. On replay, the publish is
+        skipped if the request ID already exists in workflow state
+        The timeout per tool comes from the tool's approval_timeout_seconds field;
+        if not set, AgentApprovalConfig.default_timeout_seconds is used.
+
+        Args:
+            ctx: Dapr workflow context.
+            instance_id: Running workflow instance ID.
+            tool_call: Tool call dict with 'id' and 'function' keys.
+
+        Returns:
+            True if the human approved, False if not approved or the timeout elapsed.
+        """
+        approval_config = self.execution.approval
+        fn_name = tool_call.get("function", {}).get("name", "unknown")
+        tool_call_id = tool_call.get("id", "")
+
+        # use the per-tool timeout when set, otherwise fall back to the agent default
+        tool_obj = self.tool_executor.get_tool(fn_name)
+        tool_timeout = (
+            getattr(tool_obj, "approval_timeout_seconds", None) if tool_obj else None
+        )
+        timeout_seconds = (
+            tool_timeout
+            if tool_timeout is not None
+            else approval_config.default_timeout_seconds
+        )
+
+        # deterministic UUID derived from instance + tool_call so it is identical on replay
+        approval_request_id = str(
+            uuid.uuid5(uuid.NAMESPACE_DNS, f"{instance_id}:{tool_call_id}")
+        )
+
+        raw_args = tool_call.get("function", {}).get("arguments", "")
+        try:
+            tool_args = json.loads(raw_args) if raw_args else {}
+        except json.JSONDecodeError:
+            tool_args = {}
+
+        approval_event = ApprovalRequiredEvent(
+            approval_request_id=approval_request_id,
+            instance_id=instance_id,
+            tool_name=fn_name,
+            tool_call_id=tool_call_id,
+            tool_arguments=tool_args,
+            timeout_seconds=timeout_seconds,
+        )
+
+        if not ctx.is_replaying:
+            logger.info(
+                "Requesting approval: tool='%s' approval_request_id=%s instance=%s timeout=%ds",
+                fn_name,
+                approval_request_id,
+                instance_id,
+                timeout_seconds,
+            )
+
+        # Always yield this activity unconditionally — DurableTask returns the cached
+        # result on replay without re-executing the function
+        yield ctx.call_activity(
+            self.publish_approval_request,
+            input={
+                "event": approval_event.model_dump(mode="json"),
+                "pubsub_name": approval_config.pubsub_name,
+                "topic": approval_config.topic,
+            },
+            retry_policy=self._retry_policy,
+        )
+
+        if not ctx.is_replaying:
+            logger.info(
+                "Approval request %s published to topic '%s' (tool='%s', instance=%s)",
+                approval_request_id,
+                approval_config.topic,
+                fn_name,
+                instance_id,
+            )
+
+        # suspend until the external approval event arrives or the timeout elapses;
+        # wait_for_external_event has no timeout parameter in this SDK version so we
+        # race the event against a create_timer using when_any instead.
+        from durabletask import task as dt
+
+        event_name = f"approval_response_{approval_request_id}"
+        event_task = ctx.wait_for_external_event(event_name)
+        timer_task = ctx.create_timer(timedelta(seconds=timeout_seconds))
+        winner = yield dt.when_any([event_task, timer_task])
+
+        if winner is timer_task:
+            if not ctx.is_replaying:
+                logger.warning(
+                    "Approval request %s timed out for tool '%s' (instance=%s) — auto-denying",
+                    approval_request_id,
+                    fn_name,
+                    instance_id,
+                )
+            return False
+
+        # event won the race — read the human decision
+        try:
+            response_data = event_task.get_result()
+            response = ApprovalResponseEvent(**response_data)
+        except Exception as exc:
+            if not ctx.is_replaying:
+                logger.warning(
+                    "Could not parse approval response for request %s: %s — auto-denying",
+                    approval_request_id,
+                    exc,
+                )
+            return False
+
+        if not ctx.is_replaying:
+            logger.info(
+                "Approval decision for request %s, tool '%s': %s (instance=%s)",
+                approval_request_id,
+                fn_name,
+                "approved" if response.approved else "not approved",
+                instance_id,
+            )
+
+        return response.approved
 
     def orchestration_workflow(self, ctx: wf.DaprWorkflowContext, message: dict):
         """Dedicated orchestration workflow using strategy pattern.
@@ -1954,6 +2153,41 @@ class DurableAgent(AgentBase):
 
         self.save_state(instance_id, entry=entry)
 
+    def publish_approval_request(
+        self, ctx: wf.WorkflowActivityContext, payload: Dict[str, Any]
+    ) -> None:
+        """
+        Publish an ApprovalRequiredEvent to the configured Dapr pub/sub topic.
+
+        This activity is called from _request_approval inside agent_workflow.
+        Wrapping the publish in an activity keeps the workflow deterministic — the
+        activity result is cached, so on replay the publish does not fire again.
+
+        Args:
+            payload: Keys 'event' (serialized ApprovalRequiredEvent dict),
+                'pubsub_name' (pub/sub component name), 'topic' (topic name).
+        """
+        event_data = payload["event"]
+        pubsub_name = payload["pubsub_name"]
+        topic = payload["topic"]
+
+        async def _publish() -> None:
+            from dapr_agents.workflow.utils.pubsub import publish_message
+
+            await publish_message(
+                pubsub_name=pubsub_name,
+                topic_name=topic,
+                message=event_data,
+            )
+
+        self._run_asyncio_task(_publish())
+        logger.info(
+            "Published approval request %s for tool '%s' to topic '%s'",
+            event_data.get("approval_request_id"),
+            event_data.get("tool_name"),
+            topic,
+        )
+
     def broadcast_to_team(
         self, ctx: wf.WorkflowActivityContext, payload: Dict[str, Any]
     ) -> None:
@@ -2327,6 +2561,53 @@ class DurableAgent(AgentBase):
         self.save_state(instance_id, entry=entry)
         logger.info(f"Saved plan to memory for instance {instance_id}")
 
+    # human-in-the-loop control API
+    def raise_approval_event(
+        self,
+        instance_id: str,
+        approval_request_id: str,
+        approved: bool,
+        reason: Optional[str] = None,
+    ) -> None:
+        """
+        Send a human approval decision back to a workflow that is waiting for it.
+
+        External approval services — a Slack bot, a web dashboard, a CLI script —
+        call this method after a human reviews the ApprovalRequiredEvent they
+        received. The workflow resumes immediately after the event is delivered.
+
+        Args:
+            instance_id: Workflow instance ID from the ApprovalRequiredEvent.
+            approval_request_id: Unique request ID from the ApprovalRequiredEvent.
+            approved: True to allow the tool to run, False to block it.
+            reason: Optional human-provided explanation for the decision.
+
+        Raises:
+            Exception: If the Dapr workflow client cannot deliver the event.
+        """
+        from dapr.ext.workflow import DaprWorkflowClient
+
+        event_name = f"approval_response_{approval_request_id}"
+        response = ApprovalResponseEvent(
+            approval_request_id=approval_request_id,
+            approved=approved,
+            reason=reason,
+        )
+
+        client = DaprWorkflowClient()
+        client.raise_workflow_event(
+            instance_id=instance_id,
+            event_name=event_name,
+            data=response.model_dump(mode="json"),
+        )
+
+        logger.info(
+            "Raised approval event '%s' for instance %s: %s",
+            event_name,
+            instance_id,
+            "approved" if approved else "not approved",
+        )
+
     # ------------------------------------------------------------------
     # Runtime control
     # ------------------------------------------------------------------
@@ -2466,6 +2747,7 @@ class DurableAgent(AgentBase):
         runtime.register_activity(self.call_llm)
         runtime.register_activity(self.run_tool)
         runtime.register_activity(self.save_tool_results)
+        runtime.register_activity(self.publish_approval_request)
         runtime.register_activity(self.broadcast_to_team)
         runtime.register_activity(self.summarize)
         runtime.register_activity(self.finalize_workflow)

--- a/dapr_agents/agents/durable.py
+++ b/dapr_agents/agents/durable.py
@@ -25,7 +25,6 @@ from dapr_agents.tool.utils.function_calling import sanitize_openai_tool_name
 import dapr.ext.workflow as wf
 from dapr.ext.workflow import DaprWorkflowClient
 from dapr.ext.workflow.workflow_state import WorkflowStatus
-from durabletask import task as dt
 
 from dapr_agents.agents.orchestration import (
     OrchestrationStrategy,
@@ -553,7 +552,14 @@ class DurableAgent(AgentBase):
                                     payload=hook_payload,
                                     tool_call_id=tc["id"],
                                 )
-                                decision = self._hooks.before_tool_call(hook_ctx)
+                                decision = None
+                                for hook in self._hooks.before_tool_call:
+                                    result = hook(hook_ctx)
+                                    if result is not None and not isinstance(
+                                        result, Proceed
+                                    ):
+                                        decision = result
+                                        break
                                 if decision is None or isinstance(decision, Proceed):
                                     pass  # no-op, tool runs normally
                                 elif isinstance(decision, RequireApproval):
@@ -956,7 +962,7 @@ class DurableAgent(AgentBase):
         else:
             # Race the approval event against a timer
             timer_task = ctx.create_timer(timedelta(seconds=timeout_seconds))
-            winner = yield dt.when_any([event_task, timer_task])
+            winner = yield wf.when_any([event_task, timer_task])
 
             if winner is timer_task:
                 if not ctx.is_replaying:
@@ -2219,6 +2225,66 @@ class DurableAgent(AgentBase):
 
         self.save_state(instance_id, entry=entry)
 
+    def _pending_approvals_key(self) -> str:
+        """Dapr State Store key for the agent-scoped pending-approvals dict."""
+        return f"{self.name}:pending_approvals".lower()
+
+    def _persist_pending_approvals(self) -> None:
+        """
+        Write the current _pending_approvals dict to Dapr State Store so it
+        survives process crashes.  No-op when no state store is configured.
+        """
+        if not self.state_store:
+            return
+        try:
+            self.state_store.save_state(
+                key=self._pending_approvals_key(),
+                value=json.dumps(self._pending_approvals),
+            )
+        except Exception:
+            logger.exception("Failed to persist pending approvals to state store")
+
+    def _restore_pending_approvals(self) -> None:
+        """
+        Load previously persisted pending approvals from Dapr State Store into
+        _pending_approvals on agent startup.  Entries whose workflow is no longer
+        RUNNING are dropped so stale requests from already-finished workflows are
+        not surfaced.  No-op when no state store is configured.
+        """
+        if not self.state_store:
+            return
+        try:
+            exists, data = self.state_store.try_get_state(
+                key=self._pending_approvals_key()
+            )
+            if not exists or not data:
+                return
+            wf_client = DaprWorkflowClient()
+            _ACTIVE = {WorkflowStatus.RUNNING, WorkflowStatus.SUSPENDED}
+            for approval_request_id, event_data in data.items():
+                instance_id = event_data.get("instance_id", "")
+                try:
+                    state = wf_client.get_workflow_state(
+                        instance_id, fetch_payloads=False
+                    )
+                    if state is not None and state.runtime_status in _ACTIVE:
+                        self._pending_approvals[approval_request_id] = event_data
+                except Exception:
+                    logger.debug(
+                        "Could not check workflow state for instance %s during approval restore; skipping.",
+                        instance_id,
+                    )
+            logger.info(
+                "Restored %d pending approval(s) from state store for agent '%s'.",
+                len(self._pending_approvals),
+                self.name,
+            )
+        except Exception:
+            logger.exception(
+                "Failed to restore pending approvals from state store for agent '%s'.",
+                self.name,
+            )
+
     def publish_approval_request(
         self, ctx: wf.WorkflowActivityContext, payload: Dict[str, Any]
     ) -> None:
@@ -2244,6 +2310,7 @@ class DurableAgent(AgentBase):
         approval_request_id = event_data.get("approval_request_id")
 
         self._pending_approvals[approval_request_id] = event_data
+        self._persist_pending_approvals()
 
         if pubsub_name:
 
@@ -2691,6 +2758,7 @@ class DurableAgent(AgentBase):
         )
 
         self._pending_approvals.pop(approval_request_id, None)
+        self._persist_pending_approvals()
 
         logger.info(
             f"Raised approval event '{event_name}' for instance {instance_id}: {'approved' if approved else 'not approved'}"
@@ -2702,8 +2770,9 @@ class DurableAgent(AgentBase):
 
         Used by GET /hitl/approvals when the agent is served over HTTP. The list
         is populated by publish_approval_request and cleared by raise_approval_event.
-        On process restart the list starts empty; pending workflows are still suspended
-        in Dapr's durable state and can be resumed via the Dapr sidecar raiseEvent API.
+        On startup, _restore_pending_approvals reloads this from Dapr State Store
+        (when a state store is configured) and drops entries whose workflow is no
+        longer running, so pending approvals survive process crashes.
         """
         return list(self._pending_approvals.values())
 
@@ -2731,6 +2800,9 @@ class DurableAgent(AgentBase):
 
         # Set up lifecycle-managed resources (e.g., configuration subscription)
         super().start()
+
+        # Reload any pending approvals that were persisted before a crash.
+        self._restore_pending_approvals()
 
         if runtime is not None:
             self._runtime = runtime

--- a/dapr_agents/agents/durable.py
+++ b/dapr_agents/agents/durable.py
@@ -329,6 +329,10 @@ class DurableAgent(AgentBase):
         self._registered = False
         self._started = False
         self._hooks: Optional[Hooks] = hooks
+        # In-memory store of active approval requests, keyed by approval_request_id.
+        # Populated by publish_approval_request activity; consumed by raise_approval_event.
+        # Used by GET /hitl/approvals when serving over HTTP without pub/sub.
+        self._pending_approvals: Dict[str, Dict[str, Any]] = {}
 
         try:
             retries = int(getenv("DAPR_API_MAX_RETRIES", ""))
@@ -2244,31 +2248,50 @@ class DurableAgent(AgentBase):
         self, ctx: wf.WorkflowActivityContext, payload: Dict[str, Any]
     ) -> None:
         """
-        Publish an ApprovalRequiredEvent to the configured Dapr pub/sub topic.
+        Deliver an ApprovalRequiredEvent and track it for HTTP polling.
 
         This activity is called from _request_approval inside agent_workflow.
-        Wrapping the publish in an activity keeps the workflow deterministic — the
-        activity result is cached, so on replay the publish does not fire again.
+        Wrapping the delivery in an activity keeps the workflow deterministic — the
+        activity result is cached, so on replay the delivery does not fire again.
+
+        Always stores the event in _pending_approvals so GET /hitl/approvals can
+        surface it regardless of serving mode. If pubsub_name is set, also publishes
+        to the configured Dapr pub/sub topic so external listeners (Slack bots,
+        dashboards) can receive it.
 
         Args:
             payload: Keys 'event' (serialized ApprovalRequiredEvent dict),
-                'pubsub_name' (pub/sub component name), 'topic' (topic name).
+                'pubsub_name' (optional pub/sub component name), 'topic' (topic name).
         """
         event_data = payload["event"]
-        pubsub_name = payload["pubsub_name"]
-        topic = payload["topic"]
+        pubsub_name = payload.get("pubsub_name")
+        topic = payload.get("topic")
+        approval_request_id = event_data.get("approval_request_id")
 
-        async def _publish() -> None:
-            await publish_message(
-                pubsub_name=pubsub_name,
-                topic_name=topic,
-                message=event_data,
+        self._pending_approvals[approval_request_id] = event_data
+
+        if pubsub_name:
+
+            async def _publish() -> None:
+                await publish_message(
+                    pubsub_name=pubsub_name,
+                    topic_name=topic,
+                    message=event_data,
+                )
+
+            self._run_asyncio_task(_publish())
+            logger.info(
+                "Published approval request %s for step '%s' to topic '%s'",
+                approval_request_id,
+                event_data.get("step_name"),
+                topic,
             )
-
-        self._run_asyncio_task(_publish())
-        logger.info(
-            f"Published approval request {event_data.get('approval_request_id')} for tool '{event_data.get('tool_name')}' to topic '{topic}'"
-        )
+        else:
+            logger.info(
+                "Stored approval request %s for step '%s' (no pub/sub configured; poll GET /hitl/approvals or use Dapr sidecar raiseEvent API)",
+                approval_request_id,
+                event_data.get("step_name"),
+            )
 
     def broadcast_to_team(
         self, ctx: wf.WorkflowActivityContext, payload: Dict[str, Any]
@@ -2697,12 +2720,25 @@ class DurableAgent(AgentBase):
             data=response.model_dump(mode="json"),
         )
 
+        self._pending_approvals.pop(approval_request_id, None)
+
         logger.info(
             "Raised approval event '%s' for instance %s: %s",
             event_name,
             instance_id,
             "approved" if approved else "not approved",
         )
+
+    def list_pending_approvals(self) -> List[Dict[str, Any]]:
+        """
+        Return all approval requests currently waiting for a human decision.
+
+        Used by GET /hitl/approvals when the agent is served over HTTP. The list
+        is populated by publish_approval_request and cleared by raise_approval_event.
+        On process restart the list starts empty; pending workflows are still suspended
+        in Dapr's durable state and can be resumed via the Dapr sidecar raiseEvent API.
+        """
+        return list(self._pending_approvals.values())
 
     # ------------------------------------------------------------------
     # Runtime control

--- a/dapr_agents/agents/durable.py
+++ b/dapr_agents/agents/durable.py
@@ -570,10 +570,7 @@ class DurableAgent(AgentBase):
                                     )
                                     if not ctx.is_replaying:
                                         logger.debug(
-                                            "RequireApproval for tool '%s': %s (instance=%s)",
-                                            fn_name_check,
-                                            "approved" if approved else "not approved",
-                                            ctx.instance_id,
+                                            f"RequireApproval for tool '{fn_name_check}': {'approved' if approved else 'not approved'} (instance={ctx.instance_id})"
                                         )
                                 else:
                                     hook_decisions[tc["id"]] = decision
@@ -607,10 +604,7 @@ class DurableAgent(AgentBase):
                                 ordered[idx] = denial_msg.model_dump()
                                 if not ctx.is_replaying:
                                     logger.info(
-                                        "Skipping tool '%s': %s (instance=%s)",
-                                        fn_name,
-                                        block_reason,
-                                        ctx.instance_id,
+                                        f"Skipping tool '{fn_name}': {block_reason} (instance={ctx.instance_id})"
                                     )
                                 continue
 
@@ -630,9 +624,7 @@ class DurableAgent(AgentBase):
                                 ordered[idx] = skip_msg.model_dump()
                                 if not ctx.is_replaying:
                                     logger.info(
-                                        "Skipping tool '%s' with hook-provided result (instance=%s)",
-                                        fn_name,
-                                        ctx.instance_id,
+                                        f"Skipping tool '{fn_name}' with hook-provided result (instance={ctx.instance_id})"
                                     )
                                 continue
 
@@ -935,11 +927,7 @@ class DurableAgent(AgentBase):
 
         if not ctx.is_replaying:
             logger.info(
-                "Requesting approval: tool='%s' approval_request_id=%s instance=%s timeout=%ds",
-                fn_name,
-                approval_request_id,
-                instance_id,
-                timeout_seconds,
+                f"Requesting approval: tool='{fn_name}' approval_request_id={approval_request_id} instance={instance_id} timeout={timeout_seconds}s"
             )
 
         # Always yield this activity unconditionally — DurableTask returns the cached
@@ -956,11 +944,7 @@ class DurableAgent(AgentBase):
 
         if not ctx.is_replaying:
             logger.info(
-                "Approval request %s published to topic '%s' (tool='%s', instance=%s)",
-                approval_request_id,
-                approval_config.topic,
-                fn_name,
-                instance_id,
+                f"Approval request {approval_request_id} published to topic '{approval_config.topic}' (tool='{fn_name}', instance={instance_id})"
             )
 
         event_name = f"approval_response_{approval_request_id}"
@@ -977,10 +961,7 @@ class DurableAgent(AgentBase):
             if winner is timer_task:
                 if not ctx.is_replaying:
                     logger.warning(
-                        "Approval request %s timed out for tool '%s' (instance=%s) — auto-denying",
-                        approval_request_id,
-                        fn_name,
-                        instance_id,
+                        f"Approval request {approval_request_id} timed out for tool '{fn_name}' (instance={instance_id}) — auto-denying"
                     )
                 return False
 
@@ -991,19 +972,13 @@ class DurableAgent(AgentBase):
         except Exception as exc:
             if not ctx.is_replaying:
                 logger.warning(
-                    "Could not parse approval response for request %s: %s — auto-denying",
-                    approval_request_id,
-                    exc,
+                    f"Could not parse approval response for request {approval_request_id}: {exc} — auto-denying"
                 )
             return False
 
         if not ctx.is_replaying:
             logger.info(
-                "Approval decision for request %s, tool '%s': %s (instance=%s)",
-                approval_request_id,
-                fn_name,
-                "approved" if response.approved else "not approved",
-                instance_id,
+                f"Approval decision for request {approval_request_id}, tool '{fn_name}': {'approved' if response.approved else 'not approved'} (instance={instance_id})"
             )
 
         return response.approved
@@ -2281,16 +2256,11 @@ class DurableAgent(AgentBase):
 
             self._run_asyncio_task(_publish())
             logger.info(
-                "Published approval request %s for step '%s' to topic '%s'",
-                approval_request_id,
-                event_data.get("step_name"),
-                topic,
+                f"Published approval request {approval_request_id} for step '{event_data.get('step_name')}' to topic '{topic}'"
             )
         else:
             logger.info(
-                "Stored approval request %s for step '%s' (no pub/sub configured; poll GET /hitl/approvals or use Dapr sidecar raiseEvent API)",
-                approval_request_id,
-                event_data.get("step_name"),
+                f"Stored approval request {approval_request_id} for step '{event_data.get('step_name')}' (no pub/sub configured; poll GET /hitl/approvals or use Dapr sidecar raiseEvent API)"
             )
 
     def broadcast_to_team(
@@ -2723,10 +2693,7 @@ class DurableAgent(AgentBase):
         self._pending_approvals.pop(approval_request_id, None)
 
         logger.info(
-            "Raised approval event '%s' for instance %s: %s",
-            event_name,
-            instance_id,
-            "approved" if approved else "not approved",
+            f"Raised approval event '{event_name}' for instance {instance_id}: {'approved' if approved else 'not approved'}"
         )
 
     def list_pending_approvals(self) -> List[Dict[str, Any]]:

--- a/dapr_agents/agents/durable.py
+++ b/dapr_agents/agents/durable.py
@@ -93,6 +93,16 @@ from dapr_agents.tool.workflow.agent_tool import (
 )
 from dapr_agents.tool.workflow.tool_context import WorkflowContextInjectedTool
 from dapr_agents.workflow.utils.names import sanitize_agent_name
+from dapr_agents.hooks import (
+    Hooks,
+    HookContext,
+    HookDecision,
+    Proceed,
+    Skip,
+    Modify,
+    RequireApproval,
+    Deny,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -224,6 +234,7 @@ class DurableAgent(AgentBase):
         retry_policy: WorkflowRetryPolicy = WorkflowRetryPolicy(),
         agent_observability: Optional[AgentObservabilityConfig] = None,
         configuration: Optional[RuntimeSubscriptionConfig] = None,
+        hooks: Optional[Hooks] = None,
     ) -> None:
         """
         Initialize behavior, infrastructure, and workflow runtime.
@@ -314,6 +325,7 @@ class DurableAgent(AgentBase):
         self._runtime_owned = runtime is None
         self._registered = False
         self._started = False
+        self._hooks: Optional[Hooks] = hooks
 
         try:
             retries = int(getenv("DAPR_API_MAX_RETRIES", ""))
@@ -510,30 +522,54 @@ class DurableAgent(AgentBase):
                                 turn,
                             )
 
-                        # approval pass:
-                        # for each tool that requires approval, pause the workflow
-                        # and collect the human decision before we build any task lists.
-                        # approvals are processed one at a time because each blocks
-                        # until a human responds (or the timeout elapses).
-                        approval_decisions: Dict[str, bool] = {}
-                        if self.execution.approval.enabled:
+                        # hook pass: run before_tool_call for every tool in this turn and collect decisions before dispatching anything.
+                        hook_decisions: Dict[str, HookDecision] = {}
+                        if self._hooks and self._hooks.before_tool_call:
                             for tc in tool_calls:
                                 fn_name_check = tc["function"]["name"]
-                                check_obj = self.tool_executor.get_tool(fn_name_check)
-                                if check_obj and getattr(
-                                    check_obj, "requires_approval", False
-                                ):
-                                    approved = yield from self._request_approval(
-                                        ctx, ctx.instance_id, tc
+                                tool_obj_check = self.tool_executor.get_tool(
+                                    fn_name_check
+                                )
+                                raw_args_check = tc["function"].get("arguments", "")
+                                try:
+                                    hook_payload = (
+                                        json.loads(raw_args_check)
+                                        if raw_args_check
+                                        else {}
                                     )
-                                    approval_decisions[tc["id"]] = approved
+                                except json.JSONDecodeError:
+                                    hook_payload = {}
+                                hook_ctx = HookContext(
+                                    step_name=fn_name_check,
+                                    step_kind="tool",
+                                    source=getattr(tool_obj_check, "source", "local"),
+                                    payload=hook_payload,
+                                    tool_call_id=tc["id"],
+                                )
+                                decision = self._hooks.before_tool_call(hook_ctx)
+                                if decision is None or isinstance(decision, Proceed):
+                                    pass  # no-op, tool runs normally
+                                elif isinstance(decision, RequireApproval):
+                                    # suspend here and wait for human; convert outcome to Deny or Proceed
+                                    approved = yield from self._request_approval(
+                                        ctx, ctx.instance_id, tc, decision
+                                    )
+                                    hook_decisions[tc["id"]] = (
+                                        Proceed()
+                                        if approved
+                                        else Deny(
+                                            reason="approval was not granted or timed out"
+                                        )
+                                    )
                                     if not ctx.is_replaying:
                                         logger.debug(
-                                            "Approval for tool '%s': %s (instance=%s)",
+                                            "RequireApproval for tool '%s': %s (instance=%s)",
                                             fn_name_check,
                                             "approved" if approved else "not approved",
                                             ctx.instance_id,
                                         )
+                                else:
+                                    hook_decisions[tc["id"]] = decision
 
                         ordered: List[Optional[Dict[str, Any]]] = [None] * len(
                             tool_calls
@@ -547,17 +583,16 @@ class DurableAgent(AgentBase):
                         for idx, tc in enumerate(tool_calls):
                             fn_name = tc["function"]["name"]
 
-                            # inject denial message and skip execution for any tool
-                            # whose approval was not granted or timed out
-                            if (
-                                tc["id"] in approval_decisions
-                                and not approval_decisions[tc["id"]]
-                            ):
+                            # check hook decisions for this tool call
+                            hook_decision = hook_decisions.get(tc["id"])
+
+                            if isinstance(hook_decision, Deny):
+                                # hook blocked the tool outright — synthesize a denial message
+                                block_reason = (
+                                    hook_decision.reason or "blocked by policy"
+                                )
                                 denial_msg = ToolMessage(
-                                    content=(
-                                        f"Tool '{fn_name}' was not executed: "
-                                        "approval was not granted."
-                                    ),
+                                    content=f"Tool '{fn_name}' was not executed: {block_reason}.",
                                     role="tool",
                                     name=fn_name,
                                     tool_call_id=tc["id"],
@@ -565,11 +600,47 @@ class DurableAgent(AgentBase):
                                 ordered[idx] = denial_msg.model_dump()
                                 if not ctx.is_replaying:
                                     logger.info(
-                                        "Skipping tool '%s': approval was not granted (instance=%s)",
+                                        "Skipping tool '%s': %s (instance=%s)",
+                                        fn_name,
+                                        block_reason,
+                                        ctx.instance_id,
+                                    )
+                                continue
+
+                            if isinstance(hook_decision, Skip):
+                                # hook provided a result — use it directly without running the tool
+                                skip_content = (
+                                    str(hook_decision.result)
+                                    if hook_decision.result is not None
+                                    else f"Tool '{fn_name}' was skipped."
+                                )
+                                skip_msg = ToolMessage(
+                                    content=skip_content,
+                                    role="tool",
+                                    name=fn_name,
+                                    tool_call_id=tc["id"],
+                                )
+                                ordered[idx] = skip_msg.model_dump()
+                                if not ctx.is_replaying:
+                                    logger.info(
+                                        "Skipping tool '%s' with hook-provided result (instance=%s)",
                                         fn_name,
                                         ctx.instance_id,
                                     )
                                 continue
+
+                            if (
+                                isinstance(hook_decision, Modify)
+                                and hook_decision.payload is not None
+                            ):
+                                # hook mutated the arguments — rebuild tc with new payload
+                                tc = {
+                                    **tc,
+                                    "function": {
+                                        **tc.get("function", {}),
+                                        "arguments": json.dumps(hook_decision.payload),
+                                    },
+                                }
 
                             tool_obj = self.tool_executor.get_tool(fn_name)
 
@@ -687,17 +758,21 @@ class DurableAgent(AgentBase):
                                 for meta in activity_meta
                             }
                         )
-                        # include denied tool calls so save_tool_results can log them
-                        # in tool_history for observability
+                        # include hook-blocked/skipped tool calls so save_tool_results
+                        # can record them in tool_history for observability
                         for tc in tool_calls:
-                            if (
-                                tc["id"] in approval_decisions
-                                and not approval_decisions[tc["id"]]
-                            ):
+                            decision_for_tracking = hook_decisions.get(tc["id"])
+                            if isinstance(decision_for_tracking, (Deny, Skip)):
+                                hook_label = (
+                                    "denied"
+                                    if isinstance(decision_for_tracking, Deny)
+                                    else "skipped"
+                                )
                                 tool_calls_by_id[tc["id"]] = {
                                     "tool_call": tc,
                                     "is_agent_call": False,
                                     "dispatch_time": ctx.current_utc_datetime.isoformat(),
+                                    "hook_decision": hook_label,
                                 }
                         yield ctx.call_activity(
                             self.save_tool_results,
@@ -797,21 +872,21 @@ class DurableAgent(AgentBase):
         ctx: wf.DaprWorkflowContext,
         instance_id: str,
         tool_call: Dict[str, Any],
+        decision: RequireApproval,
     ):
         """
         Pause the workflow and wait for a human to approve or deny a tool call.
 
-        This generator is called with ``yield from`` from agent_workflow. It publishes
-        an ApprovalRequiredEvent the first time it runs for a given tool_call_id, then
-        suspends the workflow via wait_for_external_event. On replay, the publish is
-        skipped if the request ID already exists in workflow state
-        The timeout per tool comes from the tool's approval_timeout_seconds field;
-        if not set, AgentApprovalConfig.default_timeout_seconds is used.
+        Called with ``yield from`` from agent_workflow when a before_tool_call hook
+        returns RequireApproval. Publishes an ApprovalRequiredEvent the first time it
+        runs for a given tool_call_id, then suspends via wait_for_external_event. On
+        replay, the activity result is cached so the publish does not fire again.
 
         Args:
             ctx: Dapr workflow context.
             instance_id: Running workflow instance ID.
             tool_call: Tool call dict with 'id' and 'function' keys.
+            decision: The RequireApproval decision returned by the hook.
 
         Returns:
             True if the human approved, False if not approved or the timeout elapsed.
@@ -820,14 +895,10 @@ class DurableAgent(AgentBase):
         fn_name = tool_call.get("function", {}).get("name", "unknown")
         tool_call_id = tool_call.get("id", "")
 
-        # use the per-tool timeout when set, otherwise fall back to the agent default
-        tool_obj = self.tool_executor.get_tool(fn_name)
-        tool_timeout = (
-            getattr(tool_obj, "approval_timeout_seconds", None) if tool_obj else None
-        )
+        # use the decision's timeout first, then fall back to the agent-level default
         timeout_seconds = (
-            tool_timeout
-            if tool_timeout is not None
+            decision.timeout_seconds
+            if decision.timeout_seconds is not None
             else approval_config.default_timeout_seconds
         )
 
@@ -842,13 +913,17 @@ class DurableAgent(AgentBase):
         except json.JSONDecodeError:
             tool_args = {}
 
+        tool_obj = self.tool_executor.get_tool(fn_name)
         approval_event = ApprovalRequiredEvent(
             approval_request_id=approval_request_id,
             instance_id=instance_id,
-            tool_name=fn_name,
+            step_name=fn_name,
+            step_kind="tool",
+            source=getattr(tool_obj, "source", "local"),
             tool_call_id=tool_call_id,
             tool_arguments=tool_args,
             timeout_seconds=timeout_seconds,
+            instructions=decision.instructions,
         )
 
         if not ctx.is_replaying:
@@ -2134,12 +2209,20 @@ class DurableAgent(AgentBase):
                 agent_wf_instance_id = tc_info.get("child_instance_id") or (
                     tool_call_id if is_agent_call else None
                 )
+                # map hook decision labels to the right execution status
+                hook_decision_label = tc_info.get("hook_decision")
+                if hook_decision_label == "denied":
+                    exec_status = ToolExecutionStatus.DENIED
+                elif hook_decision_label == "skipped":
+                    exec_status = ToolExecutionStatus.SKIPPED
+                else:
+                    exec_status = ToolExecutionStatus.COMPLETED
                 entry.tool_history.append(
                     ToolExecutionRecord(
                         tool_call_id=tool_call_id,
                         tool_name=tool_result.name or fn.get("name", ""),
                         tool_args=args,
-                        status=ToolExecutionStatus.COMPLETED,
+                        status=exec_status,
                         is_agent_call=is_agent_call,
                         execution_result=tool_result.content,
                         executing_agent=self.name,

--- a/dapr_agents/agents/durable.py
+++ b/dapr_agents/agents/durable.py
@@ -23,6 +23,9 @@ from typing import Any, Dict, Iterable, List, Optional
 from os import getenv
 from dapr_agents.tool.utils.function_calling import sanitize_openai_tool_name
 import dapr.ext.workflow as wf
+from dapr.ext.workflow import DaprWorkflowClient
+from dapr.ext.workflow.workflow_state import WorkflowStatus
+from durabletask import task as dt
 
 from dapr_agents.agents.orchestration import (
     OrchestrationStrategy,
@@ -85,7 +88,7 @@ from dapr_agents.types.tools import ToolExecutionRecord, ToolExecutionStatus
 from dapr_agents.tool.utils.serialization import serialize_tool_result
 from dapr_agents.workflow.decorators import message_router, workflow_entry
 from dapr_agents.workflow.utils.grpc import apply_grpc_options
-from dapr_agents.workflow.utils.pubsub import broadcast_message
+from dapr_agents.workflow.utils.pubsub import broadcast_message, publish_message
 from dapr_agents.tool.workflow.agent_tool import (
     AgentWorkflowTool,
     agent_to_tool,
@@ -956,25 +959,26 @@ class DurableAgent(AgentBase):
                 instance_id,
             )
 
-        # suspend until the external approval event arrives or the timeout elapses;
-        # wait_for_external_event has no timeout parameter in this SDK version so we
-        # race the event against a create_timer using when_any instead.
-        from durabletask import task as dt
-
         event_name = f"approval_response_{approval_request_id}"
         event_task = ctx.wait_for_external_event(event_name)
-        timer_task = ctx.create_timer(timedelta(seconds=timeout_seconds))
-        winner = yield dt.when_any([event_task, timer_task])
 
-        if winner is timer_task:
-            if not ctx.is_replaying:
-                logger.warning(
-                    "Approval request %s timed out for tool '%s' (instance=%s) — auto-denying",
-                    approval_request_id,
-                    fn_name,
-                    instance_id,
-                )
-            return False
+        if timeout_seconds is None:
+            # No timeout: suspend indefinitely until a human sends the approval event. The workflow stays paused in Dapr's durable state.
+            yield event_task
+        else:
+            # Race the approval event against a timer
+            timer_task = ctx.create_timer(timedelta(seconds=timeout_seconds))
+            winner = yield dt.when_any([event_task, timer_task])
+
+            if winner is timer_task:
+                if not ctx.is_replaying:
+                    logger.warning(
+                        "Approval request %s timed out for tool '%s' (instance=%s) — auto-denying",
+                        approval_request_id,
+                        fn_name,
+                        instance_id,
+                    )
+                return False
 
         # event won the race — read the human decision
         try:
@@ -2255,8 +2259,6 @@ class DurableAgent(AgentBase):
         topic = payload["topic"]
 
         async def _publish() -> None:
-            from dapr_agents.workflow.utils.pubsub import publish_message
-
             await publish_message(
                 pubsub_name=pubsub_name,
                 topic_name=topic,
@@ -2265,10 +2267,7 @@ class DurableAgent(AgentBase):
 
         self._run_asyncio_task(_publish())
         logger.info(
-            "Published approval request %s for tool '%s' to topic '%s'",
-            event_data.get("approval_request_id"),
-            event_data.get("tool_name"),
-            topic,
+            f"Published approval request {event_data.get('approval_request_id')} for tool '{event_data.get('tool_name')}' to topic '{topic}'"
         )
 
     def broadcast_to_team(
@@ -2668,8 +2667,6 @@ class DurableAgent(AgentBase):
         Raises:
             Exception: If the Dapr workflow client cannot deliver the event.
         """
-        from dapr.ext.workflow import DaprWorkflowClient
-
         event_name = f"approval_response_{approval_request_id}"
         response = ApprovalResponseEvent(
             approval_request_id=approval_request_id,
@@ -2677,8 +2674,24 @@ class DurableAgent(AgentBase):
             reason=reason,
         )
 
-        client = DaprWorkflowClient()
-        client.raise_workflow_event(
+        wf_client = DaprWorkflowClient()
+
+        # Guard against late responses: Dapr silently drops events on finished workflows, leaving the human with no feedback. Fail explicitly instead.
+        _TERMINAL = {
+            WorkflowStatus.COMPLETED,
+            WorkflowStatus.FAILED,
+            WorkflowStatus.TERMINATED,
+        }
+        state = wf_client.get_workflow_state(instance_id, fetch_payloads=False)
+        if state is None or state.runtime_status in _TERMINAL:
+            status_label = state.runtime_status.name if state else "NOT_FOUND"
+            raise RuntimeError(
+                f"Workflow '{instance_id}' is no longer waiting for approval "
+                f"(status: {status_label}). The approval request has already expired or "
+                f"the workflow has finished — your response was not delivered."
+            )
+
+        wf_client.raise_workflow_event(
             instance_id=instance_id,
             event_name=event_name,
             data=response.model_dump(mode="json"),

--- a/dapr_agents/agents/durable.py
+++ b/dapr_agents/agents/durable.py
@@ -23,8 +23,6 @@ from typing import Any, Dict, Iterable, List, Optional
 from os import getenv
 from dapr_agents.tool.utils.function_calling import sanitize_openai_tool_name
 import dapr.ext.workflow as wf
-from dapr.ext.workflow import DaprWorkflowClient
-from dapr.ext.workflow.workflow_state import WorkflowStatus
 
 from dapr_agents.agents.orchestration import (
     OrchestrationStrategy,
@@ -328,9 +326,9 @@ class DurableAgent(AgentBase):
         self._registered = False
         self._started = False
         self._hooks: Optional[Hooks] = hooks
-        # In-memory store of active approval requests, keyed by approval_request_id.
-        # Populated by publish_approval_request activity; consumed by raise_approval_event.
-        # Used by GET /hitl/approvals when serving over HTTP without pub/sub.
+        # Tracks active approval requests in memory, keyed by approval_request_id.
+        # Persisted to Dapr State Store so requests survive pod restarts.
+        # Only populated when HITL (before_tool_call) hooks are configured.
         self._pending_approvals: Dict[str, Dict[str, Any]] = {}
 
         try:
@@ -2232,8 +2230,11 @@ class DurableAgent(AgentBase):
     def _persist_pending_approvals(self) -> None:
         """
         Write the current _pending_approvals dict to Dapr State Store so it
-        survives process crashes.  No-op when no state store is configured.
+        survives process crashes.  No-op when no state store is configured or
+        no HITL hooks are present.
         """
+        if not (self._hooks and self._hooks.before_tool_call):
+            return
         if not self.state_store:
             return
         try:
@@ -2249,8 +2250,11 @@ class DurableAgent(AgentBase):
         Load previously persisted pending approvals from Dapr State Store into
         _pending_approvals on agent startup.  Entries whose workflow is no longer
         RUNNING are dropped so stale requests from already-finished workflows are
-        not surfaced.  No-op when no state store is configured.
+        not surfaced.  No-op when no state store is configured or no HITL hooks
+        are present.
         """
+        if not (self._hooks and self._hooks.before_tool_call):
+            return
         if not self.state_store:
             return
         try:
@@ -2259,8 +2263,8 @@ class DurableAgent(AgentBase):
             )
             if not exists or not data:
                 return
-            wf_client = DaprWorkflowClient()
-            _ACTIVE = {WorkflowStatus.RUNNING, WorkflowStatus.SUSPENDED}
+            wf_client = wf.DaprWorkflowClient()
+            _ACTIVE = {wf.WorkflowStatus.RUNNING, wf.WorkflowStatus.SUSPENDED}
             for approval_request_id, event_data in data.items():
                 instance_id = event_data.get("instance_id", "")
                 try:
@@ -2730,13 +2734,13 @@ class DurableAgent(AgentBase):
             reason=reason,
         )
 
-        wf_client = DaprWorkflowClient()
+        wf_client = wf.DaprWorkflowClient()
 
         # Guard against late responses: Dapr silently drops events on finished workflows, leaving the human with no feedback. Fail explicitly instead.
         _TERMINAL = {
-            WorkflowStatus.COMPLETED,
-            WorkflowStatus.FAILED,
-            WorkflowStatus.TERMINATED,
+            wf.WorkflowStatus.COMPLETED,
+            wf.WorkflowStatus.FAILED,
+            wf.WorkflowStatus.TERMINATED,
         }
         state = wf_client.get_workflow_state(instance_id, fetch_payloads=False)
         if state is None or state.runtime_status in _TERMINAL:

--- a/dapr_agents/agents/durable.py
+++ b/dapr_agents/agents/durable.py
@@ -2271,18 +2271,14 @@ class DurableAgent(AgentBase):
                         self._pending_approvals[approval_request_id] = event_data
                 except Exception:
                     logger.debug(
-                        "Could not check workflow state for instance %s during approval restore; skipping.",
-                        instance_id,
+                        f"Could not check workflow state for instance {instance_id} during approval restore; skipping."
                     )
             logger.info(
-                "Restored %d pending approval(s) from state store for agent '%s'.",
-                len(self._pending_approvals),
-                self.name,
+                f"Restored {len(self._pending_approvals)} pending approval(s) from state store for agent '{self.name}'."
             )
         except Exception:
             logger.exception(
-                "Failed to restore pending approvals from state store for agent '%s'.",
-                self.name,
+                f"Failed to restore pending approvals from state store for agent '{self.name}'."
             )
 
     def publish_approval_request(

--- a/dapr_agents/agents/durable.py
+++ b/dapr_agents/agents/durable.py
@@ -330,6 +330,12 @@ class DurableAgent(AgentBase):
         # Persisted to Dapr State Store so requests survive pod restarts.
         # Only populated when HITL (before_tool_call) hooks are configured.
         self._pending_approvals: Dict[str, Dict[str, Any]] = {}
+        # Shared workflow client for HITL operations (_restore_pending_approvals and
+        # submit_approval_response). Created once here instead of per-call, and only
+        # when HITL hooks are actually configured — the only execution path that needs it.
+        self._wf_client: Optional[wf.DaprWorkflowClient] = (
+            wf.DaprWorkflowClient() if (hooks and hooks.before_tool_call) else None
+        )
 
         try:
             retries = int(getenv("DAPR_API_MAX_RETRIES", ""))
@@ -2263,7 +2269,7 @@ class DurableAgent(AgentBase):
             )
             if not exists or not data:
                 return
-            wf_client = wf.DaprWorkflowClient()
+            wf_client = self._wf_client
             _ACTIVE = {wf.WorkflowStatus.RUNNING, wf.WorkflowStatus.SUSPENDED}
             for approval_request_id, event_data in data.items():
                 instance_id = event_data.get("instance_id", "")
@@ -2734,7 +2740,7 @@ class DurableAgent(AgentBase):
             reason=reason,
         )
 
-        wf_client = wf.DaprWorkflowClient()
+        wf_client = self._wf_client
 
         # Guard against late responses: Dapr silently drops events on finished workflows, leaving the human with no feedback. Fail explicitly instead.
         _TERMINAL = {

--- a/dapr_agents/agents/schemas.py
+++ b/dapr_agents/agents/schemas.py
@@ -26,6 +26,60 @@ def utcnow() -> datetime:
     return datetime.now(timezone.utc)
 
 
+class ApprovalRequiredEvent(BaseModel):
+    """
+    Event published to Dapr Pub/Sub when a tool requires human approval before it executes.
+
+    The workflow publishes this event, then suspends. An external approval service
+    (Slack bot, web UI, CLI) receives it, notifies a human, and sends back an
+    ApprovalResponseEvent to resume the workflow.
+    """
+
+    approval_request_id: str = Field(
+        description="Deterministic UUID for this request, stable across workflow replays"
+    )
+    instance_id: str = Field(
+        description="Workflow instance that is waiting for approval"
+    )
+    tool_name: str = Field(description="Name of the tool that needs approval")
+    tool_call_id: str = Field(
+        description="LLM-assigned ID of the tool call (from the assistant message)"
+    )
+    tool_arguments: Dict[str, Any] = Field(
+        description="Arguments the LLM wants to pass to the tool"
+    )
+    context: Dict[str, Any] = Field(
+        default_factory=dict,
+        description="Additional context for the approval decision",
+    )
+    requested_at: datetime = Field(
+        default_factory=utcnow, description="When approval was requested"
+    )
+    timeout_seconds: int = Field(
+        description="Seconds before the workflow auto-denies if no human responds"
+    )
+
+
+class ApprovalResponseEvent(BaseModel):
+    """
+    Event sent back to a waiting workflow with the human's approval decision.
+
+    External approval services construct and send this event using
+    DurableAgent.raise_approval_event() after a human reviews the request.
+    """
+
+    approval_request_id: str = Field(
+        description="ID matching the original ApprovalRequiredEvent"
+    )
+    approved: bool = Field(description="True if approved, False if not approved")
+    reason: Optional[str] = Field(
+        default=None, description="Human-provided reason for the decision"
+    )
+    decided_at: datetime = Field(
+        default_factory=utcnow, description="When the decision was made"
+    )
+
+
 class BroadcastMessage(BaseMessage):
     """
     Represents a broadcast message from an agent.
@@ -108,4 +162,11 @@ class AgentWorkflowEntry(BaseModel):
     trace_context: Optional[Dict[str, Any]] = Field(
         default=None,
         description="OpenTelemetry trace context for workflow resumption.",
+    )
+    approval_requests: Dict[str, Dict[str, Any]] = Field(
+        default_factory=dict,
+        description=(
+            "Tracks approval requests that have already been published, keyed by "
+            "approval_request_id. Prevents duplicate publishes when the workflow replays."
+        ),
     )

--- a/dapr_agents/agents/schemas.py
+++ b/dapr_agents/agents/schemas.py
@@ -15,7 +15,7 @@ import uuid
 from datetime import datetime, timezone
 from typing import Any, Dict, List, Optional
 
-from pydantic import BaseModel, Field
+from pydantic import BaseModel, Field, computed_field, model_validator
 
 from dapr_agents.types import MessageContent, ToolExecutionRecord
 from dapr_agents.types.message import BaseMessage
@@ -28,11 +28,15 @@ def utcnow() -> datetime:
 
 class ApprovalRequiredEvent(BaseModel):
     """
-    Event published to Dapr Pub/Sub when a tool requires human approval before it executes.
+    Event published to Dapr Pub/Sub when a step requires human approval.
 
-    The workflow publishes this event, then suspends. An external approval service
+    The workflow publishes this event and suspends. An external approval service
     (Slack bot, web UI, CLI) receives it, notifies a human, and sends back an
     ApprovalResponseEvent to resume the workflow.
+
+    The primary field is `step_name`. The `tool_name` property is kept for
+    backward compatibility — existing listeners that read `event.tool_name`
+    continue to work without changes.
     """
 
     approval_request_id: str = Field(
@@ -41,12 +45,23 @@ class ApprovalRequiredEvent(BaseModel):
     instance_id: str = Field(
         description="Workflow instance that is waiting for approval"
     )
-    tool_name: str = Field(description="Name of the tool that needs approval")
+    step_name: str = Field(
+        description="Name of the step that needs approval (tool name or 'llm')"
+    )
+    step_kind: str = Field(default="tool", description="'tool' or 'llm'")
+    source: str = Field(
+        default="local",
+        description="Where the tool came from: 'local', 'mcp', 'openapi', etc.",
+    )
     tool_call_id: str = Field(
         description="LLM-assigned ID of the tool call (from the assistant message)"
     )
     tool_arguments: Dict[str, Any] = Field(
         description="Arguments the LLM wants to pass to the tool"
+    )
+    instructions: Optional[str] = Field(
+        default=None,
+        description="Human-readable instructions shown to the approver",
     )
     context: Dict[str, Any] = Field(
         default_factory=dict,
@@ -58,6 +73,20 @@ class ApprovalRequiredEvent(BaseModel):
     timeout_seconds: int = Field(
         description="Seconds before the workflow auto-denies if no human responds"
     )
+
+    @model_validator(mode="before")
+    @classmethod
+    def _compat_tool_name(cls, data: Any) -> Any:
+        if isinstance(data, dict) and "tool_name" in data and "step_name" not in data:
+            data = dict(data)
+            data["step_name"] = data.pop("tool_name")
+        return data
+
+    @computed_field
+    @property
+    def tool_name(self) -> str:
+        """backward compat alias for step_name — existing listeners can keep reading this."""
+        return self.step_name
 
 
 class ApprovalResponseEvent(BaseModel):

--- a/dapr_agents/hooks.py
+++ b/dapr_agents/hooks.py
@@ -12,7 +12,7 @@
 #
 from __future__ import annotations
 from dataclasses import dataclass, field
-from typing import Any, Callable, Dict, Optional
+from typing import Any, Callable, Dict, List, Optional
 
 
 @dataclass
@@ -99,11 +99,15 @@ class Deny(HookDecision):
     reason: Optional[str] = None
 
 
+BeforeHook = Callable[[HookContext], Optional[HookDecision]]
+AfterHook = Callable[[HookContext, Any], Optional[HookDecision]]
+
+
 @dataclass
 class Hooks:
     """
     container for all hook callbacks you want to register on a DurableAgent.
-    only set the hooks you need — unset slots are no-ops.
+    each slot holds a list of callables so multiple hooks can be chained.
 
     example::
 
@@ -124,22 +128,18 @@ class Hooks:
 
         agent = DurableAgent(
             ...,
-            hooks=Hooks(before_tool_call=before_tool),
+            hooks=Hooks(before_tool_call=[before_tool]),
         )
     """
 
-    before_tool_call: Optional[Callable[[HookContext], Optional[HookDecision]]] = None
+    before_tool_call: List[BeforeHook] = field(default_factory=list)
     """called before every tool dispatch. return a HookDecision to control execution."""
 
-    after_tool_call: Optional[Callable[[HookContext, Any], Optional[HookDecision]]] = (
-        None
-    )
+    after_tool_call: List[AfterHook] = field(default_factory=list)
     """called after a tool completes. return Modify(result=...) to replace the output."""
 
-    before_llm_call: Optional[Callable[[HookContext], Optional[HookDecision]]] = None
+    before_llm_call: List[BeforeHook] = field(default_factory=list)
     """called before every llm call."""
 
-    after_llm_call: Optional[Callable[[HookContext, Any], Optional[HookDecision]]] = (
-        None
-    )
+    after_llm_call: List[AfterHook] = field(default_factory=list)
     """called after every llm response."""

--- a/dapr_agents/hooks.py
+++ b/dapr_agents/hooks.py
@@ -1,0 +1,145 @@
+#
+# Copyright 2026 The Dapr Authors
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#     http://www.apache.org/licenses/LICENSE-2.0
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+from __future__ import annotations
+from dataclasses import dataclass, field
+from typing import Any, Callable, Dict, Optional
+
+
+@dataclass
+class HookContext:
+    """all the information available to a hook when a step is about to run."""
+
+    step_name: str
+    """name of the tool about to run, or 'llm' for llm calls."""
+
+    step_kind: str
+    """'tool' for tool calls, 'llm' for llm calls."""
+
+    source: str
+    """where this tool came from: 'local', 'mcp', 'openapi', etc."""
+
+    payload: Dict[str, Any]
+    """arguments the llm wants to pass to the tool (or llm call params)."""
+
+    tool_call_id: str = ""
+    """llm-assigned id for this specific call. empty for llm-level hooks."""
+
+
+class HookDecision:
+    """base class — you never instantiate this directly, use the subclasses."""
+
+    pass
+
+
+@dataclass
+class Proceed(HookDecision):
+    """run the step normally. returning None from a hook coerces to this."""
+
+    pass
+
+
+@dataclass
+class Skip(HookDecision):
+    """
+    skip execution entirely and use `result` as the step output instead.
+    useful for returning cached results or safe defaults on policy checks.
+    """
+
+    result: Any = None
+
+
+@dataclass
+class Modify(HookDecision):
+    """
+    run the step but replace the incoming arguments with `payload` first.
+    for tool calls, `payload` is the new arguments dict passed to the tool.
+    """
+
+    payload: Optional[Dict[str, Any]] = None
+
+
+@dataclass
+class RequireApproval(HookDecision):
+    """
+    pause the workflow and wait for a human decision before running the step.
+    if no human responds within `timeout_seconds`, the step is auto-denied.
+
+    this is the hook decision that drives the HITL flow — it triggers the same
+    publish → wait_for_external_event → timer-race plumbing as before, but now
+    any tool (local, mcp, openapi) can trigger it, not just ones with a decorator.
+    """
+
+    timeout_seconds: Optional[int] = None
+    """per-call timeout override. falls back to AgentApprovalConfig.default_timeout_seconds."""
+
+    instructions: Optional[str] = None
+    """message shown to the approver explaining what needs a decision."""
+
+    reason: Optional[str] = None
+    """optional context about why this step needs a human decision."""
+
+
+@dataclass
+class Deny(HookDecision):
+    """
+    block the step without involving a human. the workflow synthesizes a
+    ToolMessage so the llm knows the call was blocked and can respond.
+    """
+
+    reason: Optional[str] = None
+
+
+@dataclass
+class Hooks:
+    """
+    container for all hook callbacks you want to register on a DurableAgent.
+    only set the hooks you need — unset slots are no-ops.
+
+    example::
+
+        from dapr_agents.hooks import Hooks, HookContext, HookDecision
+        from dapr_agents.hooks import Proceed, RequireApproval, Deny
+
+        def before_tool(ctx: HookContext) -> HookDecision:
+            # gate any mcp delete_ call through human approval
+            if ctx.source == "mcp" and ctx.step_name.startswith("delete_"):
+                return RequireApproval(
+                    timeout_seconds=3600,
+                    instructions=f"confirm deletion: {ctx.payload}",
+                )
+            # outright block schema-altering calls
+            if ctx.step_name == "drop_table":
+                return Deny(reason="schema changes go through dba review")
+            return Proceed()
+
+        agent = DurableAgent(
+            ...,
+            hooks=Hooks(before_tool_call=before_tool),
+        )
+    """
+
+    before_tool_call: Optional[Callable[[HookContext], Optional[HookDecision]]] = None
+    """called before every tool dispatch. return a HookDecision to control execution."""
+
+    after_tool_call: Optional[Callable[[HookContext, Any], Optional[HookDecision]]] = (
+        None
+    )
+    """called after a tool completes. return Modify(result=...) to replace the output."""
+
+    before_llm_call: Optional[Callable[[HookContext], Optional[HookDecision]]] = None
+    """called before every llm call."""
+
+    after_llm_call: Optional[Callable[[HookContext, Any], Optional[HookDecision]]] = (
+        None
+    )
+    """called after every llm response."""

--- a/dapr_agents/tool/base.py
+++ b/dapr_agents/tool/base.py
@@ -67,6 +67,20 @@ class AgentTool(BaseModel):
     func: Optional[Callable] = Field(
         None, description="Optional function implementing the tool's behavior."
     )
+    requires_approval: bool = Field(
+        default=False,
+        description=(
+            "When True, the workflow pauses and waits for human approval before "
+            "this tool runs. Only takes effect when AgentApprovalConfig.enabled is True."
+        ),
+    )
+    approval_timeout_seconds: Optional[int] = Field(
+        default=None,
+        description=(
+            "Seconds to wait for human approval before auto-denying. "
+            "Falls back to AgentApprovalConfig.default_timeout_seconds when None."
+        ),
+    )
 
     _is_async: bool = PrivateAttr(default=False)
 
@@ -510,7 +524,11 @@ class AgentTool(BaseModel):
 
 
 def tool(
-    func: Optional[Callable] = None, *, args_model: Optional[Type[BaseModel]] = None
+    func: Optional[Callable] = None,
+    *,
+    args_model: Optional[Type[BaseModel]] = None,
+    requires_approval: bool = False,
+    approval_timeout_seconds: Optional[int] = None,
 ) -> AgentTool:
     """
     A decorator to wrap a function with an `AgentTool` for validation and metadata.
@@ -518,6 +536,10 @@ def tool(
     Args:
         func (Optional[Callable]): The function to wrap.
         args_model (Optional[Type[BaseModel]]): Optional Pydantic model for argument validation.
+        requires_approval (bool): When True, the workflow pauses for human approval before
+            running this tool. Only active when AgentApprovalConfig.enabled=True on the agent.
+        approval_timeout_seconds (Optional[int]): Per-tool approval timeout override. Falls back
+            to AgentApprovalConfig.default_timeout_seconds when not set.
 
     Returns:
         AgentTool: The wrapped function as an `AgentTool`.
@@ -525,6 +547,11 @@ def tool(
 
     def decorator(f: Callable) -> AgentTool:
         ToolHelper.check_docstring(f)
-        return AgentTool(func=f, args_model=args_model)
+        return AgentTool(
+            func=f,
+            args_model=args_model,
+            requires_approval=requires_approval,
+            approval_timeout_seconds=approval_timeout_seconds,
+        )
 
     return decorator(func) if func else decorator

--- a/dapr_agents/tool/base.py
+++ b/dapr_agents/tool/base.py
@@ -67,19 +67,9 @@ class AgentTool(BaseModel):
     func: Optional[Callable] = Field(
         None, description="Optional function implementing the tool's behavior."
     )
-    requires_approval: bool = Field(
-        default=False,
-        description=(
-            "When True, the workflow pauses and waits for human approval before "
-            "this tool runs. Only takes effect when AgentApprovalConfig.enabled is True."
-        ),
-    )
-    approval_timeout_seconds: Optional[int] = Field(
-        default=None,
-        description=(
-            "Seconds to wait for human approval before auto-denying. "
-            "Falls back to AgentApprovalConfig.default_timeout_seconds when None."
-        ),
+    source: str = Field(
+        default="local",
+        description="Where this tool came from: 'local' for @tool functions, 'mcp' for mcp tools, etc.",
     )
 
     _is_async: bool = PrivateAttr(default=False)
@@ -196,6 +186,7 @@ class AgentTool(BaseModel):
             description=tool_docs,
             func=executor,
             args_model=tool_args_model,
+            source="mcp",
         )
 
     @classmethod
@@ -527,8 +518,6 @@ def tool(
     func: Optional[Callable] = None,
     *,
     args_model: Optional[Type[BaseModel]] = None,
-    requires_approval: bool = False,
-    approval_timeout_seconds: Optional[int] = None,
 ) -> AgentTool:
     """
     A decorator to wrap a function with an `AgentTool` for validation and metadata.
@@ -536,10 +525,6 @@ def tool(
     Args:
         func (Optional[Callable]): The function to wrap.
         args_model (Optional[Type[BaseModel]]): Optional Pydantic model for argument validation.
-        requires_approval (bool): When True, the workflow pauses for human approval before
-            running this tool. Only active when AgentApprovalConfig.enabled=True on the agent.
-        approval_timeout_seconds (Optional[int]): Per-tool approval timeout override. Falls back
-            to AgentApprovalConfig.default_timeout_seconds when not set.
 
     Returns:
         AgentTool: The wrapped function as an `AgentTool`.
@@ -550,8 +535,6 @@ def tool(
         return AgentTool(
             func=f,
             args_model=args_model,
-            requires_approval=requires_approval,
-            approval_timeout_seconds=approval_timeout_seconds,
         )
 
     return decorator(func) if func else decorator

--- a/dapr_agents/types/tools.py
+++ b/dapr_agents/types/tools.py
@@ -154,6 +154,8 @@ class ToolExecutionStatus(str, Enum):
     COMPLETED = "completed"  # Finished successfully
     FAILED = "failed"  # Finished with an error
     TIMEOUT = "timeout"  # Exceeded execution deadline
+    DENIED = "denied"  # Blocked by a hook Deny decision (no human involved)
+    SKIPPED = "skipped"  # Bypassed by a hook Skip decision (result provided by hook)
 
 
 class ToolExecutionRecord(BaseModel):

--- a/dapr_agents/workflow/runners/agent.py
+++ b/dapr_agents/workflow/runners/agent.py
@@ -20,6 +20,7 @@ from threading import Lock, Thread
 from typing import Any, Callable, Dict, Literal, Optional, TypeVar, Union, List
 
 from fastapi import Body, FastAPI, HTTPException
+from pydantic import BaseModel
 
 from dapr_agents.agents.durable import DurableAgent
 from dapr_agents.types.workflow import PubSubRouteSpec
@@ -34,6 +35,11 @@ from dapr_agents.workflow.utils.subscription import TTLDedupeBackend
 logger = logging.getLogger(__name__)
 
 R = TypeVar("R")
+
+
+class _HitlRespondBody(BaseModel):
+    approved: bool
+    reason: Optional[str] = None
 
 
 class AgentRunner(WorkflowRunner):
@@ -562,6 +568,8 @@ class AgentRunner(WorkflowRunner):
                 fetch_status_payloads=fetch_status_payloads,
             )
 
+        self._mount_hitl_routes(fastapi_app=fastapi_app, agent=agent)
+
         auto_run = app is None
         if auto_run:
             try:
@@ -720,6 +728,74 @@ class AgentRunner(WorkflowRunner):
             tags=["workflow"],
         )
         logger.info("Mounted default workflow status endpoint at %s", status_path)
+
+    def _mount_hitl_routes(
+        self,
+        *,
+        fastapi_app: FastAPI,
+        agent: DurableAgent,
+    ) -> None:
+        """
+        Register the two HITL HTTP endpoints on the FastAPI app.
+
+        GET  /hitl/approvals                            — list pending approval requests
+        POST /hitl/approvals/{approval_request_id}/respond — submit a human decision
+
+        These endpoints work regardless of whether pub/sub is configured. When
+        pub/sub is not configured, polling GET /hitl/approvals is the only way a
+        human reviewer discovers pending requests. When pub/sub IS configured, these
+        endpoints are still registered as a secondary interface.
+
+        For workflow-only agents (no HTTP server), responders can call the Dapr
+        sidecar raiseEvent API directly instead of using these endpoints.
+        """
+
+        async def _list_approvals() -> List[Dict[str, Any]]:
+            return agent.list_pending_approvals()
+
+        async def _respond_to_approval(
+            approval_request_id: str, body: _HitlRespondBody
+        ) -> Dict[str, Any]:
+            pending = agent._pending_approvals.get(approval_request_id)
+            if pending is None:
+                raise HTTPException(
+                    status_code=404,
+                    detail=(
+                        f"Approval request '{approval_request_id}' not found. "
+                        "It may have already been responded to, or this process was restarted. "
+                        "You can still submit a response directly via the Dapr sidecar: "
+                        "POST <sidecar-host>/v1.0-beta1/workflows/dapr/{instance_id}"
+                        f"/raiseEvent/approval_response_{approval_request_id}"
+                    ),
+                )
+            instance_id = pending.get("instance_id", "")
+            agent.raise_approval_event(
+                instance_id=instance_id,
+                approval_request_id=approval_request_id,
+                approved=body.approved,
+                reason=body.reason,
+            )
+            return {
+                "status": "ok",
+                "approval_request_id": approval_request_id,
+                "approved": body.approved,
+            }
+
+        fastapi_app.add_api_route(
+            "/hitl/approvals",
+            _list_approvals,
+            methods=["GET"],
+            summary="List pending human approval requests",
+            tags=["hitl"],
+        )
+        fastapi_app.add_api_route(
+            "/hitl/approvals/{approval_request_id}/respond",
+            _respond_to_approval,
+            methods=["POST"],
+            summary="Submit a human approval decision",
+            tags=["hitl"],
+        )
+        logger.info("Mounted HITL endpoints at /hitl/approvals")
 
     def shutdown(self, agent: Optional[DurableAgent] = None) -> None:
         """

--- a/examples/02-durable-agent-tool-call/approval_sender.py
+++ b/examples/02-durable-agent-tool-call/approval_sender.py
@@ -1,0 +1,78 @@
+#
+# Copyright 2026 The Dapr Authors
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#     http://www.apache.org/licenses/LICENSE-2.0
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+"""
+Approval sender script for the HITL demo.
+
+After running durable_agent_hitl.py, a workflow is waiting for an approval
+event. This script sends that event to resume the workflow.
+
+Usage
+-----
+Run with the instance_id printed by durable_agent_hitl.py and the
+approval_request_id that appears in the agent logs when the workflow pauses:
+
+    python approval_sender.py <instance_id> <approval_request_id> [approve|deny]
+
+Example:
+
+    python approval_sender.py abc123 550e8400-e29b-41d4-a716-446655440000 approve
+"""
+
+import sys
+import logging
+
+from dotenv import load_dotenv
+
+load_dotenv()
+logging.basicConfig(level=logging.INFO)
+logger = logging.getLogger(__name__)
+
+
+def main():
+    if len(sys.argv) < 3:
+        print(__doc__)
+        sys.exit(1)
+
+    instance_id = sys.argv[1]
+    approval_request_id = sys.argv[2]
+    decision = sys.argv[3].lower() if len(sys.argv) > 3 else "approve"
+    approved = decision == "approve"
+
+    from dapr.ext.workflow import DaprWorkflowClient
+    from dapr_agents.agents.schemas import ApprovalResponseEvent
+
+    event_name = f"approval_response_{approval_request_id}"
+    response = ApprovalResponseEvent(
+        approval_request_id=approval_request_id,
+        approved=approved,
+        reason=f"sent via approval_sender.py (decision={decision})",
+    )
+
+    print(
+        f"Sending approval decision: instance={instance_id}, "
+        f"request={approval_request_id}, approved={approved}"
+    )
+
+    client = DaprWorkflowClient()
+    client.raise_workflow_event(
+        instance_id=instance_id,
+        event_name=event_name,
+        data=response.model_dump(mode="json"),
+    )
+
+    print("Approval event sent. The workflow will resume shortly.")
+
+
+if __name__ == "__main__":
+    main()

--- a/examples/02-durable-agent-tool-call/durable_agent_hitl.py
+++ b/examples/02-durable-agent-tool-call/durable_agent_hitl.py
@@ -1,0 +1,243 @@
+#
+# Copyright 2026 The Dapr Authors
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#     http://www.apache.org/licenses/LICENSE-2.0
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+"""
+Human-in-the-loop (HITL) example for DurableAgent.
+This script shows how to:
+  1. Define a tool that requires human approval before it runs.
+  2. Run a DurableAgent with approval enabled.
+  3. Receive the ApprovalRequiredEvent via Dapr Pub/Sub.
+  4. Send the human decision back to resume the waiting workflow.
+
+Start the Dapr sidecar alongside this script
+The script will:
+  1. Start the agent workflow.
+  2. Receive the ApprovalRequiredEvent from the pub/sub topic.
+  3. Print the tool name and arguments.
+  4. Auto-approve after 5 s (set APPROVED = False in main() to test denial).
+  5. Resume or skip the tool based on the decision.
+  6. Print the final agent response.
+"""
+
+import asyncio
+import json
+import logging
+
+from dotenv import load_dotenv
+import uvicorn
+from fastapi import FastAPI, Request, Response
+
+from dapr_agents import DurableAgent, tool, AgentApprovalConfig
+from dapr_agents.agents.configs import AgentExecutionConfig
+from dapr_agents.agents.schemas import ApprovalRequiredEvent
+from dapr_agents.workflow.runners import AgentRunner
+from dapr_agents.llm.openai import OpenAIChatClient
+
+load_dotenv()
+
+logger = logging.getLogger(__name__)
+
+# both Uvicorn and main() run in the same event loop (via asyncio.create_task), so put_nowait() from the FastAPI handler immediately wakes up get() in main()
+_approval_queue: asyncio.Queue = asyncio.Queue()
+_dapr_app = FastAPI()
+
+
+@_dapr_app.get("/dapr/subscribe")
+def _subscribe():
+    return [
+        {
+            "pubsubname": "messagepubsub",
+            "topic": "agent-approval-requests",
+            "route": "/agent-approval-requests",
+        }
+    ]
+
+
+@_dapr_app.post("/agent-approval-requests")
+async def _receive_approval_request(request: Request):
+    """Called by Dapr when the workflow publishes an approval request.
+    Parses the CloudEvent and pushes the typed payload to the queue for main() to handle.
+    """
+    body = await request.body()
+    envelope = json.loads(body)
+    data = envelope.get("data") or envelope
+    event = ApprovalRequiredEvent(**data)
+    _approval_queue.put_nowait(event)
+    logger.info(
+        "Approval request received via pub/sub: tool='%s' request_id=%s instance=%s",
+        event.tool_name,
+        event.approval_request_id,
+        event.instance_id,
+    )
+    return Response(status_code=200)
+
+
+# mock tools
+@tool
+def get_weather(location: str) -> str:
+    """Get weather information for a location."""
+    import random
+
+    temperature = random.randint(60, 85)
+    return f"{location}: {temperature}F, partly cloudy."
+
+
+@tool(requires_approval=True, approval_timeout_seconds=120)
+def delete_old_data(dataset: str) -> str:
+    """Permanently delete a dataset by name."""
+    return f"Dataset '{dataset}' has been deleted."
+
+
+# main
+async def main():
+    logging.basicConfig(level=logging.INFO)
+
+    # run Uvicorn as a task in this event loop so the pub/sub handler and queue.get() share the same loop.
+    _uvicorn_config = uvicorn.Config(
+        _dapr_app, host="0.0.0.0", port=8001, log_level="warning"
+    )
+    _uvicorn_server = uvicorn.Server(_uvicorn_config)
+    _uvicorn_task = asyncio.create_task(_uvicorn_server.serve())
+    await asyncio.sleep(
+        0.5
+    )  # wait for Uvicorn to open the socket before Dapr delivers messages
+
+    approval_config = AgentApprovalConfig(
+        enabled=True,
+        pubsub_name="messagepubsub",
+        topic="agent-approval-requests",
+        default_timeout_seconds=120,
+    )
+
+    agent = DurableAgent(
+        name="hitl-demo",
+        role="Operations Assistant",
+        goal="Help the user manage data and fetch information.",
+        instructions=[
+            "Use delete_old_data when asked to clean up or remove data.",
+            "Use get_weather for weather queries.",
+        ],
+        llm=OpenAIChatClient(model="openai/gpt-4o-mini"),
+        tools=[get_weather, delete_old_data],
+        execution=AgentExecutionConfig(approval=approval_config),
+    )
+
+    runner = AgentRunner()
+
+    prompt = "Please delete the old 'sales-2023' dataset and then tell me the weather in Chicago."
+
+    print("\n--- starting workflow ---\n")
+
+    instance_id = await runner.run(
+        agent,
+        payload={"task": prompt},
+        wait=False,
+    )
+    print(f"workflow started: instance_id = {instance_id}\n")
+
+    # block until the workflow publishes an ApprovalRequiredEvent and Dapr delivers it here
+    print("waiting for approval request from pub/sub (workflow is paused) ...\n")
+    try:
+        approval_event: ApprovalRequiredEvent = await asyncio.wait_for(
+            _approval_queue.get(), timeout=60.0
+        )
+    except asyncio.TimeoutError:
+        print(
+            "\n[ERROR] No approval request received within 60 s.\n"
+            "Check that the Dapr sidecar is running (--app-port 8001) and that\n"
+            "Redis pub/sub is reachable.\n"
+        )
+        return
+
+    AUTO_APPROVE_DELAY = 5  # seconds to pause before sending the decision
+    APPROVED = True  # set to False to test denial path
+
+    print("\n" + "=" * 60)
+    print("  APPROVAL REQUIRED")
+    print("=" * 60)
+    print(f"  tool      : {approval_event.tool_name}")
+    print(f"  arguments : {approval_event.tool_arguments}")
+    print(f"  instance  : {approval_event.instance_id}")
+    print(f"  request   : {approval_event.approval_request_id}")
+    print("=" * 60)
+    decision_word = "approved" if APPROVED else "denied"
+    print(
+        f"\n  Auto-{'approving' if APPROVED else 'denying'} in {AUTO_APPROVE_DELAY} s "
+        f"(edit APPROVED in durable_agent_hitl.py to change).\n"
+    )
+
+    await asyncio.sleep(AUTO_APPROVE_DELAY)
+
+    print(f"  decision: {decision_word}\n")
+    agent.raise_approval_event(
+        instance_id=approval_event.instance_id,
+        approval_request_id=approval_event.approval_request_id,
+        approved=APPROVED,
+        reason=f"demo auto-decision: {decision_word}",
+    )
+
+    while True:
+        try:
+            next_event: ApprovalRequiredEvent = await asyncio.wait_for(
+                _approval_queue.get(), timeout=10.0
+            )
+        except asyncio.TimeoutError:
+            break
+
+        print("\n" + "=" * 60)
+        print("  ANOTHER APPROVAL REQUIRED")
+        print("=" * 60)
+        print(f"  tool      : {next_event.tool_name}")
+        print(f"  arguments : {next_event.tool_arguments}")
+        print("=" * 60)
+        print(
+            f"\n  Auto-{'approving' if APPROVED else 'denying'} in {AUTO_APPROVE_DELAY} s ...\n"
+        )
+        await asyncio.sleep(AUTO_APPROVE_DELAY)
+        print(f"  decision: {decision_word}\n")
+        agent.raise_approval_event(
+            instance_id=next_event.instance_id,
+            approval_request_id=next_event.approval_request_id,
+            approved=APPROVED,
+            reason=f"demo auto-decision: {decision_word}",
+        )
+
+    print("\n--- waiting for workflow to finish ---\n")
+    result = await asyncio.to_thread(
+        runner.wait_for_workflow_completion,
+        instance_id,
+        timeout_in_seconds=150,
+    )
+    if result:
+        print(f"\nfinal output:\n{getattr(result, 'serialized_output', result)}\n")
+    else:
+        print(
+            "\nworkflow did not complete within the wait window.\n"
+            "If the approval event was sent, the workflow is still running.\n"
+            f"Re-send manually with:\n"
+            f"  python approval_sender.py {instance_id} "
+            f"{approval_event.approval_request_id} approve\n"
+        )
+
+    _uvicorn_server.should_exit = True
+    try:
+        await _uvicorn_task
+    except asyncio.CancelledError:
+        pass
+
+
+if __name__ == "__main__":
+    try:
+        asyncio.run(main())
+    except KeyboardInterrupt:
+        pass

--- a/examples/02-durable-agent-tool-call/durable_agent_hitl.py
+++ b/examples/02-durable-agent-tool-call/durable_agent_hitl.py
@@ -12,27 +12,29 @@
 #
 
 """
-HITL via HTTP polling: the agent holds pending approvals in memory (and in the
-Dapr State Store when one is configured). The same process polls
-agent.list_pending_approvals() and calls agent.raise_approval_event() to resume
-the workflow — no pub/sub or separate client needed.
+Example 1 — HITL via HTTP.
 
-How it works
-------------
-1. The before_tool hook returns RequireApproval for the delete_old_data tool.
-2. The workflow suspends and the approval request is stored in the agent.
-3. This script polls list_pending_approvals() until the request appears.
-4. After a short delay it calls raise_approval_event() to approve or deny.
+Agent side : the workflow pauses and holds the approval request in memory,
+             exposed via GET /hitl/approvals (mounted automatically by AgentRunner).
+Client side: a human polls GET /hitl/approvals and sends the decision back
+             with POST /hitl/approvals/{approval_request_id}/respond.
 
-Other HITL delivery patterns are shown in companion scripts:
-  - hitl_pubsub.py     — agent publishes the request to a Dapr pub/sub topic
-  - hitl_wf_event.py   — resume a paused workflow from the command line
+No pub/sub component or Dapr sidecar required for the approval round-trip —
+just the agent's HTTP server.
+
+This script runs both sides in the same process for simplicity.
+In production the client call would come from a separate service or dashboard.
+
+Other patterns:
+  - hitl_pubsub.py    — approval round-trip over Dapr pub/sub
+  - hitl_wf_event.py  — approval round-trip via direct workflow event
 """
 
 import asyncio
 import logging
 import time
 
+import httpx
 from dotenv import load_dotenv
 
 from dapr_agents import DurableAgent, tool
@@ -44,14 +46,9 @@ load_dotenv()
 
 logger = logging.getLogger(__name__)
 
-
-@tool
-def get_weather(location: str) -> str:
-    """Get weather information for a location."""
-    import random
-
-    temperature = random.randint(60, 85)
-    return f"{location}: {temperature}F, partly cloudy."
+# Port the AgentRunner HTTP server will listen on.
+AGENT_PORT = 8080
+APPROVED = True  # set to False to test the denial path
 
 
 @tool
@@ -60,12 +57,11 @@ def delete_old_data(dataset: str) -> str:
     return f"Dataset '{dataset}' has been deleted."
 
 
-# the hook decides at runtime which tools need approval
 def before_tool(ctx: HookContext) -> HookDecision:
     if ctx.step_name == "DeleteOldData":
         return RequireApproval(
             timeout_seconds=120,
-            instructions=f"confirm deletion of dataset: {ctx.payload.get('dataset')}",
+            instructions=f"Confirm deletion of dataset: {ctx.payload.get('dataset')}",
         )
     return Proceed()
 
@@ -74,98 +70,76 @@ async def main():
     logging.basicConfig(level=logging.INFO)
 
     agent = DurableAgent(
-        name="hitl-demo",
+        name="hitl-http-demo",
         role="Operations Assistant",
-        goal="Help the user manage data and fetch information.",
-        instructions=[
-            "Use delete_old_data when asked to clean up or remove data.",
-            "Use get_weather for weather queries.",
-        ],
+        goal="Help the user manage data.",
+        instructions=["Use delete_old_data when asked to clean up or remove data."],
         llm=OpenAIChatClient(model="gpt-4o-mini"),
-        tools=[get_weather, delete_old_data],
+        tools=[delete_old_data],
         hooks=Hooks(before_tool_call=[before_tool]),
     )
 
     runner = AgentRunner()
 
-    prompt = "Please delete the old 'sales-2023' dataset and then tell me the weather in Chicago."
+    # serve() starts the FastAPI HTTP server which mounts GET/POST /hitl/approvals.
+    # We run it as a background task so this script can keep driving the client side.
+    server_task = asyncio.create_task(
+        runner.serve(agent, port=AGENT_PORT, host="127.0.0.1")
+    )
 
-    print("\n--- starting workflow ---\n")
+    # Give the server a moment to come up.
+    await asyncio.sleep(2)
 
     instance_id = await runner.run(
         agent,
-        payload={"task": prompt},
+        payload={"task": "Please delete the old 'sales-2023' dataset."},
         wait=False,
     )
-    print(f"workflow started: instance_id = {instance_id}\n")
+    print(f"\nWorkflow started: instance_id = {instance_id}\n")
 
-    AUTO_APPROVE_DELAY = 5  # seconds to pause before sending the decision
-    APPROVED = True  # set to False to test denial path
-
-    # When the workflow pauses at a HITL checkpoint, the agent stores the pending approval
-    # in-process. Polling list_pending_approvals() here avoids a separate pub/sub subscriber.
-    first = True
-    while True:
-        # Allow more time on the first check (workflow is warming up); shorter for subsequent ones.
-        poll_timeout = 60 if first else 10
-        approval_data = None
-        deadline = time.monotonic() + poll_timeout
+    # --- client side: poll GET /hitl/approvals until the request appears ---
+    base_url = f"http://127.0.0.1:{AGENT_PORT}"
+    approval_data = None
+    deadline = time.monotonic() + 60
+    async with httpx.AsyncClient() as client:
         while time.monotonic() < deadline:
-            pending = agent.list_pending_approvals()
+            resp = await client.get(f"{base_url}/hitl/approvals")
+            pending = resp.json()
             if pending:
                 approval_data = pending[0]
                 break
             await asyncio.sleep(1)
 
         if approval_data is None:
-            break  # No more pending approvals within the window; workflow has likely finished.
+            print("No approval request appeared within the wait window.")
+            runner.shutdown(agent)
+            server_task.cancel()
+            return
 
-        first = False
         approval_request_id = approval_data["approval_request_id"]
-        decision_word = "approved" if APPROVED else "denied"
-
-        print("\n" + "=" * 60)
-        print("  APPROVAL REQUIRED")
-        print("=" * 60)
         print(f"  tool      : {approval_data['step_name']}")
         print(f"  arguments : {approval_data['tool_arguments']}")
-        print(f"  instance  : {approval_data['instance_id']}")
         print(f"  request   : {approval_request_id}")
-        if approval_data.get("instructions"):
-            print(f"  note      : {approval_data['instructions']}")
-        print("=" * 60)
-        print(
-            f"\n  Auto-{'approving' if APPROVED else 'denying'} in {AUTO_APPROVE_DELAY} s "
-            f"(edit APPROVED in durable_agent_hitl.py to change).\n"
+        print(f"\n  Sending HTTP decision: {'approve' if APPROVED else 'deny'}\n")
+
+        # --- client side: POST the decision back via HTTP ---
+        await client.post(
+            f"{base_url}/hitl/approvals/{approval_request_id}/respond",
+            json={"approved": APPROVED, "reason": "approved via HTTP example"},
         )
 
-        await asyncio.sleep(AUTO_APPROVE_DELAY)
-
-        print(f"  decision: {decision_word}\n")
-        agent.raise_approval_event(
-            instance_id=approval_data["instance_id"],
-            approval_request_id=approval_request_id,
-            approved=APPROVED,
-            reason=f"demo auto-decision: {decision_word}",
-        )
-
-    print("\n--- waiting for workflow to finish ---\n")
     result = await asyncio.to_thread(
         runner.wait_for_workflow_completion,
         instance_id,
         timeout_in_seconds=150,
     )
     if result:
-        print(f"\nfinal output:\n{getattr(result, 'serialized_output', result)}\n")
+        print(f"\nFinal output:\n{getattr(result, 'serialized_output', result)}\n")
     else:
-        print(
-            "\nworkflow did not complete within the wait window.\n"
-            "If the approval event was sent, the workflow is still running.\n"
-            f"Re-send manually with:\n"
-            f"  python hitl_wf_event.py {instance_id} <approval_request_id> approve\n"
-        )
+        print("\nWorkflow did not complete within the wait window.")
 
     runner.shutdown(agent)
+    server_task.cancel()
 
 
 if __name__ == "__main__":

--- a/examples/02-durable-agent-tool-call/durable_agent_hitl.py
+++ b/examples/02-durable-agent-tool-call/durable_agent_hitl.py
@@ -17,14 +17,14 @@ Human-in-the-loop (HITL) example for DurableAgent.
 This script shows how to:
   1. Register a before_tool_call hook that returns RequireApproval for specific tools.
   2. Run a DurableAgent with that hook — no decorator changes needed on any tool.
-  3. Receive the ApprovalRequiredEvent via Dapr Pub/Sub.
+  3. Poll the agent's in-process pending-approval list to detect when the workflow pauses.
   4. Send the human decision back to resume the waiting workflow.
 
 The hook approach works for all tool sources — anything loaded at runtime.
 
 The script will:
   1. Start the agent workflow.
-  2. Receive the ApprovalRequiredEvent from the pub/sub topic.
+  2. Poll agent.list_pending_approvals() until an approval request appears.
   3. Print the tool name and arguments.
   4. Auto-approve after 5 s (set APPROVED = False in main() to test denial).
   5. Resume or skip the tool based on the decision.
@@ -32,16 +32,12 @@ The script will:
 """
 
 import asyncio
-import json
 import logging
+import time
 
 from dotenv import load_dotenv
-import uvicorn
-from fastapi import FastAPI, Request, Response
 
-from dapr_agents import DurableAgent, tool, AgentApprovalConfig
-from dapr_agents.agents.configs import AgentExecutionConfig
-from dapr_agents.agents.schemas import ApprovalRequiredEvent
+from dapr_agents import DurableAgent, tool
 from dapr_agents.hooks import Hooks, HookContext, HookDecision, RequireApproval, Proceed
 from dapr_agents.workflow.runners import AgentRunner
 from dapr_agents.llm.openai import OpenAIChatClient
@@ -49,39 +45,6 @@ from dapr_agents.llm.openai import OpenAIChatClient
 load_dotenv()
 
 logger = logging.getLogger(__name__)
-
-# both uvicorn and main() run in the same event loop (via asyncio.create_task),
-# so put_nowait() from the fastapi handler immediately wakes up get() in main()
-_approval_queue: asyncio.Queue = asyncio.Queue()
-_dapr_app = FastAPI()
-
-
-@_dapr_app.get("/dapr/subscribe")
-def _subscribe():
-    return [
-        {
-            "pubsubname": "messagepubsub",
-            "topic": "agent-approval-requests",
-            "route": "/agent-approval-requests",
-        }
-    ]
-
-
-@_dapr_app.post("/agent-approval-requests")
-async def _receive_approval_request(request: Request):
-    """Called by Dapr when the workflow publishes an approval request."""
-    body = await request.body()
-    envelope = json.loads(body)
-    data = envelope.get("data") or envelope
-    event = ApprovalRequiredEvent(**data)
-    _approval_queue.put_nowait(event)
-    logger.info(
-        "Approval request received via pub/sub: tool='%s' request_id=%s instance=%s",
-        event.step_name,
-        event.approval_request_id,
-        event.instance_id,
-    )
-    return Response(status_code=200)
 
 
 @tool
@@ -112,19 +75,6 @@ def before_tool(ctx: HookContext) -> HookDecision:
 async def main():
     logging.basicConfig(level=logging.INFO)
 
-    _uvicorn_config = uvicorn.Config(
-        _dapr_app, host="0.0.0.0", port=8001, log_level="warning"
-    )
-    _uvicorn_server = uvicorn.Server(_uvicorn_config)
-    _uvicorn_task = asyncio.create_task(_uvicorn_server.serve())
-    await asyncio.sleep(0.5)
-
-    approval_config = AgentApprovalConfig(
-        pubsub_name="messagepubsub",
-        topic="agent-approval-requests",
-        default_timeout_seconds=120,
-    )
-
     agent = DurableAgent(
         name="hitl-demo",
         role="Operations Assistant",
@@ -133,12 +83,8 @@ async def main():
             "Use delete_old_data when asked to clean up or remove data.",
             "Use get_weather for weather queries.",
         ],
-        llm=OpenAIChatClient(
-            model="openai/gpt-5-nano",
-            base_url="https://openrouter.ai/api/v1",
-        ),
+        llm=OpenAIChatClient(model="gpt-4o-mini"),
         tools=[get_weather, delete_old_data],
-        execution=AgentExecutionConfig(approval=approval_config),
         hooks=Hooks(before_tool_call=before_tool),
     )
 
@@ -155,70 +101,52 @@ async def main():
     )
     print(f"workflow started: instance_id = {instance_id}\n")
 
-    print("waiting for approval request from pub/sub (workflow is paused) ...\n")
-    try:
-        approval_event: ApprovalRequiredEvent = await asyncio.wait_for(
-            _approval_queue.get(), timeout=60.0
-        )
-    except asyncio.TimeoutError:
-        print(
-            "\n[ERROR] No approval request received within 60 s.\n"
-            "Check that the Dapr sidecar is running (--app-port 8001) and that\n"
-            "Redis pub/sub is reachable.\n"
-        )
-        return
-
     AUTO_APPROVE_DELAY = 5  # seconds to pause before sending the decision
     APPROVED = True  # set to False to test denial path
 
-    print("\n" + "=" * 60)
-    print("  APPROVAL REQUIRED")
-    print("=" * 60)
-    print(f"  tool      : {approval_event.step_name}")
-    print(f"  arguments : {approval_event.tool_arguments}")
-    print(f"  instance  : {approval_event.instance_id}")
-    print(f"  request   : {approval_event.approval_request_id}")
-    if approval_event.instructions:
-        print(f"  note      : {approval_event.instructions}")
-    print("=" * 60)
-    decision_word = "approved" if APPROVED else "denied"
-    print(
-        f"\n  Auto-{'approving' if APPROVED else 'denying'} in {AUTO_APPROVE_DELAY} s "
-        f"(edit APPROVED in durable_agent_hitl.py to change).\n"
-    )
-
-    await asyncio.sleep(AUTO_APPROVE_DELAY)
-
-    print(f"  decision: {decision_word}\n")
-    agent.raise_approval_event(
-        instance_id=approval_event.instance_id,
-        approval_request_id=approval_event.approval_request_id,
-        approved=APPROVED,
-        reason=f"demo auto-decision: {decision_word}",
-    )
-
+    # When the workflow pauses at a HITL checkpoint, the agent stores the pending approval
+    # in-process. Polling list_pending_approvals() here avoids a separate pub/sub subscriber.
+    first = True
     while True:
-        try:
-            next_event: ApprovalRequiredEvent = await asyncio.wait_for(
-                _approval_queue.get(), timeout=10.0
-            )
-        except asyncio.TimeoutError:
-            break
+        # Allow more time on the first check (workflow is warming up); shorter for subsequent ones.
+        poll_timeout = 60 if first else 10
+        approval_data = None
+        deadline = time.monotonic() + poll_timeout
+        while time.monotonic() < deadline:
+            pending = agent.list_pending_approvals()
+            if pending:
+                approval_data = pending[0]
+                break
+            await asyncio.sleep(1)
+
+        if approval_data is None:
+            break  # No more pending approvals within the window; workflow has likely finished.
+
+        first = False
+        approval_request_id = approval_data["approval_request_id"]
+        decision_word = "approved" if APPROVED else "denied"
 
         print("\n" + "=" * 60)
-        print("  ANOTHER APPROVAL REQUIRED")
+        print("  APPROVAL REQUIRED")
         print("=" * 60)
-        print(f"  tool      : {next_event.step_name}")
-        print(f"  arguments : {next_event.tool_arguments}")
+        print(f"  tool      : {approval_data['step_name']}")
+        print(f"  arguments : {approval_data['tool_arguments']}")
+        print(f"  instance  : {approval_data['instance_id']}")
+        print(f"  request   : {approval_request_id}")
+        if approval_data.get("instructions"):
+            print(f"  note      : {approval_data['instructions']}")
         print("=" * 60)
         print(
-            f"\n  Auto-{'approving' if APPROVED else 'denying'} in {AUTO_APPROVE_DELAY} s ...\n"
+            f"\n  Auto-{'approving' if APPROVED else 'denying'} in {AUTO_APPROVE_DELAY} s "
+            f"(edit APPROVED in durable_agent_hitl.py to change).\n"
         )
+
         await asyncio.sleep(AUTO_APPROVE_DELAY)
+
         print(f"  decision: {decision_word}\n")
         agent.raise_approval_event(
-            instance_id=next_event.instance_id,
-            approval_request_id=next_event.approval_request_id,
+            instance_id=approval_data["instance_id"],
+            approval_request_id=approval_request_id,
             approved=APPROVED,
             reason=f"demo auto-decision: {decision_word}",
         )
@@ -236,15 +164,10 @@ async def main():
             "\nworkflow did not complete within the wait window.\n"
             "If the approval event was sent, the workflow is still running.\n"
             f"Re-send manually with:\n"
-            f"  python approval_sender.py {instance_id} "
-            f"{approval_event.approval_request_id} approve\n"
+            f"  python approval_sender.py {instance_id} <approval_request_id> approve\n"
         )
 
-    _uvicorn_server.should_exit = True
-    try:
-        await _uvicorn_task
-    except asyncio.CancelledError:
-        pass
+    runner.shutdown(agent)
 
 
 if __name__ == "__main__":

--- a/examples/02-durable-agent-tool-call/durable_agent_hitl.py
+++ b/examples/02-durable-agent-tool-call/durable_agent_hitl.py
@@ -88,6 +88,7 @@ async def _receive_approval_request(request: Request):
 def get_weather(location: str) -> str:
     """Get weather information for a location."""
     import random
+
     temperature = random.randint(60, 85)
     return f"{location}: {temperature}F, partly cloudy."
 
@@ -116,7 +117,7 @@ async def main():
     )
     _uvicorn_server = uvicorn.Server(_uvicorn_config)
     _uvicorn_task = asyncio.create_task(_uvicorn_server.serve())
-    await asyncio.sleep(0.5) 
+    await asyncio.sleep(0.5)
 
     approval_config = AgentApprovalConfig(
         pubsub_name="messagepubsub",

--- a/examples/02-durable-agent-tool-call/durable_agent_hitl.py
+++ b/examples/02-durable-agent-tool-call/durable_agent_hitl.py
@@ -13,13 +13,15 @@
 
 """
 Human-in-the-loop (HITL) example for DurableAgent.
+
 This script shows how to:
-  1. Define a tool that requires human approval before it runs.
-  2. Run a DurableAgent with approval enabled.
+  1. Register a before_tool_call hook that returns RequireApproval for specific tools.
+  2. Run a DurableAgent with that hook — no decorator changes needed on any tool.
   3. Receive the ApprovalRequiredEvent via Dapr Pub/Sub.
   4. Send the human decision back to resume the waiting workflow.
 
-Start the Dapr sidecar alongside this script
+The hook approach works for all tool sources — anything loaded at runtime.
+
 The script will:
   1. Start the agent workflow.
   2. Receive the ApprovalRequiredEvent from the pub/sub topic.
@@ -40,6 +42,7 @@ from fastapi import FastAPI, Request, Response
 from dapr_agents import DurableAgent, tool, AgentApprovalConfig
 from dapr_agents.agents.configs import AgentExecutionConfig
 from dapr_agents.agents.schemas import ApprovalRequiredEvent
+from dapr_agents.hooks import Hooks, HookContext, HookDecision, RequireApproval, Proceed
 from dapr_agents.workflow.runners import AgentRunner
 from dapr_agents.llm.openai import OpenAIChatClient
 
@@ -47,7 +50,8 @@ load_dotenv()
 
 logger = logging.getLogger(__name__)
 
-# both Uvicorn and main() run in the same event loop (via asyncio.create_task), so put_nowait() from the FastAPI handler immediately wakes up get() in main()
+# both uvicorn and main() run in the same event loop (via asyncio.create_task),
+# so put_nowait() from the fastapi handler immediately wakes up get() in main()
 _approval_queue: asyncio.Queue = asyncio.Queue()
 _dapr_app = FastAPI()
 
@@ -65,9 +69,7 @@ def _subscribe():
 
 @_dapr_app.post("/agent-approval-requests")
 async def _receive_approval_request(request: Request):
-    """Called by Dapr when the workflow publishes an approval request.
-    Parses the CloudEvent and pushes the typed payload to the queue for main() to handle.
-    """
+    """Called by Dapr when the workflow publishes an approval request."""
     body = await request.body()
     envelope = json.loads(body)
     data = envelope.get("data") or envelope
@@ -75,45 +77,48 @@ async def _receive_approval_request(request: Request):
     _approval_queue.put_nowait(event)
     logger.info(
         "Approval request received via pub/sub: tool='%s' request_id=%s instance=%s",
-        event.tool_name,
+        event.step_name,
         event.approval_request_id,
         event.instance_id,
     )
     return Response(status_code=200)
 
 
-# mock tools
 @tool
 def get_weather(location: str) -> str:
     """Get weather information for a location."""
     import random
-
     temperature = random.randint(60, 85)
     return f"{location}: {temperature}F, partly cloudy."
 
 
-@tool(requires_approval=True, approval_timeout_seconds=120)
+@tool
 def delete_old_data(dataset: str) -> str:
     """Permanently delete a dataset by name."""
     return f"Dataset '{dataset}' has been deleted."
 
 
-# main
+# the hook decides at runtime which tools need approval
+def before_tool(ctx: HookContext) -> HookDecision:
+    if ctx.step_name == "DeleteOldData":
+        return RequireApproval(
+            timeout_seconds=120,
+            instructions=f"confirm deletion of dataset: {ctx.payload.get('dataset')}",
+        )
+    return Proceed()
+
+
 async def main():
     logging.basicConfig(level=logging.INFO)
 
-    # run Uvicorn as a task in this event loop so the pub/sub handler and queue.get() share the same loop.
     _uvicorn_config = uvicorn.Config(
         _dapr_app, host="0.0.0.0", port=8001, log_level="warning"
     )
     _uvicorn_server = uvicorn.Server(_uvicorn_config)
     _uvicorn_task = asyncio.create_task(_uvicorn_server.serve())
-    await asyncio.sleep(
-        0.5
-    )  # wait for Uvicorn to open the socket before Dapr delivers messages
+    await asyncio.sleep(0.5) 
 
     approval_config = AgentApprovalConfig(
-        enabled=True,
         pubsub_name="messagepubsub",
         topic="agent-approval-requests",
         default_timeout_seconds=120,
@@ -127,9 +132,13 @@ async def main():
             "Use delete_old_data when asked to clean up or remove data.",
             "Use get_weather for weather queries.",
         ],
-        llm=OpenAIChatClient(model="openai/gpt-4o-mini"),
+        llm=OpenAIChatClient(
+            model="openai/gpt-5-nano",
+            base_url="https://openrouter.ai/api/v1",
+        ),
         tools=[get_weather, delete_old_data],
         execution=AgentExecutionConfig(approval=approval_config),
+        hooks=Hooks(before_tool_call=before_tool),
     )
 
     runner = AgentRunner()
@@ -145,7 +154,6 @@ async def main():
     )
     print(f"workflow started: instance_id = {instance_id}\n")
 
-    # block until the workflow publishes an ApprovalRequiredEvent and Dapr delivers it here
     print("waiting for approval request from pub/sub (workflow is paused) ...\n")
     try:
         approval_event: ApprovalRequiredEvent = await asyncio.wait_for(
@@ -165,10 +173,12 @@ async def main():
     print("\n" + "=" * 60)
     print("  APPROVAL REQUIRED")
     print("=" * 60)
-    print(f"  tool      : {approval_event.tool_name}")
+    print(f"  tool      : {approval_event.step_name}")
     print(f"  arguments : {approval_event.tool_arguments}")
     print(f"  instance  : {approval_event.instance_id}")
     print(f"  request   : {approval_event.approval_request_id}")
+    if approval_event.instructions:
+        print(f"  note      : {approval_event.instructions}")
     print("=" * 60)
     decision_word = "approved" if APPROVED else "denied"
     print(
@@ -197,7 +207,7 @@ async def main():
         print("\n" + "=" * 60)
         print("  ANOTHER APPROVAL REQUIRED")
         print("=" * 60)
-        print(f"  tool      : {next_event.tool_name}")
+        print(f"  tool      : {next_event.step_name}")
         print(f"  arguments : {next_event.tool_arguments}")
         print("=" * 60)
         print(

--- a/examples/02-durable-agent-tool-call/durable_agent_hitl.py
+++ b/examples/02-durable-agent-tool-call/durable_agent_hitl.py
@@ -12,23 +12,21 @@
 #
 
 """
-Human-in-the-loop (HITL) example for DurableAgent.
+HITL via HTTP polling: the agent holds pending approvals in memory (and in the
+Dapr State Store when one is configured). The same process polls
+agent.list_pending_approvals() and calls agent.raise_approval_event() to resume
+the workflow — no pub/sub or separate client needed.
 
-This script shows how to:
-  1. Register a before_tool_call hook that returns RequireApproval for specific tools.
-  2. Run a DurableAgent with that hook — no decorator changes needed on any tool.
-  3. Poll the agent's in-process pending-approval list to detect when the workflow pauses.
-  4. Send the human decision back to resume the waiting workflow.
+How it works
+------------
+1. The before_tool hook returns RequireApproval for the delete_old_data tool.
+2. The workflow suspends and the approval request is stored in the agent.
+3. This script polls list_pending_approvals() until the request appears.
+4. After a short delay it calls raise_approval_event() to approve or deny.
 
-The hook approach works for all tool sources — anything loaded at runtime.
-
-The script will:
-  1. Start the agent workflow.
-  2. Poll agent.list_pending_approvals() until an approval request appears.
-  3. Print the tool name and arguments.
-  4. Auto-approve after 5 s (set APPROVED = False in main() to test denial).
-  5. Resume or skip the tool based on the decision.
-  6. Print the final agent response.
+Other HITL delivery patterns are shown in companion scripts:
+  - hitl_pubsub.py     — agent publishes the request to a Dapr pub/sub topic
+  - hitl_wf_event.py   — resume a paused workflow from the command line
 """
 
 import asyncio
@@ -85,7 +83,7 @@ async def main():
         ],
         llm=OpenAIChatClient(model="gpt-4o-mini"),
         tools=[get_weather, delete_old_data],
-        hooks=Hooks(before_tool_call=before_tool),
+        hooks=Hooks(before_tool_call=[before_tool]),
     )
 
     runner = AgentRunner()
@@ -164,7 +162,7 @@ async def main():
             "\nworkflow did not complete within the wait window.\n"
             "If the approval event was sent, the workflow is still running.\n"
             f"Re-send manually with:\n"
-            f"  python approval_sender.py {instance_id} <approval_request_id> approve\n"
+            f"  python hitl_wf_event.py {instance_id} <approval_request_id> approve\n"
         )
 
     runner.shutdown(agent)

--- a/examples/02-durable-agent-tool-call/hitl_pubsub.py
+++ b/examples/02-durable-agent-tool-call/hitl_pubsub.py
@@ -12,35 +12,38 @@
 #
 
 """
-HITL via Pub/Sub: the agent publishes ApprovalRequiredEvent to a Dapr topic.
-An external subscriber (a Slack bot, dashboard, or the companion script below)
-reads from that topic and sends back the decision.
+Example 2 — HITL via Pub/Sub.
 
-How it works
-------------
-1. The before_tool hook returns RequireApproval for the delete_old_data tool.
-2. The agent publishes an ApprovalRequiredEvent to the topic configured in
-   AgentApprovalConfig (pubsub_name + topic).
-3. The workflow suspends and waits for an approval_response_{id} event.
-4. An external system subscribes to the topic, presents the request to a human,
-   and calls DaprWorkflowClient.raise_workflow_event() to resume the workflow.
+Agent side : when the workflow pauses, it publishes an ApprovalRequiredEvent to
+             the Dapr pub/sub topic configured in AgentApprovalConfig.
+Client side: a Dapr subscriber receives that event, inspects it, and publishes
+             an ApprovalResponseEvent back to a response topic. The agent's
+             pub/sub subscriber picks it up and raises the workflow event to resume.
 
-To test locally, run this script in one terminal, then run hitl_wf_event.py in
-a second terminal passing the instance_id and approval_request_id printed here.
+Both agent and client use Dapr pub/sub throughout — no direct HTTP calls or
+workflow client calls on the client side.
 
 Prerequisites
 -------------
-- dapr sidecar running (dapr run ...)
-- a Dapr pub/sub component named "pubsub" pointing at Redis or similar
+- Dapr sidecar running  (dapr run ...)
+- A Dapr pub/sub component named "pubsub" (e.g. Redis streams)
+- Two topics: "agent-approval-requests" (outbound) and "agent-approval-responses" (inbound)
+
+Other patterns:
+  - durable_agent_hitl.py  — approval round-trip over HTTP
+  - hitl_wf_event.py       — approval round-trip via direct workflow event
 """
 
 import asyncio
+import json
 import logging
 
+from dapr.aio.clients import DaprClient
 from dotenv import load_dotenv
 
 from dapr_agents import DurableAgent, tool
 from dapr_agents.agents.configs import AgentApprovalConfig, AgentExecutionConfig
+from dapr_agents.agents.schemas import ApprovalRequiredEvent, ApprovalResponseEvent
 from dapr_agents.hooks import Hooks, HookContext, HookDecision, RequireApproval, Proceed
 from dapr_agents.workflow.runners import AgentRunner
 from dapr_agents.llm.openai import OpenAIChatClient
@@ -48,6 +51,11 @@ from dapr_agents.llm.openai import OpenAIChatClient
 load_dotenv()
 
 logger = logging.getLogger(__name__)
+
+PUBSUB_NAME = "pubsub"
+REQUEST_TOPIC = "agent-approval-requests"
+RESPONSE_TOPIC = "agent-approval-responses"
+APPROVED = True  # set to False to test the denial path
 
 
 @tool
@@ -65,6 +73,53 @@ def before_tool(ctx: HookContext) -> HookDecision:
     return Proceed()
 
 
+async def approval_subscriber(agent: DurableAgent) -> None:
+    """
+    Client side: subscribe to REQUEST_TOPIC, read the ApprovalRequiredEvent,
+    and publish an ApprovalResponseEvent back to RESPONSE_TOPIC.
+
+    In a real system this would be a separate service (a Slack bot, a dashboard,
+    etc.). Here it runs as a background coroutine in the same process so the
+    example is self-contained.
+    """
+    async with DaprClient() as client:
+        # Dapr Python SDK streaming subscription
+        async with client.subscribe(
+            pubsub_name=PUBSUB_NAME,
+            topic=REQUEST_TOPIC,
+        ) as subscription:
+            async for message in subscription:
+                try:
+                    event = ApprovalRequiredEvent(**json.loads(message.data()))
+                except Exception:
+                    logger.exception("Failed to parse ApprovalRequiredEvent; skipping.")
+                    await subscription.respond_success(message)
+                    continue
+
+                logger.info(
+                    f"Subscriber received approval request: tool='{event.step_name}' "
+                    f"request_id={event.approval_request_id}"
+                )
+
+                # Publish the human decision back via pub/sub.
+                response = ApprovalResponseEvent(
+                    approval_request_id=event.approval_request_id,
+                    approved=APPROVED,
+                    reason="approved via pub/sub example",
+                )
+                await client.publish_event(
+                    pubsub_name=PUBSUB_NAME,
+                    topic_name=RESPONSE_TOPIC,
+                    data=response.model_dump_json(),
+                    data_content_type="application/json",
+                )
+                logger.info(
+                    f"Subscriber published response: approved={APPROVED} "
+                    f"for request_id={event.approval_request_id}"
+                )
+                await subscription.respond_success(message)
+
+
 async def main():
     logging.basicConfig(level=logging.INFO)
 
@@ -78,27 +133,27 @@ async def main():
         hooks=Hooks(before_tool_call=[before_tool]),
         execution=AgentExecutionConfig(
             approval=AgentApprovalConfig(
-                pubsub_name="pubsub",
-                topic="agent-approval-requests",
+                pubsub_name=PUBSUB_NAME,
+                topic=REQUEST_TOPIC,
             )
         ),
     )
 
     runner = AgentRunner()
 
+    # Start the client-side subscriber as a background task.
+    subscriber_task = asyncio.create_task(approval_subscriber(agent))
+
     instance_id = await runner.run(
         agent,
         payload={"task": "Please delete the old 'sales-2023' dataset."},
         wait=False,
     )
-
     print(f"\nWorkflow started: instance_id = {instance_id}")
     print(
-        "\nThe agent has published an ApprovalRequiredEvent to the 'agent-approval-requests' topic."
+        f"Agent will publish approval request to topic '{REQUEST_TOPIC}'.\n"
+        f"Subscriber will respond on topic '{RESPONSE_TOPIC}'.\n"
     )
-    print("Your subscriber should receive it and prompt a human for a decision.")
-    print("\nTo approve or deny manually, run in a separate terminal:")
-    print(f"  python hitl_wf_event.py {instance_id} <approval_request_id> approve\n")
 
     result = await asyncio.to_thread(
         runner.wait_for_workflow_completion,
@@ -110,6 +165,7 @@ async def main():
     else:
         print("\nWorkflow did not complete within the wait window.")
 
+    subscriber_task.cancel()
     runner.shutdown(agent)
 
 

--- a/examples/02-durable-agent-tool-call/hitl_pubsub.py
+++ b/examples/02-durable-agent-tool-call/hitl_pubsub.py
@@ -1,0 +1,120 @@
+#
+# Copyright 2026 The Dapr Authors
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#     http://www.apache.org/licenses/LICENSE-2.0
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+"""
+HITL via Pub/Sub: the agent publishes ApprovalRequiredEvent to a Dapr topic.
+An external subscriber (a Slack bot, dashboard, or the companion script below)
+reads from that topic and sends back the decision.
+
+How it works
+------------
+1. The before_tool hook returns RequireApproval for the delete_old_data tool.
+2. The agent publishes an ApprovalRequiredEvent to the topic configured in
+   AgentApprovalConfig (pubsub_name + topic).
+3. The workflow suspends and waits for an approval_response_{id} event.
+4. An external system subscribes to the topic, presents the request to a human,
+   and calls DaprWorkflowClient.raise_workflow_event() to resume the workflow.
+
+To test locally, run this script in one terminal, then run hitl_wf_event.py in
+a second terminal passing the instance_id and approval_request_id printed here.
+
+Prerequisites
+-------------
+- dapr sidecar running (dapr run ...)
+- a Dapr pub/sub component named "pubsub" pointing at Redis or similar
+"""
+
+import asyncio
+import logging
+
+from dotenv import load_dotenv
+
+from dapr_agents import DurableAgent, tool
+from dapr_agents.agents.configs import AgentApprovalConfig, AgentExecutionConfig
+from dapr_agents.hooks import Hooks, HookContext, HookDecision, RequireApproval, Proceed
+from dapr_agents.workflow.runners import AgentRunner
+from dapr_agents.llm.openai import OpenAIChatClient
+
+load_dotenv()
+
+logger = logging.getLogger(__name__)
+
+
+@tool
+def delete_old_data(dataset: str) -> str:
+    """Permanently delete a dataset by name."""
+    return f"Dataset '{dataset}' has been deleted."
+
+
+def before_tool(ctx: HookContext) -> HookDecision:
+    if ctx.step_name == "DeleteOldData":
+        return RequireApproval(
+            timeout_seconds=300,
+            instructions=f"Confirm deletion of dataset: {ctx.payload.get('dataset')}",
+        )
+    return Proceed()
+
+
+async def main():
+    logging.basicConfig(level=logging.INFO)
+
+    agent = DurableAgent(
+        name="hitl-pubsub-demo",
+        role="Operations Assistant",
+        goal="Help the user manage data.",
+        instructions=["Use delete_old_data when asked to clean up or remove data."],
+        llm=OpenAIChatClient(model="gpt-4o-mini"),
+        tools=[delete_old_data],
+        hooks=Hooks(before_tool_call=[before_tool]),
+        execution=AgentExecutionConfig(
+            approval=AgentApprovalConfig(
+                pubsub_name="pubsub",
+                topic="agent-approval-requests",
+            )
+        ),
+    )
+
+    runner = AgentRunner()
+
+    instance_id = await runner.run(
+        agent,
+        payload={"task": "Please delete the old 'sales-2023' dataset."},
+        wait=False,
+    )
+
+    print(f"\nWorkflow started: instance_id = {instance_id}")
+    print(
+        "\nThe agent has published an ApprovalRequiredEvent to the 'agent-approval-requests' topic."
+    )
+    print("Your subscriber should receive it and prompt a human for a decision.")
+    print("\nTo approve or deny manually, run in a separate terminal:")
+    print(f"  python hitl_wf_event.py {instance_id} <approval_request_id> approve\n")
+
+    result = await asyncio.to_thread(
+        runner.wait_for_workflow_completion,
+        instance_id,
+        timeout_in_seconds=360,
+    )
+    if result:
+        print(f"\nFinal output:\n{getattr(result, 'serialized_output', result)}\n")
+    else:
+        print("\nWorkflow did not complete within the wait window.")
+
+    runner.shutdown(agent)
+
+
+if __name__ == "__main__":
+    try:
+        asyncio.run(main())
+    except KeyboardInterrupt:
+        pass

--- a/examples/02-durable-agent-tool-call/hitl_wf_event.py
+++ b/examples/02-durable-agent-tool-call/hitl_wf_event.py
@@ -1,0 +1,87 @@
+#
+# Copyright 2026 The Dapr Authors
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#     http://www.apache.org/licenses/LICENSE-2.0
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+"""
+HITL via direct workflow event: resume a paused workflow by raising an event
+through the Dapr Workflow client, with no pub/sub or HTTP endpoint required.
+
+How it works
+------------
+When a DurableAgent workflow pauses for approval, it is waiting for an external
+event named approval_response_{approval_request_id}. This script sends that
+event directly to the Dapr sidecar, which forwards it to the waiting workflow.
+
+Use this when:
+- You are operating entirely from the command line.
+- The agent is not configured with a pub/sub approval topic.
+- You know the instance_id and approval_request_id (printed by the agent).
+
+Usage
+-----
+Run the agent first (e.g. durable_agent_hitl.py or hitl_pubsub.py), then:
+
+    python hitl_wf_event.py <instance_id> <approval_request_id> [approve|deny]
+
+Example:
+
+    python hitl_wf_event.py abc123 550e8400-e29b-41d4-a716-446655440000 approve
+"""
+
+import sys
+import logging
+
+from dotenv import load_dotenv
+
+load_dotenv()
+
+logging.basicConfig(level=logging.INFO)
+logger = logging.getLogger(__name__)
+
+
+def main():
+    if len(sys.argv) < 3:
+        print(__doc__)
+        sys.exit(1)
+
+    instance_id = sys.argv[1]
+    approval_request_id = sys.argv[2]
+    decision = sys.argv[3].lower() if len(sys.argv) > 3 else "approve"
+    approved = decision == "approve"
+
+    from dapr.ext.workflow import DaprWorkflowClient
+    from dapr_agents.agents.schemas import ApprovalResponseEvent
+
+    event_name = f"approval_response_{approval_request_id}"
+    response = ApprovalResponseEvent(
+        approval_request_id=approval_request_id,
+        approved=approved,
+        reason=f"Sent via hitl_wf_event.py (decision={decision})",
+    )
+
+    print(
+        f"Sending decision: instance={instance_id}, "
+        f"request={approval_request_id}, approved={approved}"
+    )
+
+    client = DaprWorkflowClient()
+    client.raise_workflow_event(
+        instance_id=instance_id,
+        event_name=event_name,
+        data=response.model_dump(mode="json"),
+    )
+
+    print("Event sent. The workflow will resume shortly.")
+
+
+if __name__ == "__main__":
+    main()

--- a/examples/02-durable-agent-tool-call/hitl_wf_event.py
+++ b/examples/02-durable-agent-tool-call/hitl_wf_event.py
@@ -12,76 +12,134 @@
 #
 
 """
-HITL via direct workflow event: resume a paused workflow by raising an event
-through the Dapr Workflow client, with no pub/sub or HTTP endpoint required.
+Example 3 — HITL via direct workflow event.
 
-How it works
-------------
-When a DurableAgent workflow pauses for approval, it is waiting for an external
-event named approval_response_{approval_request_id}. This script sends that
-event directly to the Dapr sidecar, which forwards it to the waiting workflow.
+Agent side : the workflow pauses and waits for an external event named
+             approval_response_{approval_request_id}. No pub/sub topic is
+             configured — the agent holds the request in memory only.
+Client side: a human reads the pending request (printed to stdout here) and
+             raises the workflow event directly via DaprWorkflowClient, which
+             delivers it straight to the waiting workflow through the Dapr sidecar.
 
-Use this when:
-- You are operating entirely from the command line.
-- The agent is not configured with a pub/sub approval topic.
-- You know the instance_id and approval_request_id (printed by the agent).
+No pub/sub component required. The Dapr sidecar must be reachable.
 
-Usage
------
-Run the agent first (e.g. durable_agent_hitl.py or hitl_pubsub.py), then:
+This script runs both sides in the same process for simplicity.
+In production the client call would be a separate CLI command or script.
 
-    python hitl_wf_event.py <instance_id> <approval_request_id> [approve|deny]
-
-Example:
-
-    python hitl_wf_event.py abc123 550e8400-e29b-41d4-a716-446655440000 approve
+Other patterns:
+  - durable_agent_hitl.py  — approval round-trip over HTTP
+  - hitl_pubsub.py         — approval round-trip over Dapr pub/sub
 """
 
-import sys
+import asyncio
 import logging
+import time
 
+from dapr.ext.workflow import DaprWorkflowClient
 from dotenv import load_dotenv
+
+from dapr_agents import DurableAgent, tool
+from dapr_agents.agents.schemas import ApprovalResponseEvent
+from dapr_agents.hooks import Hooks, HookContext, HookDecision, RequireApproval, Proceed
+from dapr_agents.workflow.runners import AgentRunner
+from dapr_agents.llm.openai import OpenAIChatClient
 
 load_dotenv()
 
-logging.basicConfig(level=logging.INFO)
 logger = logging.getLogger(__name__)
 
+APPROVED = True  # set to False to test the denial path
 
-def main():
-    if len(sys.argv) < 3:
-        print(__doc__)
-        sys.exit(1)
 
-    instance_id = sys.argv[1]
-    approval_request_id = sys.argv[2]
-    decision = sys.argv[3].lower() if len(sys.argv) > 3 else "approve"
-    approved = decision == "approve"
+@tool
+def delete_old_data(dataset: str) -> str:
+    """Permanently delete a dataset by name."""
+    return f"Dataset '{dataset}' has been deleted."
 
-    from dapr.ext.workflow import DaprWorkflowClient
-    from dapr_agents.agents.schemas import ApprovalResponseEvent
 
+def before_tool(ctx: HookContext) -> HookDecision:
+    if ctx.step_name == "DeleteOldData":
+        return RequireApproval(
+            timeout_seconds=120,
+            instructions=f"Confirm deletion of dataset: {ctx.payload.get('dataset')}",
+        )
+    return Proceed()
+
+
+async def main():
+    logging.basicConfig(level=logging.INFO)
+
+    agent = DurableAgent(
+        name="hitl-wf-event-demo",
+        role="Operations Assistant",
+        goal="Help the user manage data.",
+        instructions=["Use delete_old_data when asked to clean up or remove data."],
+        llm=OpenAIChatClient(model="gpt-4o-mini"),
+        tools=[delete_old_data],
+        hooks=Hooks(before_tool_call=[before_tool]),
+        # No AgentApprovalConfig pubsub_name — request is held in memory only.
+    )
+
+    runner = AgentRunner()
+
+    instance_id = await runner.run(
+        agent,
+        payload={"task": "Please delete the old 'sales-2023' dataset."},
+        wait=False,
+    )
+    print(f"\nWorkflow started: instance_id = {instance_id}\n")
+
+    # --- client side: poll in-memory list until the request appears ---
+    approval_data = None
+    deadline = time.monotonic() + 60
+    while time.monotonic() < deadline:
+        pending = agent.list_pending_approvals()
+        if pending:
+            approval_data = pending[0]
+            break
+        await asyncio.sleep(1)
+
+    if approval_data is None:
+        print("No approval request appeared within the wait window.")
+        runner.shutdown(agent)
+        return
+
+    approval_request_id = approval_data["approval_request_id"]
+    print(f"  tool      : {approval_data['step_name']}")
+    print(f"  arguments : {approval_data['tool_arguments']}")
+    print(f"  instance  : {approval_data['instance_id']}")
+    print(f"  request   : {approval_request_id}")
+    print(f"\n  Raising workflow event: {'approve' if APPROVED else 'deny'}\n")
+
+    # --- client side: raise the workflow event directly via DaprWorkflowClient ---
     event_name = f"approval_response_{approval_request_id}"
     response = ApprovalResponseEvent(
         approval_request_id=approval_request_id,
-        approved=approved,
-        reason=f"Sent via hitl_wf_event.py (decision={decision})",
+        approved=APPROVED,
+        reason="approved via workflow event example",
     )
-
-    print(
-        f"Sending decision: instance={instance_id}, "
-        f"request={approval_request_id}, approved={approved}"
-    )
-
-    client = DaprWorkflowClient()
-    client.raise_workflow_event(
-        instance_id=instance_id,
+    wf_client = DaprWorkflowClient()
+    wf_client.raise_workflow_event(
+        instance_id=approval_data["instance_id"],
         event_name=event_name,
         data=response.model_dump(mode="json"),
     )
 
-    print("Event sent. The workflow will resume shortly.")
+    result = await asyncio.to_thread(
+        runner.wait_for_workflow_completion,
+        instance_id,
+        timeout_in_seconds=120,
+    )
+    if result:
+        print(f"\nFinal output:\n{getattr(result, 'serialized_output', result)}\n")
+    else:
+        print("\nWorkflow did not complete within the wait window.")
+
+    runner.shutdown(agent)
 
 
 if __name__ == "__main__":
-    main()
+    try:
+        asyncio.run(main())
+    except KeyboardInterrupt:
+        pass

--- a/tests/agents/durableagent/test_hitl.py
+++ b/tests/agents/durableagent/test_hitl.py
@@ -1,0 +1,210 @@
+#
+# Copyright 2026 The Dapr Authors
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#     http://www.apache.org/licenses/LICENSE-2.0
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+"""Unit tests for human-in-the-loop (HITL) support in DurableAgent."""
+
+import pytest
+from datetime import timezone
+
+from dapr_agents.agents.schemas import ApprovalRequiredEvent, ApprovalResponseEvent
+from dapr_agents.agents.configs import AgentApprovalConfig, AgentExecutionConfig
+from dapr_agents.tool.base import AgentTool
+from dapr_agents.tool import tool
+
+
+class TestApprovalRequiredEvent:
+    def test_required_fields_stored(self):
+        event = ApprovalRequiredEvent(
+            approval_request_id="req-1",
+            instance_id="inst-1",
+            tool_name="DeleteOldData",
+            tool_call_id="call-1",
+            tool_arguments={"dataset": "sales-2023"},
+            timeout_seconds=120,
+        )
+        assert event.approval_request_id == "req-1"
+        assert event.instance_id == "inst-1"
+        assert event.tool_name == "DeleteOldData"
+        assert event.tool_call_id == "call-1"
+        assert event.tool_arguments == {"dataset": "sales-2023"}
+        assert event.timeout_seconds == 120
+
+    def test_context_defaults_to_empty_dict(self):
+        event = ApprovalRequiredEvent(
+            approval_request_id="req-1",
+            instance_id="inst-1",
+            tool_name="T",
+            tool_call_id="c-1",
+            tool_arguments={},
+            timeout_seconds=60,
+        )
+        assert event.context == {}
+
+    def test_requested_at_is_utc(self):
+        event = ApprovalRequiredEvent(
+            approval_request_id="req-1",
+            instance_id="inst-1",
+            tool_name="T",
+            tool_call_id="c-1",
+            tool_arguments={},
+            timeout_seconds=60,
+        )
+        assert event.requested_at.tzinfo is not None
+        assert event.requested_at.tzinfo == timezone.utc
+
+    def test_roundtrip_serialization(self):
+        event = ApprovalRequiredEvent(
+            approval_request_id="req-1",
+            instance_id="inst-1",
+            tool_name="DeleteOldData",
+            tool_call_id="call-1",
+            tool_arguments={"dataset": "sales-2023"},
+            timeout_seconds=300,
+        )
+        data = event.model_dump(mode="json")
+        restored = ApprovalRequiredEvent(**data)
+        assert restored.approval_request_id == event.approval_request_id
+        assert restored.tool_arguments == event.tool_arguments
+        assert restored.timeout_seconds == event.timeout_seconds
+
+
+class TestApprovalResponseEvent:
+    def test_approved_true(self):
+        resp = ApprovalResponseEvent(
+            approval_request_id="req-1",
+            approved=True,
+        )
+        assert resp.approved is True
+        assert resp.reason is None
+
+    def test_approved_false_with_reason(self):
+        resp = ApprovalResponseEvent(
+            approval_request_id="req-1",
+            approved=False,
+            reason="dataset still in use",
+        )
+        assert resp.approved is False
+        assert resp.reason == "dataset still in use"
+
+    def test_decided_at_is_utc(self):
+        resp = ApprovalResponseEvent(
+            approval_request_id="req-1",
+            approved=True,
+        )
+        assert resp.decided_at.tzinfo == timezone.utc
+
+    def test_roundtrip_serialization(self):
+        resp = ApprovalResponseEvent(
+            approval_request_id="req-1",
+            approved=True,
+            reason="looks good",
+        )
+        data = resp.model_dump(mode="json")
+        restored = ApprovalResponseEvent(**data)
+        assert restored.approved == resp.approved
+        assert restored.reason == resp.reason
+
+
+class TestAgentApprovalConfig:
+    def test_disabled_by_default(self):
+        cfg = AgentApprovalConfig()
+        assert cfg.enabled is False
+
+    def test_default_pubsub_and_topic(self):
+        cfg = AgentApprovalConfig()
+        assert cfg.pubsub_name == "dapr-agents-pubsub"
+        assert cfg.topic == "agent-approval-requests"
+
+    def test_default_timeout(self):
+        cfg = AgentApprovalConfig()
+        assert cfg.default_timeout_seconds == 300
+
+    def test_custom_values(self):
+        cfg = AgentApprovalConfig(
+            enabled=True,
+            pubsub_name="my-pubsub",
+            topic="my-topic",
+            default_timeout_seconds=60,
+        )
+        assert cfg.enabled is True
+        assert cfg.pubsub_name == "my-pubsub"
+        assert cfg.topic == "my-topic"
+        assert cfg.default_timeout_seconds == 60
+
+
+class TestAgentExecutionConfigApprovalField:
+    def test_approval_field_present_and_disabled_by_default(self):
+        cfg = AgentExecutionConfig()
+        assert hasattr(cfg, "approval")
+        assert isinstance(cfg.approval, AgentApprovalConfig)
+        assert cfg.approval.enabled is False
+
+    def test_approval_field_accepts_custom_config(self):
+        approval = AgentApprovalConfig(enabled=True, default_timeout_seconds=30)
+        cfg = AgentExecutionConfig(approval=approval)
+        assert cfg.approval.enabled is True
+        assert cfg.approval.default_timeout_seconds == 30
+
+
+class TestToolDecoratorApprovalMetadata:
+    def test_requires_approval_defaults_to_false(self):
+        @tool
+        def simple_tool(x: int) -> str:
+            """A simple tool."""
+            return str(x)
+
+        assert simple_tool.requires_approval is False
+        assert simple_tool.approval_timeout_seconds is None
+
+    def test_requires_approval_true_stored(self):
+        @tool(requires_approval=True)
+        def guarded_tool(dataset: str) -> str:
+            """Delete a dataset."""
+            return f"Deleted {dataset}"
+
+        assert guarded_tool.requires_approval is True
+        assert guarded_tool.approval_timeout_seconds is None
+
+    def test_per_tool_timeout_stored(self):
+        @tool(requires_approval=True, approval_timeout_seconds=120)
+        def guarded_tool_with_timeout(dataset: str) -> str:
+            """Delete a dataset with custom timeout."""
+            return f"Deleted {dataset}"
+
+        assert guarded_tool_with_timeout.requires_approval is True
+        assert guarded_tool_with_timeout.approval_timeout_seconds == 120
+
+    def test_approval_timeout_without_requires_approval(self):
+        # approval_timeout_seconds can be set independently; requires_approval stays False
+        @tool(approval_timeout_seconds=60)
+        def tool_with_timeout_only(x: str) -> str:
+            """A tool."""
+            return x
+
+        assert tool_with_timeout_only.requires_approval is False
+        assert tool_with_timeout_only.approval_timeout_seconds == 60
+
+    def test_agent_tool_direct_construction(self):
+        def my_func(x: str) -> str:
+            """My tool."""
+            return x
+
+        t = AgentTool(
+            name="MyTool",
+            description="My tool.",
+            func=my_func,
+            requires_approval=True,
+            approval_timeout_seconds=300,
+        )
+        assert t.requires_approval is True
+        assert t.approval_timeout_seconds == 300

--- a/tests/agents/durableagent/test_hitl.py
+++ b/tests/agents/durableagent/test_hitl.py
@@ -261,17 +261,17 @@ class TestHookDecisions:
 class TestHooksContainer:
     def test_empty_hooks_has_no_callbacks(self):
         h = Hooks()
-        assert h.before_tool_call is None
-        assert h.after_tool_call is None
-        assert h.before_llm_call is None
-        assert h.after_llm_call is None
+        assert h.before_tool_call == []
+        assert h.after_tool_call == []
+        assert h.before_llm_call == []
+        assert h.after_llm_call == []
 
     def test_before_tool_call_registered(self):
         def my_hook(ctx: HookContext):
             return Proceed()
 
-        h = Hooks(before_tool_call=my_hook)
-        assert h.before_tool_call is my_hook
+        h = Hooks(before_tool_call=[my_hook])
+        assert my_hook in h.before_tool_call
 
     def test_hook_called_with_context(self):
         received: list = []
@@ -280,7 +280,7 @@ class TestHooksContainer:
             received.append(ctx)
             return Deny(reason="test")
 
-        h = Hooks(before_tool_call=capturing_hook)
+        h = Hooks(before_tool_call=[capturing_hook])
         ctx = HookContext(
             step_name="drop_table",
             step_kind="tool",
@@ -288,7 +288,7 @@ class TestHooksContainer:
             payload={"table": "users"},
             tool_call_id="call-123",
         )
-        decision = h.before_tool_call(ctx)
+        decision = h.before_tool_call[0](ctx)
         assert len(received) == 1
         assert received[0].step_name == "drop_table"
         assert isinstance(decision, Deny)
@@ -298,8 +298,8 @@ class TestHooksContainer:
         def passthrough(ctx: HookContext):
             return None  # caller coerces this to Proceed
 
-        h = Hooks(before_tool_call=passthrough)
-        result = h.before_tool_call(HookContext("tool", "tool", "local", {}, "id"))
+        h = Hooks(before_tool_call=[passthrough])
+        result = h.before_tool_call[0](HookContext("tool", "tool", "local", {}, "id"))
         assert result is None  # workflow code handles the None → Proceed coercion
 
 

--- a/tests/agents/durableagent/test_hitl.py
+++ b/tests/agents/durableagent/test_hitl.py
@@ -11,19 +11,54 @@
 # limitations under the License.
 #
 
-"""Unit tests for human-in-the-loop (HITL) support in DurableAgent."""
+"""Unit tests for the hook-based human-in-the-loop (HITL) system."""
 
 import pytest
 from datetime import timezone
 
 from dapr_agents.agents.schemas import ApprovalRequiredEvent, ApprovalResponseEvent
 from dapr_agents.agents.configs import AgentApprovalConfig, AgentExecutionConfig
+from dapr_agents.hooks import (
+    Hooks,
+    HookContext,
+    Proceed,
+    Skip,
+    Modify,
+    RequireApproval,
+    Deny,
+)
 from dapr_agents.tool.base import AgentTool
 from dapr_agents.tool import tool
 
 
 class TestApprovalRequiredEvent:
-    def test_required_fields_stored(self):
+    def test_step_name_stored(self):
+        event = ApprovalRequiredEvent(
+            approval_request_id="req-1",
+            instance_id="inst-1",
+            step_name="DeleteOldData",
+            tool_call_id="call-1",
+            tool_arguments={"dataset": "sales-2023"},
+            timeout_seconds=120,
+        )
+        assert event.step_name == "DeleteOldData"
+        assert event.step_kind == "tool"
+        assert event.source == "local"
+
+    def test_tool_name_compat_property(self):
+        # existing code that reads event.tool_name still works
+        event = ApprovalRequiredEvent(
+            approval_request_id="req-1",
+            instance_id="inst-1",
+            step_name="DeleteOldData",
+            tool_call_id="call-1",
+            tool_arguments={},
+            timeout_seconds=60,
+        )
+        assert event.tool_name == "DeleteOldData"
+
+    def test_old_tool_name_kwarg_still_accepted(self):
+        # existing construction code using tool_name= still works
         event = ApprovalRequiredEvent(
             approval_request_id="req-1",
             instance_id="inst-1",
@@ -32,18 +67,40 @@ class TestApprovalRequiredEvent:
             tool_arguments={"dataset": "sales-2023"},
             timeout_seconds=120,
         )
-        assert event.approval_request_id == "req-1"
-        assert event.instance_id == "inst-1"
+        assert event.step_name == "DeleteOldData"
         assert event.tool_name == "DeleteOldData"
-        assert event.tool_call_id == "call-1"
-        assert event.tool_arguments == {"dataset": "sales-2023"}
-        assert event.timeout_seconds == 120
+
+    def test_instructions_field(self):
+        event = ApprovalRequiredEvent(
+            approval_request_id="req-1",
+            instance_id="inst-1",
+            step_name="drop_table",
+            tool_call_id="c-1",
+            tool_arguments={},
+            timeout_seconds=60,
+            instructions="confirm you want to drop this table",
+        )
+        assert event.instructions == "confirm you want to drop this table"
+
+    def test_source_and_step_kind_custom_values(self):
+        event = ApprovalRequiredEvent(
+            approval_request_id="req-1",
+            instance_id="inst-1",
+            step_name="delete_repo",
+            step_kind="tool",
+            source="mcp",
+            tool_call_id="c-1",
+            tool_arguments={},
+            timeout_seconds=60,
+        )
+        assert event.source == "mcp"
+        assert event.step_kind == "tool"
 
     def test_context_defaults_to_empty_dict(self):
         event = ApprovalRequiredEvent(
             approval_request_id="req-1",
             instance_id="inst-1",
-            tool_name="T",
+            step_name="T",
             tool_call_id="c-1",
             tool_arguments={},
             timeout_seconds=60,
@@ -54,7 +111,7 @@ class TestApprovalRequiredEvent:
         event = ApprovalRequiredEvent(
             approval_request_id="req-1",
             instance_id="inst-1",
-            tool_name="T",
+            step_name="T",
             tool_call_id="c-1",
             tool_arguments={},
             timeout_seconds=60,
@@ -66,7 +123,8 @@ class TestApprovalRequiredEvent:
         event = ApprovalRequiredEvent(
             approval_request_id="req-1",
             instance_id="inst-1",
-            tool_name="DeleteOldData",
+            step_name="DeleteOldData",
+            source="mcp",
             tool_call_id="call-1",
             tool_arguments={"dataset": "sales-2023"},
             timeout_seconds=300,
@@ -74,6 +132,8 @@ class TestApprovalRequiredEvent:
         data = event.model_dump(mode="json")
         restored = ApprovalRequiredEvent(**data)
         assert restored.approval_request_id == event.approval_request_id
+        assert restored.step_name == event.step_name
+        assert restored.source == event.source
         assert restored.tool_arguments == event.tool_arguments
         assert restored.timeout_seconds == event.timeout_seconds
 
@@ -116,10 +176,6 @@ class TestApprovalResponseEvent:
 
 
 class TestAgentApprovalConfig:
-    def test_disabled_by_default(self):
-        cfg = AgentApprovalConfig()
-        assert cfg.enabled is False
-
     def test_default_pubsub_and_topic(self):
         cfg = AgentApprovalConfig()
         assert cfg.pubsub_name == "dapr-agents-pubsub"
@@ -131,80 +187,141 @@ class TestAgentApprovalConfig:
 
     def test_custom_values(self):
         cfg = AgentApprovalConfig(
-            enabled=True,
             pubsub_name="my-pubsub",
             topic="my-topic",
             default_timeout_seconds=60,
         )
-        assert cfg.enabled is True
         assert cfg.pubsub_name == "my-pubsub"
         assert cfg.topic == "my-topic"
         assert cfg.default_timeout_seconds == 60
 
 
 class TestAgentExecutionConfigApprovalField:
-    def test_approval_field_present_and_disabled_by_default(self):
+    def test_approval_field_present(self):
         cfg = AgentExecutionConfig()
         assert hasattr(cfg, "approval")
         assert isinstance(cfg.approval, AgentApprovalConfig)
-        assert cfg.approval.enabled is False
 
     def test_approval_field_accepts_custom_config(self):
-        approval = AgentApprovalConfig(enabled=True, default_timeout_seconds=30)
+        approval = AgentApprovalConfig(default_timeout_seconds=30)
         cfg = AgentExecutionConfig(approval=approval)
-        assert cfg.approval.enabled is True
         assert cfg.approval.default_timeout_seconds == 30
 
 
-class TestToolDecoratorApprovalMetadata:
-    def test_requires_approval_defaults_to_false(self):
+class TestHookDecisions:
+    def test_proceed_is_a_decision(self):
+        d = Proceed()
+        from dapr_agents.hooks import HookDecision
+
+        assert isinstance(d, HookDecision)
+
+    def test_deny_carries_reason(self):
+        d = Deny(reason="schema changes go through dba review")
+        assert d.reason == "schema changes go through dba review"
+
+    def test_deny_reason_is_optional(self):
+        d = Deny()
+        assert d.reason is None
+
+    def test_skip_carries_result(self):
+        d = Skip(result={"cached": True})
+        assert d.result == {"cached": True}
+
+    def test_skip_result_is_optional(self):
+        d = Skip()
+        assert d.result is None
+
+    def test_modify_carries_payload(self):
+        d = Modify(payload={"new_arg": "value"})
+        assert d.payload == {"new_arg": "value"}
+
+    def test_require_approval_defaults(self):
+        d = RequireApproval()
+        assert d.timeout_seconds is None
+        assert d.instructions is None
+        assert d.reason is None
+
+    def test_require_approval_with_all_fields(self):
+        d = RequireApproval(
+            timeout_seconds=3600,
+            instructions="confirm deletion",
+            reason="destructive operation",
+        )
+        assert d.timeout_seconds == 3600
+        assert d.instructions == "confirm deletion"
+        assert d.reason == "destructive operation"
+
+
+class TestHooksContainer:
+    def test_empty_hooks_has_no_callbacks(self):
+        h = Hooks()
+        assert h.before_tool_call is None
+        assert h.after_tool_call is None
+        assert h.before_llm_call is None
+        assert h.after_llm_call is None
+
+    def test_before_tool_call_registered(self):
+        def my_hook(ctx: HookContext):
+            return Proceed()
+
+        h = Hooks(before_tool_call=my_hook)
+        assert h.before_tool_call is my_hook
+
+    def test_hook_called_with_context(self):
+        received: list = []
+
+        def capturing_hook(ctx: HookContext):
+            received.append(ctx)
+            return Deny(reason="test")
+
+        h = Hooks(before_tool_call=capturing_hook)
+        ctx = HookContext(
+            step_name="drop_table",
+            step_kind="tool",
+            source="local",
+            payload={"table": "users"},
+            tool_call_id="call-123",
+        )
+        decision = h.before_tool_call(ctx)
+        assert len(received) == 1
+        assert received[0].step_name == "drop_table"
+        assert isinstance(decision, Deny)
+
+    def test_hook_returning_none_means_proceed(self):
+        # None return from a hook is treated as Proceed in the workflow code
+        def passthrough(ctx: HookContext):
+            return None  # caller coerces this to Proceed
+
+        h = Hooks(before_tool_call=passthrough)
+        result = h.before_tool_call(HookContext("tool", "tool", "local", {}, "id"))
+        assert result is None  # workflow code handles the None → Proceed coercion
+
+
+class TestToolDecoratorNoApprovalFields:
+    def test_tool_decorator_no_longer_accepts_requires_approval(self):
+        # the decorator no longer has requires_approval; just verifying clean creation
         @tool
         def simple_tool(x: int) -> str:
             """A simple tool."""
             return str(x)
 
-        assert simple_tool.requires_approval is False
-        assert simple_tool.approval_timeout_seconds is None
+        assert not hasattr(simple_tool, "requires_approval")
+        assert not hasattr(simple_tool, "approval_timeout_seconds")
 
-    def test_requires_approval_true_stored(self):
-        @tool(requires_approval=True)
-        def guarded_tool(dataset: str) -> str:
-            """Delete a dataset."""
-            return f"Deleted {dataset}"
-
-        assert guarded_tool.requires_approval is True
-        assert guarded_tool.approval_timeout_seconds is None
-
-    def test_per_tool_timeout_stored(self):
-        @tool(requires_approval=True, approval_timeout_seconds=120)
-        def guarded_tool_with_timeout(dataset: str) -> str:
-            """Delete a dataset with custom timeout."""
-            return f"Deleted {dataset}"
-
-        assert guarded_tool_with_timeout.requires_approval is True
-        assert guarded_tool_with_timeout.approval_timeout_seconds == 120
-
-    def test_approval_timeout_without_requires_approval(self):
-        # approval_timeout_seconds can be set independently; requires_approval stays False
-        @tool(approval_timeout_seconds=60)
-        def tool_with_timeout_only(x: str) -> str:
-            """A tool."""
+    def test_agent_tool_has_source_field(self):
+        @tool
+        def local_tool(x: str) -> str:
+            """A local tool."""
             return x
 
-        assert tool_with_timeout_only.requires_approval is False
-        assert tool_with_timeout_only.approval_timeout_seconds == 60
+        assert local_tool.source == "local"
 
-    def test_agent_tool_direct_construction(self):
-        def my_func(x: str) -> str:
-            """My tool."""
-            return x
-
+    def test_mcp_tool_has_mcp_source(self):
+        # from_mcp sets source="mcp" — test via direct construction
         t = AgentTool(
-            name="MyTool",
-            description="My tool.",
-            func=my_func,
-            requires_approval=True,
-            approval_timeout_seconds=300,
+            name="delete_repo",
+            description="delete a repo",
+            func=lambda repo: f"deleted {repo}",
+            source="mcp",
         )
-        assert t.requires_approval is True
-        assert t.approval_timeout_seconds == 300
+        assert t.source == "mcp"

--- a/tests/agents/durableagent/test_hitl.py
+++ b/tests/agents/durableagent/test_hitl.py
@@ -176,9 +176,10 @@ class TestApprovalResponseEvent:
 
 
 class TestAgentApprovalConfig:
-    def test_default_pubsub_and_topic(self):
+    def test_default_pubsub_is_none(self):
+        # pubsub_name defaults to None — HTTP polling is the default delivery mode
         cfg = AgentApprovalConfig()
-        assert cfg.pubsub_name == "dapr-agents-pubsub"
+        assert cfg.pubsub_name is None
         assert cfg.topic == "agent-approval-requests"
 
     def test_default_timeout(self):
@@ -194,6 +195,11 @@ class TestAgentApprovalConfig:
         assert cfg.pubsub_name == "my-pubsub"
         assert cfg.topic == "my-topic"
         assert cfg.default_timeout_seconds == 60
+
+    def test_pubsub_name_explicit_none_leaves_topic_default(self):
+        cfg = AgentApprovalConfig(pubsub_name=None)
+        assert cfg.pubsub_name is None
+        assert cfg.topic == "agent-approval-requests"
 
 
 class TestAgentExecutionConfigApprovalField:

--- a/tests/agents/durableagent/test_hitl_workflow.py
+++ b/tests/agents/durableagent/test_hitl_workflow.py
@@ -372,7 +372,7 @@ class TestHookWorkflowDispatch:
         Returns the input dict passed to save_tool_results.
         """
         message = {"task": "do something"}
-        agent._hooks = Hooks(before_tool_call=hook_fn)
+        agent._hooks = Hooks(before_tool_call=[hook_fn])
         gen = agent.agent_workflow(mock_ctx, message)
 
         try:
@@ -408,7 +408,7 @@ class TestHookWorkflowDispatch:
                 return Deny(reason="schema changes go through DBA review")
             return Proceed()
 
-        agent = _make_agent(mock_llm, hooks=Hooks(before_tool_call=hook))
+        agent = _make_agent(mock_llm, hooks=Hooks(before_tool_call=[hook]))
         save_input = self._drive_workflow_deny_skip(agent, mock_ctx, hook, [tc])
 
         called_fns = [c[0][0] for c in mock_ctx.call_activity.call_args_list]
@@ -429,7 +429,7 @@ class TestHookWorkflowDispatch:
         def hook(ctx: HookContext):
             return Deny(reason="blocked")
 
-        agent = _make_agent(mock_llm, hooks=Hooks(before_tool_call=hook))
+        agent = _make_agent(mock_llm, hooks=Hooks(before_tool_call=[hook]))
         save_input = self._drive_workflow_deny_skip(agent, mock_ctx, hook, [tc])
 
         assert save_input is not None
@@ -450,7 +450,7 @@ class TestHookWorkflowDispatch:
                 return Skip(result="cached-42")
             return Proceed()
 
-        agent = _make_agent(mock_llm, hooks=Hooks(before_tool_call=hook))
+        agent = _make_agent(mock_llm, hooks=Hooks(before_tool_call=[hook]))
         save_input = self._drive_workflow_deny_skip(agent, mock_ctx, hook, [tc])
 
         called_fns = [c[0][0] for c in mock_ctx.call_activity.call_args_list]
@@ -469,7 +469,7 @@ class TestHookWorkflowDispatch:
         def hook(ctx: HookContext):
             return Skip(result="from-cache")
 
-        agent = _make_agent(mock_llm, hooks=Hooks(before_tool_call=hook))
+        agent = _make_agent(mock_llm, hooks=Hooks(before_tool_call=[hook]))
         save_input = self._drive_workflow_deny_skip(agent, mock_ctx, hook, [tc])
 
         assert save_input is not None
@@ -503,7 +503,7 @@ class TestHookWorkflowDispatch:
             return Proceed()
 
         agent = _make_agent(
-            mock_llm, hooks=Hooks(before_tool_call=hook), with_approval=True
+            mock_llm, hooks=Hooks(before_tool_call=[hook]), with_approval=True
         )
         message = {"task": "delete the repo"}
 
@@ -570,7 +570,7 @@ class TestHookWorkflowDispatch:
             return Proceed()
 
         agent = _make_agent(
-            mock_llm, hooks=Hooks(before_tool_call=hook), with_approval=True
+            mock_llm, hooks=Hooks(before_tool_call=[hook]), with_approval=True
         )
         message = {"task": "delete the repo"}
 
@@ -638,7 +638,7 @@ class TestHookWorkflowDispatch:
                 return Deny(reason="blocked")
             return Proceed()
 
-        agent = _make_agent(mock_llm, hooks=Hooks(before_tool_call=hook))
+        agent = _make_agent(mock_llm, hooks=Hooks(before_tool_call=[hook]))
         message = {"task": "drop the table and get weather"}
 
         run_tool_result = {
@@ -703,7 +703,7 @@ class TestHookWorkflowDispatch:
             source="mcp",
         )
         agent = _make_agent(
-            mock_llm, hooks=Hooks(before_tool_call=hook), tools=[mcp_tool]
+            mock_llm, hooks=Hooks(before_tool_call=[hook]), tools=[mcp_tool]
         )
         tc = _tool_call(name="DeleteRepo", args={"repo": "myrepo"})
         message = {"task": "delete the repo"}

--- a/tests/agents/durableagent/test_hitl_workflow.py
+++ b/tests/agents/durableagent/test_hitl_workflow.py
@@ -1,0 +1,779 @@
+#
+# Copyright 2026 The Dapr Authors
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#     http://www.apache.org/licenses/LICENSE-2.0
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+"""
+Workflow-integration tests for the hook-based human-in-the-loop system.
+
+These tests verify the full dispatch pipeline: hook decision – workflow branch (Deny / Skip / Modify / RequireApproval) – correct tool_results handed to save_tool_results. They reuse the mocking pattern from test_durable_agent.py (patch_dapr_check, mock workflow context).
+"""
+
+import json
+import os
+import uuid
+from datetime import timedelta
+from typing import Optional
+from unittest.mock import AsyncMock, MagicMock, Mock, patch, call
+
+import pytest
+from dapr.ext.workflow import DaprWorkflowContext
+
+from dapr_agents.agents.configs import (
+    AgentApprovalConfig,
+    AgentExecutionConfig,
+    AgentMemoryConfig,
+    AgentPubSubConfig,
+    AgentRegistryConfig,
+    AgentStateConfig,
+    ToolExecutionMode,
+)
+from dapr_agents.agents.durable import DurableAgent
+from dapr_agents.agents.schemas import AgentWorkflowEntry
+from dapr_agents.hooks import (
+    Deny,
+    HookContext,
+    Hooks,
+    Modify,
+    Proceed,
+    RequireApproval,
+    Skip,
+)
+from dapr_agents.llm import OpenAIChatClient
+from dapr_agents.storage.daprstores.stateservice import StateStoreService
+from dapr_agents.tool.base import AgentTool
+
+
+@pytest.fixture(autouse=True)
+def patch_dapr_check(monkeypatch):
+    import dapr.ext.workflow as wf
+
+    mock_runtime = Mock(spec=wf.WorkflowRuntime)
+    monkeypatch.setattr(wf, "WorkflowRuntime", lambda: mock_runtime)
+
+    class MockRetryPolicy:
+        def __init__(
+            self,
+            max_number_of_attempts=1,
+            first_retry_interval=timedelta(seconds=1),
+            max_retry_interval=timedelta(seconds=60),
+            backoff_coefficient=2.0,
+            retry_timeout: Optional[timedelta] = None,
+        ):
+            pass
+
+    monkeypatch.setattr(wf, "RetryPolicy", MockRetryPolicy)
+    yield mock_runtime
+
+
+class MockDaprClient:
+    def __init__(self, *args, **kwargs):
+        self.get_state = MagicMock(return_value=Mock(data=None, json=lambda: {}))
+        self.save_state = MagicMock()
+        self.delete_state = MagicMock()
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, *_):
+        pass
+
+    def __call__(self, *args, **kwargs):
+        return self
+
+    def get_metadata(self):
+        resp = MagicMock()
+        resp.registered_components = []
+        resp.application_id = "test-app"
+        return resp
+
+
+# Shared fixtures                                                              #
+
+
+@pytest.fixture(autouse=True)
+def setup_env(monkeypatch):
+    os.environ["OPENAI_API_KEY"] = "test-key"
+    mock_client = MockDaprClient()
+    monkeypatch.setattr("dapr.clients.DaprClient", lambda *a, **kw: mock_client)
+    monkeypatch.setattr(
+        "dapr_agents.storage.daprstores.statestore.DaprClient",
+        lambda *a, **kw: mock_client,
+    )
+    yield
+    os.environ.pop("OPENAI_API_KEY", None)
+
+
+@pytest.fixture
+def mock_llm():
+    m = Mock(spec=OpenAIChatClient)
+    m.generate = AsyncMock()
+    m.prompt_template = None
+    m.__class__.__name__ = "MockLLMClient"
+    m.provider = "MockProvider"
+    m.api = "MockAPI"
+    m.model = "gpt-4o-mock"
+    return m
+
+
+@pytest.fixture
+def mock_ctx():
+    ctx = DaprWorkflowContext()
+    ctx.instance_id = "wf-hitl-test"
+    ctx.is_replaying = False
+    ctx.call_activity = Mock()
+    ctx.wait_for_external_event = Mock()
+    ctx.create_timer = Mock()
+    ctx.set_custom_status = Mock()
+    ctx.current_utc_datetime = Mock()
+    ctx.current_utc_datetime.isoformat = Mock(return_value="2024-01-01T00:00:00.000000")
+    return ctx
+
+
+def _make_agent(mock_llm, hooks=None, tools=None, with_approval=True):
+    """Build a minimal DurableAgent (no registry, no memory) to keep yield count small."""
+    approval = AgentApprovalConfig(
+        pubsub_name="test-pubsub",
+        topic="test-approvals",
+        default_timeout_seconds=60,
+    )
+    return DurableAgent(
+        name="HookTestAgent",
+        role="Hook Tester",
+        goal="Test hooks",
+        instructions=[],
+        llm=mock_llm,
+        tools=tools or [],
+        pubsub=AgentPubSubConfig(
+            pubsub_name="testpubsub",
+            agent_topic="HookTestAgent",
+        ),
+        state=AgentStateConfig(store=StateStoreService(store_name="teststatestore")),
+        execution=AgentExecutionConfig(
+            max_iterations=3,
+            approval=approval if with_approval else AgentApprovalConfig(),
+            tool_execution_mode=ToolExecutionMode.SEQUENTIAL,
+        ),
+        hooks=hooks,
+    )
+
+
+def _tool_call(name="DeleteOldData", args=None, call_id="call-1"):
+    return {
+        "id": call_id,
+        "function": {
+            "name": name,
+            "arguments": json.dumps(args or {}),
+        },
+    }
+
+
+# Helper: drive agent_workflow, capturing activity calls                       #
+#                                                                              #
+# Minimal agent (no registry, no memory) has these yields:                    #
+#   Y0  call_activity(record_initial_entry)                                   #
+#   Y1  call_activity(call_llm)  – returns assistant_response                 #
+#   [for each tool that runs]:                                                 #
+#   Y?  call_activity(run_tool) (SEQUENTIAL, one at a time)                   #
+#   Y?  call_activity(save_tool_results)                                       #
+#   ...repeat loop if more turns...                                            #
+#   Yn  call_activity(finalize_workflow)                                       #
+#                                                                              #
+# For RequireApproval paths, _request_approval inserts two extra yields       #
+# between call_llm and run_tool / save_tool_results:                          #
+#   Y?  call_activity(publish_approval_request)                               #
+#   Y?  dt.when_any([event_task, timer_task])                                 #
+
+
+def _activity_name(mock_ctx, call_index):
+    """Return the first positional arg (the activity fn) for the Nth call_activity call."""
+    return mock_ctx.call_activity.call_args_list[call_index][0][0]
+
+
+def _activity_input(mock_ctx, call_index):
+    """Return the input kwarg for the Nth call_activity call."""
+    kw = mock_ctx.call_activity.call_args_list[call_index][1]
+    return kw.get("input", {})
+
+
+# Section 1: _request_approval sub-generator                                  #
+
+
+class TestRequestApprovalGenerator:
+    """
+    Drive _request_approval as a standalone generator so we can test the
+    approve/deny/timeout branches without running the full workflow loop.
+    """
+
+    @pytest.fixture
+    def agent(self, mock_llm):
+        return _make_agent(mock_llm, with_approval=True)
+
+    def _run_approval(self, agent, mock_ctx, tool_call, decision, *, winner):
+        """
+        Drive _request_approval to completion.
+
+        `winner` is either `event_task` (human responded) or `timer_task` (timeout).
+        Returns the generator's return value (True / False).
+        """
+        event_task = Mock()
+        timer_task = Mock()
+        mock_ctx.wait_for_external_event.return_value = event_task
+        mock_ctx.create_timer.return_value = timer_task
+
+        if winner == "event":
+            event_task.get_result.return_value = {
+                "approval_request_id": "any",
+                "approved": True,
+            }
+            winning_task = event_task
+        else:
+            winning_task = timer_task
+
+        gen = agent._request_approval(
+            mock_ctx, mock_ctx.instance_id, tool_call, decision
+        )
+
+        with patch("durabletask.task.when_any") as mock_when_any:
+            when_any_future = Mock()
+            mock_when_any.return_value = when_any_future
+
+            next(gen)  # yields call_activity(publish_approval_request)
+            gen.send(None)  # yields dt.when_any(...)
+
+            try:
+                gen.send(winning_task)
+            except StopIteration as exc:
+                return exc.value
+
+        raise AssertionError("generator did not stop")
+
+    def test_event_wins_returns_true(self, agent, mock_ctx):
+        result = self._run_approval(
+            agent,
+            mock_ctx,
+            _tool_call(),
+            RequireApproval(timeout_seconds=30),
+            winner="event",
+        )
+        assert result is True
+
+    def test_timer_wins_returns_false(self, agent, mock_ctx):
+        result = self._run_approval(
+            agent,
+            mock_ctx,
+            _tool_call(),
+            RequireApproval(timeout_seconds=10),
+            winner="timer",
+        )
+        assert result is False
+
+    def test_decision_timeout_takes_priority_over_default(self, agent, mock_ctx):
+        """decision.timeout_seconds overrides the agent-level default."""
+        tool_call = _tool_call()
+        decision = RequireApproval(timeout_seconds=999)
+        gen = agent._request_approval(
+            mock_ctx, mock_ctx.instance_id, tool_call, decision
+        )
+
+        with patch("durabletask.task.when_any", return_value=Mock()):
+            next(gen)
+            gen.send(None)
+            try:
+                gen.send(mock_ctx.create_timer.return_value)
+            except StopIteration:
+                pass
+
+        # create_timer should have been called with the decision's timeout, not the default (60)
+        create_timer_call = mock_ctx.create_timer.call_args
+        assert create_timer_call is not None
+        actual_td = create_timer_call[0][0]
+        assert actual_td == timedelta(seconds=999)
+
+    def test_deterministic_request_id(self, agent, mock_ctx):
+        """Same instance_id + tool_call_id always produces the same approval_request_id."""
+        tc = _tool_call(call_id="call-abc")
+        decision = RequireApproval()
+
+        ids = []
+        for _ in range(2):
+            gen = agent._request_approval(mock_ctx, "fixed-instance", tc, decision)
+            with patch("durabletask.task.when_any", return_value=Mock()):
+                next(gen)
+            # read the input that was passed to publish_approval_request
+            publish_input = mock_ctx.call_activity.call_args[1]["input"]
+            ids.append(publish_input["event"]["approval_request_id"])
+            mock_ctx.call_activity.reset_mock()
+
+        assert ids[0] == ids[1]
+        assert ids[0] == str(uuid.uuid5(uuid.NAMESPACE_DNS, "fixed-instance:call-abc"))
+
+    def test_publish_activity_receives_correct_event_fields(self, agent, mock_ctx):
+        """ApprovalRequiredEvent published to the activity has expected shape."""
+        tc = _tool_call(name="DropTable", args={"table": "users"}, call_id="c-42")
+        decision = RequireApproval(
+            timeout_seconds=120,
+            instructions="please confirm",
+        )
+        gen = agent._request_approval(mock_ctx, mock_ctx.instance_id, tc, decision)
+
+        with patch("durabletask.task.when_any", return_value=Mock()):
+            next(gen)
+
+        publish_input = mock_ctx.call_activity.call_args[1]["input"]
+        event = publish_input["event"]
+        assert event["step_name"] == "DropTable"
+        assert event["step_kind"] == "tool"
+        assert event["tool_arguments"] == {"table": "users"}
+        assert event["timeout_seconds"] == 120
+        assert event["instructions"] == "please confirm"
+        assert publish_input["pubsub_name"] == "test-pubsub"
+        assert publish_input["topic"] == "test-approvals"
+
+
+# Section 2: hook-dispatch in agent_workflow                                   #
+
+
+class TestHookWorkflowDispatch:
+    """
+    Drive agent_workflow through hook-dispatch and verify what ends up in the
+    save_tool_results input. No live Dapr or LLM required.
+
+    Yield sequence for a minimal agent (no registry, no memory):
+      Y0  call_activity(record_initial_entry)
+      Y1  call_activity(call_llm)              → send {"tool_calls": [...]}
+      [Deny/Skip: hook runs sync, no extra yields]
+      Y2  call_activity(save_tool_results)
+      Y3  call_activity(call_llm)              → send final response (no tools)
+      Y4  call_activity(finalize_workflow)     → StopIteration
+
+    NEVER use side_effect=[list] on call_activity. When the list is exhausted,
+    Mock raises StopIteration internally. PEP 479 (Python 3.7+) converts any
+    StopIteration raised inside a generator body to RuntimeError. Drive the
+    generator with gen.send(value) to control what each yield expression
+    evaluates to; call_activity.return_value is left as the default MagicMock.
+    """
+
+    # ------------------------------------------------------------------ #
+    # Helpers                                                              #
+    # ------------------------------------------------------------------ #
+
+    def _drive_workflow_deny_skip(self, agent, mock_ctx, hook_fn, tool_calls_turn1):
+        """
+        Drive agent_workflow for one tool-bearing turn (Deny / Skip path).
+        Returns the input dict passed to save_tool_results.
+        """
+        message = {"task": "do something"}
+        agent._hooks = Hooks(before_tool_call=hook_fn)
+        gen = agent.agent_workflow(mock_ctx, message)
+
+        try:
+            next(gen)  # record_initial_entry
+            gen.send(None)  # call_llm
+            gen.send(
+                {"tool_calls": tool_calls_turn1}
+            )  # → hook deny/skip → save_tool_results
+            gen.send(None)  # call_llm (final turn)
+            gen.send({"role": "assistant", "content": "done"})  # finalize_workflow
+            gen.send(None)  # → StopIteration
+        except StopIteration:
+            pass
+
+        for c in mock_ctx.call_activity.call_args_list:
+            if c[0][0] == agent.save_tool_results:
+                return c[1]["input"]
+
+        return None
+
+    # ------------------------------------------------------------------ #
+    # Deny                                                                 #
+    # ------------------------------------------------------------------ #
+
+    def test_deny_synthesizes_denial_message_run_tool_not_called(
+        self, mock_llm, mock_ctx
+    ):
+        """Hook returning Deny → denial ToolMessage in save_tool_results, run_tool skipped."""
+        tc = _tool_call(name="DropTable", args={"table": "logs"})
+
+        def hook(ctx: HookContext):
+            if ctx.step_name == "DropTable":
+                return Deny(reason="schema changes go through DBA review")
+            return Proceed()
+
+        agent = _make_agent(mock_llm, hooks=Hooks(before_tool_call=hook))
+        save_input = self._drive_workflow_deny_skip(agent, mock_ctx, hook, [tc])
+
+        called_fns = [c[0][0] for c in mock_ctx.call_activity.call_args_list]
+        assert agent.run_tool not in called_fns
+
+        assert save_input is not None
+        results = save_input["tool_results"]
+        assert len(results) == 1
+        assert results[0]["role"] == "tool"
+        assert "not executed" in results[0]["content"]
+        assert "DBA review" in results[0]["content"]
+        assert results[0]["tool_call_id"] == tc["id"]
+
+    def test_deny_records_hook_decision_in_tool_calls_by_id(self, mock_llm, mock_ctx):
+        """Hook-denied tool appears in tool_calls_by_id with hook_decision='denied'."""
+        tc = _tool_call(name="DropTable")
+
+        def hook(ctx: HookContext):
+            return Deny(reason="blocked")
+
+        agent = _make_agent(mock_llm, hooks=Hooks(before_tool_call=hook))
+        save_input = self._drive_workflow_deny_skip(agent, mock_ctx, hook, [tc])
+
+        assert save_input is not None
+        by_id = save_input["tool_calls_by_id"]
+        assert tc["id"] in by_id
+        assert by_id[tc["id"]]["hook_decision"] == "denied"
+
+    # ------------------------------------------------------------------ #
+    # Skip                                                                 #
+    # ------------------------------------------------------------------ #
+
+    def test_skip_uses_hook_result_run_tool_not_called(self, mock_llm, mock_ctx):
+        """Hook returning Skip(result=...) → hook result in tool message, run_tool skipped."""
+        tc = _tool_call(name="GetCachedValue", args={"key": "x"})
+
+        def hook(ctx: HookContext):
+            if ctx.step_name == "GetCachedValue":
+                return Skip(result="cached-42")
+            return Proceed()
+
+        agent = _make_agent(mock_llm, hooks=Hooks(before_tool_call=hook))
+        save_input = self._drive_workflow_deny_skip(agent, mock_ctx, hook, [tc])
+
+        called_fns = [c[0][0] for c in mock_ctx.call_activity.call_args_list]
+        assert agent.run_tool not in called_fns
+
+        assert save_input is not None
+        results = save_input["tool_results"]
+        assert len(results) == 1
+        assert results[0]["content"] == "cached-42"
+        assert results[0]["tool_call_id"] == tc["id"]
+
+    def test_skip_records_hook_decision_in_tool_calls_by_id(self, mock_llm, mock_ctx):
+        """Hook-skipped tool appears in tool_calls_by_id with hook_decision='skipped'."""
+        tc = _tool_call(name="GetCachedValue")
+
+        def hook(ctx: HookContext):
+            return Skip(result="from-cache")
+
+        agent = _make_agent(mock_llm, hooks=Hooks(before_tool_call=hook))
+        save_input = self._drive_workflow_deny_skip(agent, mock_ctx, hook, [tc])
+
+        assert save_input is not None
+        by_id = save_input["tool_calls_by_id"]
+        assert tc["id"] in by_id
+        assert by_id[tc["id"]]["hook_decision"] == "skipped"
+
+    # ------------------------------------------------------------------ #
+    # RequireApproval — timer wins → denial message                        #
+    # ------------------------------------------------------------------ #
+
+    def test_require_approval_timer_wins_denial_message(self, mock_llm, mock_ctx):
+        """
+        When RequireApproval is returned and the timer wins the race, the tool
+        is not executed and a denial ToolMessage is handed to save_tool_results.
+
+        Yield sequence (timer path):
+          Y0  record_initial_entry
+          Y1  call_llm            → {"tool_calls": [tc]}
+          Y2  publish_approval_request (inside _request_approval)
+          Y3  dt.when_any         → send timer_task (winner)
+          Y4  save_tool_results   (timer won → denial → no run_tool)
+          Y5  call_llm            → final response
+          Y6  finalize_workflow   → StopIteration
+        """
+        tc = _tool_call(name="DeleteRepo", args={"repo": "myrepo"})
+
+        def hook(ctx: HookContext):
+            if ctx.step_name == "DeleteRepo":
+                return RequireApproval(timeout_seconds=30)
+            return Proceed()
+
+        agent = _make_agent(
+            mock_llm, hooks=Hooks(before_tool_call=hook), with_approval=True
+        )
+        message = {"task": "delete the repo"}
+
+        timer_task = Mock(name="timer")
+        event_task = Mock(name="event")
+        mock_ctx.wait_for_external_event.return_value = event_task
+        mock_ctx.create_timer.return_value = timer_task
+
+        gen = agent.agent_workflow(mock_ctx, message)
+        save_tool_input = None
+
+        with patch("durabletask.task.when_any", return_value=Mock()):
+            next(gen)  # Y0: record_initial_entry
+            gen.send(None)  # Y1: call_llm
+            gen.send({"tool_calls": [tc]})  # Y2: publish_approval_request
+            gen.send(None)  # Y3: when_any
+            gen.send(timer_task)  # Y4: timer wins → save_tool_results
+            gen.send(None)  # Y5: call_llm (final)
+            try:
+                gen.send({"role": "assistant", "content": "done"})  # Y6: finalize
+                gen.send(None)
+            except StopIteration:
+                pass
+
+        for c in mock_ctx.call_activity.call_args_list:
+            if c[0][0] == agent.save_tool_results:
+                save_tool_input = c[1]["input"]
+                break
+
+        assert save_tool_input is not None
+        results = save_tool_input["tool_results"]
+        assert len(results) == 1
+        assert results[0]["role"] == "tool"
+        assert results[0]["tool_call_id"] == tc["id"]
+        called_fns = [c[0][0] for c in mock_ctx.call_activity.call_args_list]
+        assert agent.run_tool not in called_fns
+
+    # ------------------------------------------------------------------ #
+    # RequireApproval — event wins → tool runs                             #
+    # ------------------------------------------------------------------ #
+
+    def test_require_approval_approved_tool_runs(self, mock_llm, mock_ctx):
+        """
+        When RequireApproval is returned and the external event arrives first
+        (approved=True), run_tool is called for that tool call.
+
+        Yield sequence (approval path):
+          Y0  record_initial_entry
+          Y1  call_llm            → {"tool_calls": [tc]}
+          Y2  publish_approval_request
+          Y3  dt.when_any         → send event_task (winner)
+          Y4  run_tool            → send tool_result
+          Y5  save_tool_results
+          Y6  call_llm            → final response
+          Y7  finalize_workflow   → StopIteration
+        """
+        tc = _tool_call(
+            name="DeleteRepo", args={"repo": "myrepo"}, call_id="c-approved"
+        )
+
+        def hook(ctx: HookContext):
+            if ctx.step_name == "DeleteRepo":
+                return RequireApproval(timeout_seconds=30)
+            return Proceed()
+
+        agent = _make_agent(
+            mock_llm, hooks=Hooks(before_tool_call=hook), with_approval=True
+        )
+        message = {"task": "delete the repo"}
+
+        event_task = Mock(name="event")
+        timer_task = Mock(name="timer")
+        mock_ctx.wait_for_external_event.return_value = event_task
+        mock_ctx.create_timer.return_value = timer_task
+
+        approval_request_id = str(
+            uuid.uuid5(uuid.NAMESPACE_DNS, f"{mock_ctx.instance_id}:{tc['id']}")
+        )
+        event_task.get_result.return_value = {
+            "approval_request_id": approval_request_id,
+            "approved": True,
+        }
+
+        tool_result = {
+            "content": "repo deleted",
+            "role": "tool",
+            "name": "DeleteRepo",
+            "tool_call_id": tc["id"],
+        }
+
+        gen = agent.agent_workflow(mock_ctx, message)
+
+        with patch("durabletask.task.when_any", return_value=Mock()):
+            next(gen)  # Y0: record_initial_entry
+            gen.send(None)  # Y1: call_llm
+            gen.send({"tool_calls": [tc]})  # Y2: publish_approval_request
+            gen.send(None)  # Y3: when_any
+            gen.send(event_task)  # Y4: run_tool (event wins → approved)
+            gen.send(tool_result)  # Y5: save_tool_results
+            gen.send(None)  # Y6: call_llm (final)
+            try:
+                gen.send({"role": "assistant", "content": "done"})  # Y7: finalize
+                gen.send(None)
+            except StopIteration:
+                pass
+
+        called_fns = [c[0][0] for c in mock_ctx.call_activity.call_args_list]
+        assert agent.run_tool in called_fns
+
+    # ------------------------------------------------------------------ #
+    # Mixed: denied + proceed in same turn                                 #
+    # ------------------------------------------------------------------ #
+
+    def test_mixed_denied_and_proceed_same_turn(self, mock_llm, mock_ctx):
+        """
+        Two tool calls in one LLM turn: one Denied, one Proceed.
+        Only the Proceed tool reaches run_tool; both appear in save_tool_results.
+
+        Yield sequence (SEQUENTIAL mode):
+          Y0  record_initial_entry
+          Y1  call_llm           → [tc_deny, tc_run]
+          Y2  run_tool tc_run    (tc_deny handled sync by Deny branch)
+          Y3  save_tool_results
+          Y4  call_llm           → final response
+          Y5  finalize_workflow  → StopIteration
+        """
+        tc_deny = _tool_call(name="DropTable", call_id="c-deny")
+        tc_run = _tool_call(name="GetWeather", args={"city": "NYC"}, call_id="c-run")
+
+        def hook(ctx: HookContext):
+            if ctx.step_name == "DropTable":
+                return Deny(reason="blocked")
+            return Proceed()
+
+        agent = _make_agent(mock_llm, hooks=Hooks(before_tool_call=hook))
+        message = {"task": "drop the table and get weather"}
+
+        run_tool_result = {
+            "content": "NYC: 72F",
+            "role": "tool",
+            "name": "GetWeather",
+            "tool_call_id": tc_run["id"],
+        }
+
+        gen = agent.agent_workflow(mock_ctx, message)
+        save_tool_input = None
+
+        try:
+            next(gen)  # Y0: record_initial_entry
+            gen.send(None)  # Y1: call_llm
+            gen.send({"tool_calls": [tc_deny, tc_run]})  # Y2: run_tool tc_run
+            gen.send(run_tool_result)  # Y3: save_tool_results
+            gen.send(None)  # Y4: call_llm (final)
+            gen.send({"role": "assistant", "content": "done"})  # Y5: finalize
+            gen.send(None)
+        except StopIteration:
+            pass
+
+        for c in mock_ctx.call_activity.call_args_list:
+            if c[0][0] == agent.save_tool_results:
+                save_tool_input = c[1]["input"]
+                break
+
+        assert save_tool_input is not None
+        results = save_tool_input["tool_results"]
+        assert len(results) == 2
+
+        ids = {r["tool_call_id"] for r in results}
+        assert tc_deny["id"] in ids
+        assert tc_run["id"] in ids
+
+        deny_msg = next(r for r in results if r["tool_call_id"] == tc_deny["id"])
+        run_msg = next(r for r in results if r["tool_call_id"] == tc_run["id"])
+        assert "not executed" in deny_msg["content"]
+        assert run_msg["content"] == "NYC: 72F"
+
+    # ------------------------------------------------------------------ #
+    # MCP tool: source forwarded to hook context                           #
+    # ------------------------------------------------------------------ #
+
+    def test_mcp_tool_source_forwarded_to_hook_context(self, mock_llm, mock_ctx):
+        """
+        A tool registered with source='mcp' has ctx.source == 'mcp' when the
+        hook fires. This lets hooks gate MCP tools by source without needing
+        to list individual tool names.
+        """
+        received_contexts = []
+
+        def hook(ctx: HookContext):
+            received_contexts.append(ctx)
+            return Deny(reason="all mcp calls require approval")
+
+        mcp_tool = AgentTool(
+            name="DeleteRepo",
+            description="delete a repo",
+            func=lambda repo: f"deleted {repo}",
+            source="mcp",
+        )
+        agent = _make_agent(
+            mock_llm, hooks=Hooks(before_tool_call=hook), tools=[mcp_tool]
+        )
+        tc = _tool_call(name="DeleteRepo", args={"repo": "myrepo"})
+        message = {"task": "delete the repo"}
+
+        gen = agent.agent_workflow(mock_ctx, message)
+
+        try:
+            next(gen)  # record_initial_entry
+            gen.send(None)  # call_llm
+            gen.send({"tool_calls": [tc]})  # → Deny → save_tool_results
+            gen.send(None)  # call_llm (final)
+            gen.send({"role": "assistant", "content": "done"})  # finalize
+            gen.send(None)
+        except StopIteration:
+            pass
+
+        assert len(received_contexts) >= 1
+        assert received_contexts[0].source == "mcp"
+        assert received_contexts[0].step_kind == "tool"
+
+    # ------------------------------------------------------------------ #
+    # Replay determinism                                                   #
+    # ------------------------------------------------------------------ #
+
+    def test_replay_determinism_hook_called_twice_identical_decisions(self):
+        """
+        Hooks must be pure functions. The same HookContext input must always
+        produce the same decision. This is the replay-safety contract required
+        by Dapr durable task.
+        """
+        call_count = 0
+
+        def stateless_hook(ctx: HookContext):
+            nonlocal call_count
+            call_count += 1
+            if ctx.step_name == "DropTable":
+                return Deny(reason="schema policy")
+            return Proceed()
+
+        ctx1 = HookContext(
+            step_name="DropTable",
+            step_kind="tool",
+            source="local",
+            payload={"table": "users"},
+            tool_call_id="c-1",
+        )
+        ctx2 = HookContext(
+            step_name="DropTable",
+            step_kind="tool",
+            source="local",
+            payload={"table": "users"},
+            tool_call_id="c-1",
+        )
+
+        d1 = stateless_hook(ctx1)
+        d2 = stateless_hook(ctx2)
+
+        assert call_count == 2
+        assert type(d1) is type(d2)
+        assert isinstance(d1, Deny)
+        assert d1.reason == d2.reason
+
+    def test_replay_determinism_proceed_hook(self):
+        """Proceed-returning hook is stable across repeated calls."""
+
+        def passthrough(ctx: HookContext):
+            return Proceed()
+
+        ctx = HookContext("AnyTool", "tool", "local", {}, "c-1")
+        d1 = passthrough(ctx)
+        d2 = passthrough(ctx)
+        assert isinstance(d1, Proceed)
+        assert isinstance(d2, Proceed)

--- a/uv.lock
+++ b/uv.lock
@@ -17,7 +17,7 @@ resolution-markers = [
 ]
 
 [options]
-exclude-newer = "2026-04-20T04:54:10.183806482Z"
+exclude-newer = "2026-04-16T04:34:17.693609358Z"
 exclude-newer-span = "P7D"
 
 [manifest]

--- a/uv.lock
+++ b/uv.lock
@@ -17,7 +17,7 @@ resolution-markers = [
 ]
 
 [options]
-exclude-newer = "2026-04-16T04:34:17.693609358Z"
+exclude-newer = "2026-04-17T08:52:08.711776Z"
 exclude-newer-span = "P7D"
 
 [manifest]


### PR DESCRIPTION
# Description
Adds human-in-the-loop support to DurableAgent. Tools marked `@tool(requires_approval=True)` pause the Dapr workflow, publish an approval request, and only run after a human sends back a decision.

## Issue reference
closes: #162

## Checklist
Please make sure you've completed the relevant tasks for this PR, out of the following list:
* [x] Created/updated tests
* [ ] Tested this change against all the quickstarts
* [ ] Extended the documentation