### PR TITLE
chore(deps): lax otel version to coexist with google-adk

### DIFF
--- a/dapr_agents/agents/base.py
+++ b/dapr_agents/agents/base.py
@@ -97,10 +97,15 @@ from opentelemetry.exporter.otlp.proto.http._log_exporter import (
 from opentelemetry.exporter.zipkin.json import ZipkinExporter
 from opentelemetry.sdk.resources import Resource
 from opentelemetry.sdk._logs import LoggerProvider
-from opentelemetry.sdk._logs.export import (
-    BatchLogRecordProcessor,
-    ConsoleLogRecordExporter,
-)
+from opentelemetry.sdk._logs.export import BatchLogRecordProcessor
+
+try:
+    from opentelemetry.sdk._logs.export import ConsoleLogRecordExporter
+except ImportError:
+    # opentelemetry-sdk < 1.39 exposed it under the older name.
+    from opentelemetry.sdk._logs.export import (
+        ConsoleLogExporter as ConsoleLogRecordExporter,
+    )
 from dapr_agents.observability import DaprAgentsInstrumentor
 
 

--- a/dapr_agents/observability/constants.py
+++ b/dapr_agents/observability/constants.py
@@ -47,7 +47,6 @@ from opentelemetry.semconv._incubating.attributes.gen_ai_attributes import (
     GEN_AI_INPUT_MESSAGES,
     GEN_AI_OUTPUT_MESSAGES,
     GEN_AI_SYSTEM_INSTRUCTIONS,
-    GEN_AI_TOOL_DEFINITIONS,
     GEN_AI_TOOL_NAME,
     GEN_AI_TOOL_CALL_ID,
     GEN_AI_RESPONSE_ID,
@@ -55,7 +54,11 @@ from opentelemetry.semconv._incubating.attributes.gen_ai_attributes import (
     GenAiOperationNameValues as _GenAiOpEnum,
 )
 
-# Not yet in the Python semconv package (0.60b1) but defined in the spec:
+# Added in semconv 0.60b0; inlined so we can permit older semconv
+# versions (required to coexist with packages pinning opentelemetry-api < 1.39).
+GEN_AI_TOOL_DEFINITIONS = "gen_ai.tool.definitions"
+
+# Not yet in the Python semconv package but defined in the spec:
 # https://opentelemetry.io/docs/specs/semconv/gen-ai/gen-ai-spans/
 GEN_AI_USAGE_CACHE_CREATION_INPUT_TOKENS = "gen_ai.usage.cache_creation.input_tokens"
 GEN_AI_USAGE_CACHE_READ_INPUT_TOKENS = "gen_ai.usage.cache_read.input_tokens"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -56,15 +56,16 @@ dependencies = [
     "opentelemetry-api>=1.35.0,<2.0.0",
     "opentelemetry-exporter-otlp>=1.35.0,<2.0.0",
     "opentelemetry-proto>=1.35.0,<2.0.0",
-    "opentelemetry-instrumentation-grpc>=0.60b0",
+    "tiktoken>=0.9.0",
+    "cachetools>=6.1.0,<8.0.0",
     "wrapt>=1.14.0,<2.0.0",
     "openinference-instrumentation>=0.1.0,<1.0.0",
     "openinference-semantic-conventions>=0.1.0,<1.0.0",
-    "opentelemetry.exporter.zipkin.json>=1.39.1",
-    "tiktoken>=0.9.0",
-    "opentelemetry-instrumentation-httpx>=0.60b1",
-    "opentelemetry-semantic-conventions>=0.60b1",
-    "cachetools>=6.1.0,<8.0.0",
+    # The below have specific lax settings to allow greater compatability for downstream consumers
+    "opentelemetry-instrumentation-grpc>=0.59b0",
+    "opentelemetry-exporter-zipkin-json>=1.36.0",
+    "opentelemetry-instrumentation-httpx>=0.59b0",
+    "opentelemetry-semantic-conventions>=0.59b0",
 ]
 classifiers = [
     "Development Status :: 2 - Pre-Alpha",

--- a/uv.lock
+++ b/uv.lock
@@ -17,7 +17,7 @@ resolution-markers = [
 ]
 
 [options]
-exclude-newer = "2026-04-17T04:36:26.70448397Z"
+exclude-newer = "0001-01-01T00:00:00Z" # This has no effect and is included for backwards compatibility when using relative exclude-newer values.
 exclude-newer-span = "P7D"
 
 [manifest]
@@ -1484,11 +1484,11 @@ requires-dist = [
     { name = "openinference-semantic-conventions", specifier = ">=0.1.0,<1.0.0" },
     { name = "opentelemetry-api", specifier = ">=1.35.0,<2.0.0" },
     { name = "opentelemetry-exporter-otlp", specifier = ">=1.35.0,<2.0.0" },
-    { name = "opentelemetry-exporter-zipkin-json", specifier = ">=1.39.1" },
-    { name = "opentelemetry-instrumentation-grpc", specifier = ">=0.60b0" },
-    { name = "opentelemetry-instrumentation-httpx", specifier = ">=0.60b1" },
+    { name = "opentelemetry-exporter-zipkin-json", specifier = ">=1.36.0" },
+    { name = "opentelemetry-instrumentation-grpc", specifier = ">=0.59b0" },
+    { name = "opentelemetry-instrumentation-httpx", specifier = ">=0.59b0" },
     { name = "opentelemetry-proto", specifier = ">=1.35.0,<2.0.0" },
-    { name = "opentelemetry-semantic-conventions", specifier = ">=0.60b1" },
+    { name = "opentelemetry-semantic-conventions", specifier = ">=0.59b0" },
     { name = "posthog", specifier = "<8.0.0" },
     { name = "protobuf", specifier = ">=6.33.5,<7.0.0" },
     { name = "pydantic", specifier = ">=2.11.3,<3.0.0" },


### PR DESCRIPTION
# Description

Lax OTel dependencies to allow downstream to coexists with `google-adk`

## Issue reference

We strive to have all PR being opened based on an issue, where the problem or feature have been discussed prior to implementation.

Please reference the issue this PR closes: N/A

## Checklist

Please make sure you've completed the relevant tasks for this PR, out of the following list:

* [ ] Created/updated tests
* [ ] Tested this change against all the quickstarts
* [ ] Extended the documentation
    * [ ] Created the [dapr/docs](https://github.com/dapr/docs) PR: <insert PR link here>

**Note:** We expect contributors to open a corresponding documentation PR in the [dapr/docs](https://github.com/dapr/docs/) repository. As the implementer, you are the best person to document your work! Implementation PRs will not be merged until the documentation PR is opened and ready for review.
