### PR TITLE
stop over-sanitizing valid names

### DIFF
--- a/dapr_agents/agents/durable.py
+++ b/dapr_agents/agents/durable.py
@@ -2048,7 +2048,7 @@ class DurableAgent(AgentBase):
         registered: List[str] = []
 
         for name, meta in agents_metadata.items():
-            # Normalize name for lookup since AgentTool sanitizes names to TitleCase
+            # Normalize name for lookup: AgentTool strips spec-illegal chars at registration
             sanitized_name = sanitize_openai_tool_name(name)
             if not self.tool_executor.get_tool(sanitized_name):
                 # Defensive check: ensure meta is a dict

--- a/dapr_agents/tool/executor.py
+++ b/dapr_agents/tool/executor.py
@@ -47,8 +47,13 @@ class AgentToolExecutor(BaseModel):
 
     @staticmethod
     def _normalize(name: str) -> str:
-        """Normalize a tool name: lowercase, strip spaces and underscores."""
-        return name.lower().replace(" ", "").replace("_", "")
+        """Normalize a tool name for fuzzy lookup.
+
+        Lowercases and strips spaces, underscores, and hyphens so that
+        ``TestTool``, ``test-tool``, and ``test`` all resolve
+        to the same key (``testtool``).
+        """
+        return name.lower().replace(" ", "").replace("_", "").replace("-", "")
 
     def register_tool(self, tool: Union[AgentTool, Callable]) -> None:
         """

--- a/dapr_agents/tool/executor.py
+++ b/dapr_agents/tool/executor.py
@@ -47,13 +47,8 @@ class AgentToolExecutor(BaseModel):
 
     @staticmethod
     def _normalize(name: str) -> str:
-        """Normalize a tool name for fuzzy lookup.
-
-        Lowercases and strips spaces, underscores, and hyphens so that
-        ``TestTool``, ``test-tool``, and ``test`` all resolve
-        to the same key (``testtool``).
-        """
-        return name.lower().replace(" ", "").replace("_", "").replace("-", "")
+        """Normalize a tool name: lowercase, strip spaces and underscores."""
+        return name.lower().replace(" ", "").replace("_", "")
 
     def register_tool(self, tool: Union[AgentTool, Callable]) -> None:
         """

--- a/dapr_agents/tool/utils/function_calling.py
+++ b/dapr_agents/tool/utils/function_calling.py
@@ -29,7 +29,7 @@ logger = logging.getLogger(__name__)
 # OpenAI and Anthropic both require tool names to match ^[a-zA-Z0-9_-]{1,64}$.
 # Only letters, digits, underscores, and hyphens are allowed.
 # Everything else (spaces, dots, slashes, special symbols, non-ASCII) is stripped.
-_VALID_TOOL_NAME_CHARS = re.compile(r"[^a-zA-Z0-9_-]")
+_INVALID_TOOL_NAME_CHARS = re.compile(r"[^a-zA-Z0-9_-]")
 _MAX_TOOL_NAME_LENGTH = 64
 
 
@@ -66,7 +66,7 @@ def sanitize_openai_tool_name(name: str) -> str:
     if not name:
         return "unnamed_tool"
 
-    sanitized = _VALID_TOOL_NAME_CHARS.sub("", name)
+    sanitized = _INVALID_TOOL_NAME_CHARS.sub("", name)
 
     if not sanitized:
         return "unnamed_tool"

--- a/dapr_agents/tool/utils/function_calling.py
+++ b/dapr_agents/tool/utils/function_calling.py
@@ -26,93 +26,67 @@ from dapr_agents.types.exceptions import FunCallBuilderError
 
 logger = logging.getLogger(__name__)
 
-# OpenAI tool name pattern: ^[^\s<|\\/>]+$
-# Tool names cannot contain: spaces, <, |, \, /, >
-_OPENAI_TOOL_NAME_PATTERN = re.compile(r"[^\s<|\\/>]+")
-
-
-def _normalize_to_title_case(name: str) -> str:
-    """
-    Normalize a name to TitleCase format.
-
-    Converts snake_case, kebab-case, and space-separated names to TitleCase.
-    Examples:
-        "get_user" -> "GetUser"
-        "get-user" -> "GetUser"
-        "get user" -> "GetUser"
-        "GetUser" -> "GetUser" (already title case, preserved)
-        "GET_USER" -> "GetUser"
-        "UPPERCASE" -> "Uppercase" (all uppercase converted)
-        "mixed_Case_name" -> "MixedCaseName"
-        "SamwiseGamgee" -> "SamwiseGamgee" (already TitleCase, preserved)
-
-    Args:
-        name: The original name
-
-    Returns:
-        A TitleCase normalized name (no separators)
-    """
-    if not name:
-        return ""
-
-    # Check if name is all uppercase (needs conversion to TitleCase)
-    # This must come before the TitleCase check to handle "UPPERCASE" -> "Uppercase"
-    if name.isupper() and len(name) > 1:
-        return name.capitalize()
-
-    # Check if name is already TitleCase (no separators, starts with uppercase, has lowercase)
-    # This handles cases like "SamwiseGamgee" or "GetUser" that are already correct
-    # We check for at least one lowercase letter to distinguish from all-uppercase
-    if re.match(r"^[A-Z][a-z]", name) and not re.search(r"[_\s-]", name):
-        return name
-
-    # Split on common separators (underscores, hyphens, spaces)
-    parts = re.split(r"[_\s-]+", name)
-
-    # Capitalize each part and join (no separators)
-    # Use capitalize() which makes first char uppercase and rest lowercase
-    title_parts = [part.capitalize() for part in parts if part]
-
-    return "".join(title_parts)
+# OpenAI and Anthropic both require tool names to match ^[a-zA-Z0-9_-]{1,64}$.
+# Only letters, digits, underscores, and hyphens are allowed.
+# Everything else (spaces, dots, slashes, special symbols, non-ASCII) is stripped.
+_VALID_TOOL_NAME_CHARS = re.compile(r"[^a-zA-Z0-9_-]")
+_MAX_TOOL_NAME_LENGTH = 64
 
 
 def sanitize_openai_tool_name(name: str) -> str:
     """
-    Sanitize a name to comply with OpenAI's name requirements.
+    Sanitize a name to comply with OpenAI/Anthropic tool-name requirements.
 
-    OpenAI requires names to match the pattern: ^[^\\s<|\\\\/>]+$
-    This means names cannot contain spaces, <, |, \\, /, or >.
-
-    All names (tool names, agent names, etc.) are normalized to TitleCase format,
-    removing all separators (spaces, underscores, hyphens) and capitalizing each word.
+    Provider APIs require tool names to match ``^[a-zA-Z0-9_-]{1,64}$``.
+    Any character outside that set is stripped. Hyphens, underscores, and
+    the original casing are preserved so that a valid name such as
+    ``get-xyz-count`` reaches the LLM unchanged — matching what developers
+    write in YAML/config and what ``toolbox_core.ToolboxTool`` exposes as
+    the tool's name.
 
     Args:
-        name: The original name (e.g., "get_user", "Samwise Gamgee", "agent<name>")
+        name: The original name (e.g., ``get-items``, ``My Agent``,
+            ``agent<name>``).
 
     Returns:
-        A sanitized name in TitleCase format with invalid characters removed.
-        Examples:
-            "get_user" -> "GetUser"
-            "Samwise Gamgee" -> "SamwiseGamgee"
-            "agent<name>" -> "Agentname"
+        A sanitized name with only invalid characters removed. Returns
+        ``"unnamed_tool"`` if the input is empty or becomes empty after
+        sanitization.
+
+    Raises:
+        ValueError: If the sanitized name exceeds 64 characters.
+
+    Examples:
+        ``get-xyz-count`` -> ``get-xyz-count``
+        ``get_user`` -> ``get_user``
+        ``My Agent`` -> ``MyAgent``
+        ``agent<name>`` -> ``agentname``
+        ``café_finder`` -> ``caf_finder``
     """
     if not name:
         return "unnamed_tool"
 
-    # Normalize to TitleCase (converts snake_case, kebab-case, space-separated to TitleCase)
-    # This removes all separators and capitalizes each word
-    sanitized = _normalize_to_title_case(name)
+    sanitized = _VALID_TOOL_NAME_CHARS.sub("", name)
 
     if not sanitized:
         return "unnamed_tool"
 
-    # Replace invalid characters (<, |, \, /, >) with empty string (remove them)
-    # Since we're already in TitleCase, we don't want to introduce underscores
-    sanitized = re.sub(r"[<|\\/>]", "", sanitized)
+    if len(sanitized) > _MAX_TOOL_NAME_LENGTH:
+        raise ValueError(
+            f"Tool/agent name '{name}' is {len(sanitized)} characters after "
+            f"sanitization (max {_MAX_TOOL_NAME_LENGTH}). Shorten the name "
+            f"to fit within the limit."
+        )
 
-    # Ensure it's not empty after sanitization
-    if not sanitized:
-        sanitized = "unnamed_tool"
+    if sanitized != name:
+        logger.warning(
+            "Tool/agent name '%s' contained characters rejected by the "
+            "OpenAI/Anthropic tool-name spec (^[a-zA-Z0-9_-]{1,64}$); "
+            "sanitized to '%s'. Update any instruction strings that "
+            "reference the original name.",
+            name,
+            sanitized,
+        )
 
     return sanitized
 

--- a/dapr_agents/tool/workflow/agent_tool.py
+++ b/dapr_agents/tool/workflow/agent_tool.py
@@ -197,12 +197,15 @@ def agent_to_tool(
     Args:
         agent_name: The name of the target agent (e.g., ``"catering-coordinator"``).
             This value is used to derive the tool name exposed to the LLM.
-            The underlying :class:`AgentTool` only strips characters rejected
-            by the OpenAI/Anthropic tool-name specs (whitespace, ``<``, ``|``,
-            ``\\``, ``/``, ``>``); hyphens, underscores, and the original
-            casing are preserved, so ``"catering-coordinator"`` reaches the
-            LLM as ``catering-coordinator`` and ``"my agent"`` becomes
-            ``"myagent"``.
+            The underlying :class:`AgentTool` sanitizes the name to satisfy
+            the OpenAI/Anthropic tool-name constraints, preserving only ASCII
+            letters, digits, underscores, and hyphens. Other characters,
+            including whitespace, punctuation such as ``.`` or ``:``, and
+            non-ASCII characters, are removed. Hyphens, underscores, and the
+            original casing are preserved when valid, so
+            ``"catering-coordinator"`` reaches the LLM as
+            ``catering-coordinator`` and ``"my agent:v2"`` becomes
+            ``"myagentv2"``.
         description: Human-readable description shown to the LLM in the tool
             schema (e.g. ``"Ring-bearer. Goal: carry the One Ring to Mordor."``).
         agent_type: Framework/type prefix for the workflow name (e.g. "strands",

--- a/dapr_agents/tool/workflow/agent_tool.py
+++ b/dapr_agents/tool/workflow/agent_tool.py
@@ -49,7 +49,7 @@ def agent_workflow_id(
     - Explicit workflow names passed directly
 
     Args:
-        agent_name: The agent name (e.g., "catering-coordinator", "Samwise Gamgee")
+        agent_name: The agent name (e.g., "catering-coordinator", "My Agent")
         framework: Optional framework name (e.g., "openai", "pydantic_ai", "langgraph", "crewai").
             If None or "Dapr Agents", uses the standard dapr.agents.* format.
         workflow_name: Optional explicit workflow name. If provided, this takes precedence
@@ -196,11 +196,13 @@ def agent_to_tool(
 
     Args:
         agent_name: The name of the target agent (e.g., ``"catering-coordinator"``).
-            This value is used to derive the tool name exposed to the LLM; the
-            underlying :class:`AgentTool` normalizes it (title-casing, removing
-            spaces and underscores), so e.g. ``"my agent"`` becomes ``"MyAgent"``.
-            It should correspond to the agent's registered name under this
-            normalization, rather than needing to match character-for-character.
+            This value is used to derive the tool name exposed to the LLM.
+            The underlying :class:`AgentTool` only strips characters rejected
+            by the OpenAI/Anthropic tool-name specs (whitespace, ``<``, ``|``,
+            ``\\``, ``/``, ``>``); hyphens, underscores, and the original
+            casing are preserved, so ``"catering-coordinator"`` reaches the
+            LLM as ``catering-coordinator`` and ``"my agent"`` becomes
+            ``"myagent"``.
         description: Human-readable description shown to the LLM in the tool
             schema (e.g. ``"Ring-bearer. Goal: carry the One Ring to Mordor."``).
         agent_type: Framework/type prefix for the workflow name (e.g. "strands",
@@ -236,7 +238,7 @@ def agent_to_tool(
             "Coordinates catering services.",
             framework="openai",
         )
-        # This will call workflow: dapr.openai.CateringCoordinator.workflow
+        # This will call workflow: dapr.openai.catering-coordinator.workflow
     """
     executor = functools.partial(
         _schedule_agent_workflow,

--- a/tests/tool/test_agent_workflow_tool.py
+++ b/tests/tool/test_agent_workflow_tool.py
@@ -352,10 +352,7 @@ class TestAgentToTool:
         assert sanitize_openai_tool_name("search:query") == "searchquery"
 
         # Hyphens, underscores, and casing are preserved verbatim
-        assert (
-            sanitize_openai_tool_name("get-xyz-count")
-            == "get-xyz-count"
-        )
+        assert sanitize_openai_tool_name("get-xyz-count") == "get-xyz-count"
         assert sanitize_openai_tool_name("get_user") == "get_user"
         assert sanitize_openai_tool_name("valid_name") == "valid_name"
         assert sanitize_openai_tool_name("tool___name") == "tool___name"
@@ -379,11 +376,12 @@ class TestAgentToTool:
         assert sanitize_openai_tool_name("@#$%") == "unnamed_tool"
 
     def test_sanitize_openai_tool_name_logs_warning_on_change(self, caplog):
-        """A WARNING should be emitted whenever sanitization mutates the name.
-        """
+        """A WARNING should be emitted whenever sanitization mutates the name."""
         import logging
 
-        with caplog.at_level(logging.WARNING, logger="dapr_agents.tool.utils.function_calling"):
+        with caplog.at_level(
+            logging.WARNING, logger="dapr_agents.tool.utils.function_calling"
+        ):
             result = sanitize_openai_tool_name("Randomagee Geegee")
         assert result == "RandomageeGeegee"
         assert any(
@@ -393,11 +391,10 @@ class TestAgentToTool:
 
         # No warning when the name is already valid (including kebab-case)
         caplog.clear()
-        with caplog.at_level(logging.WARNING, logger="dapr_agents.tool.utils.function_calling"):
-            assert (
-                sanitize_openai_tool_name("get-xyz-count")
-                == "get-xyz-count"
-            )
+        with caplog.at_level(
+            logging.WARNING, logger="dapr_agents.tool.utils.function_calling"
+        ):
+            assert sanitize_openai_tool_name("get-xyz-count") == "get-xyz-count"
         assert not caplog.records, (
             "Valid kebab-case names must not trigger a sanitization warning"
         )

--- a/tests/tool/test_agent_workflow_tool.py
+++ b/tests/tool/test_agent_workflow_tool.py
@@ -34,9 +34,9 @@ class TestAgentWorkflowSuffix:
         assert AGENT_WORKFLOW_SUFFIX == "_agent_workflow"  # backward compat
 
     def test_agent_workflow_id(self):
-        # Agent names are sanitized to TitleCase for OpenAI compliance
-        assert agent_workflow_id("sam") == "dapr.agents.Sam.workflow"
-        assert agent_workflow_id("frodo") == "dapr.agents.Frodo.workflow"
+        # Valid agent names are preserved verbatim (casing, hyphens, underscores).
+        assert agent_workflow_id("sam") == "dapr.agents.sam.workflow"
+        assert agent_workflow_id("frodo") == "dapr.agents.frodo.workflow"
 
     def test_agent_workflow_id_with_full_workflow_name(self):
         """Test that full workflow names are returned as-is."""
@@ -46,47 +46,47 @@ class TestAgentWorkflowSuffix:
         full_name2 = "dapr.pydantic_ai.decoration-planner.workflow"
         assert agent_workflow_id(full_name2) == full_name2
 
-        # Legacy format should still work (agent name sanitized to TitleCase)
+        # Legacy format: kebab-case agent names are preserved verbatim
         assert (
             agent_workflow_id("catering-coordinator")
-            == "dapr.agents.CateringCoordinator.workflow"
+            == "dapr.agents.catering-coordinator.workflow"
         )
 
     def test_agent_workflow_id_with_framework(self):
-        """Test that framework parameter constructs correct workflow names."""
-        # Agent names are sanitized to TitleCase for OpenAI compliance
-        # OpenAI framework
+        """Test that framework parameter constructs correct workflow names.
+
+        Agent names are preserved verbatim (hyphens/underscores/casing) —
+        only characters rejected by the OpenAI/Anthropic tool-name specs
+        are stripped.
+        """
         assert (
             agent_workflow_id("catering-coordinator", framework="openai")
-            == "dapr.openai.CateringCoordinator.workflow"
+            == "dapr.openai.catering-coordinator.workflow"
         )
 
-        # Pydantic AI framework
         assert (
             agent_workflow_id("decoration-planner", framework="pydantic_ai")
-            == "dapr.pydantic-ai.DecorationPlanner.workflow"
+            == "dapr.pydantic-ai.decoration-planner.workflow"
         )
 
-        # LangGraph framework
         assert (
             agent_workflow_id("schedule-planner", framework="langgraph")
-            == "dapr.langgraph.SchedulePlanner.workflow"
+            == "dapr.langgraph.schedule-planner.workflow"
         )
 
-        # CrewAI framework
         assert (
             agent_workflow_id("venue-scout", framework="crewai")
-            == "dapr.crewai.VenueScout.workflow"
+            == "dapr.crewai.venue-scout.workflow"
         )
 
         # Dapr Agents framework (should use standard format)
         assert (
             agent_workflow_id("sam", framework="Dapr Agents")
-            == "dapr.agents.Sam.workflow"
+            == "dapr.agents.sam.workflow"
         )
 
         # None framework (should use standard format)
-        assert agent_workflow_id("sam", framework=None) == "dapr.agents.Sam.workflow"
+        assert agent_workflow_id("sam", framework=None) == "dapr.agents.sam.workflow"
 
     def test_agent_workflow_id_with_explicit_workflow_name(self):
         """Test that explicit workflow_name takes precedence."""
@@ -109,20 +109,20 @@ class TestAgentWorkflowSuffix:
         )
 
     def test_agent_workflow_id_with_strands_framework(self):
-        """Strands framework uses TitleCase sanitized names."""
+        """Kebab-case agent names are preserved verbatim."""
         assert (
             agent_workflow_id("strands-default", framework="strands")
-            == "dapr.strands.StrandsDefault.workflow"
+            == "dapr.strands.strands-default.workflow"
         )
         assert (
             agent_workflow_id("my-agent", framework="Strands")
-            == "dapr.strands.MyAgent.workflow"
+            == "dapr.strands.my-agent.workflow"
         )
 
     def test_agent_workflow_id_langgraph(self):
         assert (
             agent_workflow_id("schedule-planner", framework="CompiledStateGraph")
-            == "dapr.compiledstategraph.SchedulePlanner.workflow"
+            == "dapr.compiledstategraph.schedule-planner.workflow"
         )
 
 
@@ -165,7 +165,7 @@ class TestScheduleAgentWorkflow:
             framework="strands",
         )
         ctx.call_child_workflow.assert_called_once_with(
-            workflow="dapr.strands.StrandsDefault.workflow",
+            workflow="dapr.strands.strands-default.workflow",
             input={"task": "estimate costs"},
         )
 
@@ -185,9 +185,9 @@ class TestScheduleAgentWorkflow:
             agent_name="catering-coordinator",
             framework="openai",
         )
-        # Agent name is sanitized to TitleCase for OpenAI compliance
+        # Hyphens are valid per OpenAI/Anthropic specs and preserved verbatim
         ctx.call_child_workflow.assert_called_once_with(
-            workflow="dapr.openai.CateringCoordinator.workflow",
+            workflow="dapr.openai.catering-coordinator.workflow",
             input={"task": "coordinate catering"},
         )
 
@@ -288,9 +288,9 @@ class TestAgentToTool:
         )
         ctx = MagicMock()
         tool(ctx=ctx, task="Plan the menu")
-        # Agent name is sanitized to TitleCase for OpenAI compliance
+        # Hyphens are valid per OpenAI/Anthropic specs and preserved verbatim
         ctx.call_child_workflow.assert_called_once_with(
-            workflow="dapr.openai.CateringCoordinator.workflow",
+            workflow="dapr.openai.catering-coordinator.workflow",
             input={"task": "Plan the menu"},
         )
         assert tool.target_agent_name == "catering-coordinator"
@@ -311,53 +311,102 @@ class TestAgentToTool:
         )
 
     def test_agent_to_tool_sanitizes_name_with_spaces(self):
-        """Test that agent names with spaces are sanitized for OpenAI compatibility."""
-        tool = agent_to_tool("Samwise Gamgee", "Helper.")
-        # Tool name should be sanitized to TitleCase (spaces removed, no separators)
-        assert tool.name == "SamwiseGamgee"
+        """Test that agent names with spaces have the spaces stripped."""
+        tool = agent_to_tool("Randomagee Geegee", "Helper.")
+        # Whitespace is stripped; original casing is preserved.
+        assert tool.name == "RandomageeGeegee"
 
-        # Verify the sanitized name is used in OpenAI function call format
         function_call = tool.to_function_call()
-        assert function_call["function"]["name"] == "SamwiseGamgee"
+        assert function_call["function"]["name"] == "RandomageeGeegee"
 
     def test_agent_to_tool_sanitizes_name_with_special_chars(self):
-        """Test that agent names with special characters are sanitized."""
+        """Test that agent names with invalid characters have them stripped."""
         tool = agent_to_tool("agent<name>", "Test agent.")
-        # Special characters are removed, name converted to TitleCase
-        assert tool.name == "Agentname"
+        # Only the invalid characters (<, >) are removed; casing preserved.
+        assert tool.name == "agentname"
 
         function_call = tool.to_function_call()
-        assert function_call["function"]["name"] == "Agentname"
+        assert function_call["function"]["name"] == "agentname"
 
     def test_sanitize_openai_tool_name(self):
-        """Test the sanitize_openai_tool_name function directly."""
-        # Names are normalized to TitleCase (no separators) and invalid chars removed
-        assert sanitize_openai_tool_name("Samwise Gamgee") == "SamwiseGamgee"
-        assert sanitize_openai_tool_name("agent<name>") == "Agentname"
-        assert sanitize_openai_tool_name("tool|name") == "Toolname"
-        assert sanitize_openai_tool_name("tool\\name") == "Toolname"
-        assert sanitize_openai_tool_name("tool/name") == "Toolname"
-        assert sanitize_openai_tool_name("tool>name") == "Toolname"
-        assert sanitize_openai_tool_name("tool  name") == "ToolName"  # Multiple spaces
+        """Test the sanitize_openai_tool_name function directly.
+
+        Provider APIs require tool names to match ``^[a-zA-Z0-9_-]{1,64}$``.
+        Any character outside that set is stripped. Hyphens, underscores,
+        and the original casing must be preserved so developer-written names
+        (e.g. kebab-case YAML keys) reach the LLM unchanged.
+        """
+        # Characters outside [a-zA-Z0-9_-] are stripped
+        assert sanitize_openai_tool_name("Randomagee Geegee") == "RandomageeGeegee"
+        assert sanitize_openai_tool_name("agent<name>") == "agentname"
+        assert sanitize_openai_tool_name("tool|name") == "toolname"
+        assert sanitize_openai_tool_name("tool\\name") == "toolname"
+        assert sanitize_openai_tool_name("tool/name") == "toolname"
+        assert sanitize_openai_tool_name("tool>name") == "toolname"
+        assert sanitize_openai_tool_name("tool  name") == "toolname"
+
+        # Dots, special symbols, non-ASCII are stripped
+        assert sanitize_openai_tool_name("my.tool.name") == "mytoolname"
+        assert sanitize_openai_tool_name("tool!@#$%^&*()") == "tool"
+        assert sanitize_openai_tool_name("café_finder") == "caf_finder"
+        assert sanitize_openai_tool_name("search:query") == "searchquery"
+
+        # Hyphens, underscores, and casing are preserved verbatim
         assert (
-            sanitize_openai_tool_name("tool___name") == "ToolName"
-        )  # Multiple underscores
-        assert (
-            sanitize_openai_tool_name("_tool_name_") == "ToolName"
-        )  # Leading/trailing
-        assert sanitize_openai_tool_name("") == "unnamed_tool"  # Empty string
-        assert (
-            sanitize_openai_tool_name("valid_name") == "ValidName"
-        )  # Converted to TitleCase
-        assert (
-            sanitize_openai_tool_name("get_user") == "GetUser"
-        )  # snake_case -> TitleCase
+            sanitize_openai_tool_name("get-xyz-count")
+            == "get-xyz-count"
+        )
+        assert sanitize_openai_tool_name("get_user") == "get_user"
+        assert sanitize_openai_tool_name("valid_name") == "valid_name"
+        assert sanitize_openai_tool_name("tool___name") == "tool___name"
+        assert sanitize_openai_tool_name("_tool_name_") == "_tool_name_"
+        assert sanitize_openai_tool_name("GetUser") == "GetUser"
+        assert sanitize_openai_tool_name("RandomageeGeegee") == "RandomageeGeegee"
+        assert sanitize_openai_tool_name("UPPERCASE") == "UPPERCASE"
+
+        # Names exceeding 64 characters raise ValueError
+        with pytest.raises(ValueError, match="65 characters"):
+            sanitize_openai_tool_name("a" * 65)
+
+        # Exactly 64 is fine
+        assert sanitize_openai_tool_name("a" * 64) == "a" * 64
+
+        # Fallback cases
+        assert sanitize_openai_tool_name("") == "unnamed_tool"
+        assert sanitize_openai_tool_name("   ") == "unnamed_tool"
+        assert sanitize_openai_tool_name("<|\\/>") == "unnamed_tool"
+        assert sanitize_openai_tool_name("...") == "unnamed_tool"
+        assert sanitize_openai_tool_name("@#$%") == "unnamed_tool"
+
+    def test_sanitize_openai_tool_name_logs_warning_on_change(self, caplog):
+        """A WARNING should be emitted whenever sanitization mutates the name.
+        """
+        import logging
+
+        with caplog.at_level(logging.WARNING, logger="dapr_agents.tool.utils.function_calling"):
+            result = sanitize_openai_tool_name("Randomagee Geegee")
+        assert result == "RandomageeGeegee"
+        assert any(
+            "Randomagee Geegee" in rec.message and "RandomageeGeegee" in rec.message
+            for rec in caplog.records
+        ), "Expected a WARNING containing both original and sanitized names"
+
+        # No warning when the name is already valid (including kebab-case)
+        caplog.clear()
+        with caplog.at_level(logging.WARNING, logger="dapr_agents.tool.utils.function_calling"):
+            assert (
+                sanitize_openai_tool_name("get-xyz-count")
+                == "get-xyz-count"
+            )
+        assert not caplog.records, (
+            "Valid kebab-case names must not trigger a sanitization warning"
+        )
 
     def test_tool_with_custom_framework(self):
         tool = agent_to_tool("strands-default", "Budget analyst.", framework="strands")
         ctx = MagicMock()
         tool(ctx=ctx, task="Estimate costs")
         ctx.call_child_workflow.assert_called_once_with(
-            workflow="dapr.strands.StrandsDefault.workflow",
+            workflow="dapr.strands.strands-default.workflow",
             input={"task": "Estimate costs"},
         )

--- a/tests/tool/test_toolbox.py
+++ b/tests/tool/test_toolbox.py
@@ -417,32 +417,11 @@ class TestFromToolboxEdgeCases:
 
 
 class TestExecutorFuzzyLookup:
-    """The tool executor must resolve tool names regardless of whether the
-    caller uses kebab-case, snake_case, or the legacy TitleCase form produced
-    by the old ``_normalize_to_title_case`` helper.
-
-    This matters for backwards compatibility: LLMs that were previously shown
-    the TitleCase name (e.g. ``TestTool``) may continue to emit it even
-    after the sanitization fix preserves the original ``test-tool``.
+    """The tool executor normalizes names (lowercase, strip spaces/underscores)
+    so that case and underscore variations resolve to the same tool.
     """
 
-    def test_kebab_and_titlecase_resolve_to_same_tool(self):
-        from dapr_agents.tool.executor import AgentToolExecutor
-
-        def dummy(**kwargs):
-            return "ok"
-
-        tool = AgentTool(name="test-tool", description="test", func=dummy)
-        executor = AgentToolExecutor(tools=[tool])
-
-        # All of these should find the same tool
-        assert executor.get_tool("test-tool") is tool
-        assert executor.get_tool("TestTool") is tool
-        assert executor.get_tool("test_tool") is tool
-        assert executor.get_tool("TEST-TOOL") is tool
-        assert executor.get_tool("testtool") is tool
-
-    def test_snake_case_and_titlecase_resolve_to_same_tool(self):
+    def test_case_insensitive_lookup(self):
         from dapr_agents.tool.executor import AgentToolExecutor
 
         def dummy(**kwargs):
@@ -452,7 +431,21 @@ class TestExecutorFuzzyLookup:
         executor = AgentToolExecutor(tools=[tool])
 
         assert executor.get_tool("get_user") is tool
-        assert executor.get_tool("GetUser") is tool
         assert executor.get_tool("GET_USER") is tool
-        assert executor.get_tool("get-user") is tool
         assert executor.get_tool("getuser") is tool
+        assert executor.get_tool("Get_User") is tool
+
+    def test_kebab_case_is_distinct(self):
+        """Hyphens are meaningful — ``get-user`` and ``get_user`` are different tools."""
+        from dapr_agents.tool.executor import AgentToolExecutor
+
+        def dummy(**kwargs):
+            return "ok"
+
+        tool = AgentTool(name="get-user", description="test", func=dummy)
+        executor = AgentToolExecutor(tools=[tool])
+
+        assert executor.get_tool("get-user") is tool
+        assert executor.get_tool("GET-USER") is tool
+        # Underscore variant is a different normalized key
+        assert executor.get_tool("get_user") is None

--- a/tests/tool/test_toolbox.py
+++ b/tests/tool/test_toolbox.py
@@ -66,7 +66,11 @@ class TestFromToolbox:
 
         agent_tool = AgentTool.from_toolbox(mock_tool)
 
-        assert agent_tool.name == "GetUser"  # Normalized name
+        # Valid names (underscores allowed by the spec) are preserved verbatim —
+        # this matters for parity with toolbox_core.ToolboxTool._name, which
+        # returns the YAML key unchanged, so instruction strings referencing
+        # the YAML key still match the registered tool.
+        assert agent_tool.name == "get_user"
         assert agent_tool.description == "Fetches a user by ID"
         assert agent_tool.args_model is not None
         assert "user_id" in agent_tool.args_model.model_fields
@@ -106,7 +110,7 @@ class TestFromToolbox:
 
         agent_tool = AgentTool.from_toolbox(mock_tool)
 
-        assert agent_tool.name == "GetCurrentTime"
+        assert agent_tool.name == "get_current_time"
         assert agent_tool.description == "Returns the current server time"
         # Should have an empty args model, not None
         assert agent_tool.args_model is not None
@@ -124,7 +128,7 @@ class TestFromToolbox:
 
         agent_tool = AgentTool.from_toolbox(mock_tool)
 
-        assert agent_tool.name == "Ping"
+        assert agent_tool.name == "ping"
         # Should have an empty args model even when params is None
         assert agent_tool.args_model is not None
 
@@ -212,12 +216,18 @@ class TestFromToolbox:
         assert "ValidationError" in result.content[0].text
 
     def test_name_normalization(self):
-        """Test that tool names are properly normalized."""
+        """Tool names are preserved verbatim when they contain only spec-legal
+        characters (letters, digits, underscores, hyphens). Only characters
+        the OpenAI/Anthropic APIs actually reject are stripped.
+        """
         test_cases = [
-            ("get_user_by_id", "GetUserById"),
-            ("simple", "Simple"),
-            ("UPPERCASE", "Uppercase"),
-            ("mixed_Case_name", "MixedCaseName"),
+            ("get_user_by_id", "get_user_by_id"),
+            ("get-xyz-count", "get-xyz-count"),
+            ("simple", "simple"),
+            ("UPPERCASE", "UPPERCASE"),
+            ("mixed_Case_name", "mixed_Case_name"),
+            ("agent<name>", "agentname"),
+            ("Randomagee Geegee", "RandomageeGeegee"),
         ]
 
         for original, expected in test_cases:
@@ -262,9 +272,9 @@ class TestFromToolboxMany:
 
         assert len(agent_tools) == 3
         assert all(isinstance(t, AgentTool) for t in agent_tools)
-        assert agent_tools[0].name == "ToolOne"
-        assert agent_tools[1].name == "ToolTwo"
-        assert agent_tools[2].name == "ToolThree"
+        assert agent_tools[0].name == "tool_one"
+        assert agent_tools[1].name == "tool_two"
+        assert agent_tools[2].name == "tool_three"
 
     def test_empty_list(self):
         """Test conversion of empty list."""
@@ -284,7 +294,7 @@ class TestFromToolboxMany:
         agent_tools = AgentTool.from_toolbox_many(mock_tools)
 
         assert len(agent_tools) == 1
-        assert agent_tools[0].name == "OnlyTool"
+        assert agent_tools[0].name == "only_tool"
 
 
 class TestFromToolboxIntegration:
@@ -388,7 +398,12 @@ class TestFromToolboxEdgeCases:
         assert "<html>" in agent_tool.description
 
     def test_unicode_in_tool_name_and_description(self):
-        """Test tool with unicode characters."""
+        """Test tool with unicode characters.
+
+        Non-ASCII characters in the name are stripped by sanitization
+        (OpenAI/Anthropic require ^[a-zA-Z0-9_-]{1,64}$), but the
+        description is passed through unchanged.
+        """
         mock_tool = MockToolboxSyncTool(
             name="café_finder",
             description="Finds nearby cafés ☕",
@@ -397,4 +412,47 @@ class TestFromToolboxEdgeCases:
 
         agent_tool = AgentTool.from_toolbox(mock_tool)
 
+        assert agent_tool.name == "caf_finder"
         assert "☕" in agent_tool.description
+
+
+class TestExecutorFuzzyLookup:
+    """The tool executor must resolve tool names regardless of whether the
+    caller uses kebab-case, snake_case, or the legacy TitleCase form produced
+    by the old ``_normalize_to_title_case`` helper.
+
+    This matters for backwards compatibility: LLMs that were previously shown
+    the TitleCase name (e.g. ``TestTool``) may continue to emit it even
+    after the sanitization fix preserves the original ``test-tool``.
+    """
+
+    def test_kebab_and_titlecase_resolve_to_same_tool(self):
+        from dapr_agents.tool.executor import AgentToolExecutor
+
+        def dummy(**kwargs):
+            return "ok"
+
+        tool = AgentTool(name="test-tool", description="test", func=dummy)
+        executor = AgentToolExecutor(tools=[tool])
+
+        # All of these should find the same tool
+        assert executor.get_tool("test-tool") is tool
+        assert executor.get_tool("TestTool") is tool
+        assert executor.get_tool("test_tool") is tool
+        assert executor.get_tool("TEST-TOOL") is tool
+        assert executor.get_tool("testtool") is tool
+
+    def test_snake_case_and_titlecase_resolve_to_same_tool(self):
+        from dapr_agents.tool.executor import AgentToolExecutor
+
+        def dummy(**kwargs):
+            return "ok"
+
+        tool = AgentTool(name="get_user", description="test", func=dummy)
+        executor = AgentToolExecutor(tools=[tool])
+
+        assert executor.get_tool("get_user") is tool
+        assert executor.get_tool("GetUser") is tool
+        assert executor.get_tool("GET_USER") is tool
+        assert executor.get_tool("get-user") is tool
+        assert executor.get_tool("getuser") is tool

--- a/tests/workflow/test_call_agent.py
+++ b/tests/workflow/test_call_agent.py
@@ -42,7 +42,8 @@ def test_call_agent_sanitizes_name():
     ctx = _make_ctx()
     call_agent(ctx, "weather agent", input={}, app_id="weather-agent")
     kwargs = ctx.call_child_workflow.call_args.kwargs
-    assert kwargs["workflow"] == "dapr.agents.WeatherAgent.workflow"
+    # Spaces are stripped (invalid per spec), but casing is preserved
+    assert kwargs["workflow"] == "dapr.agents.weatheragent.workflow"
 
 
 def test_call_agent_passes_app_id():


### PR DESCRIPTION
preserve hyphens, underscores, and casing in tool/agent names. 

`sanitize_openai_tool_name()` was silently TitleCasing all tool names 
ex: `get-xyz-count` -> `GetXyzCount` even though hyphens, underscores, & mixed casing are valid per both OpenAI && Anthropic tool-name specs (^[a-zA-Z0-9_-]{1,64}$).

Users expect names to remain as-is and not changed bc then they run into naming issues where tools or agent names are not found which is a hard to track down bug.

Now, I strip invalid chars, raise an err if the char length exceeds 64 chars, log a warning if the name is changed due to sanitization to surface this to users.
                                                               
Tool and agent wf names that previously got TitleCased will now preserve their original form
ex: `get-xyz-count` stays `get-xyz-count` instead of becoming `GetXyzCount`

This affects:                       
                                                                                                                                       
- Workflow names: `dapr.agents.GetXyzCount.workflow` -> `dapr.agents.get-xyz-count.workflow`                                                                                    
- Tool names sent to the LLM in the tool schema                                                                                      
                                                                                                                                       
Code that hardcoded the old TitleCased names will need to be updated. LLMs self-correct on the next request since they see the correct name in the tool schema. The old behavior was a bug that no one expects their tool names to be silently rewritten.  