### PR TITLE
feat(hooks): wire before_llm_call and after_llm_call in DurableAgent

### DIFF
--- a/dapr_agents/agents/durable.py
+++ b/dapr_agents/agents/durable.py
@@ -1929,31 +1929,97 @@ class DurableAgent(AgentBase):
         if tools and self.execution.tool_choice is not None:
             generate_kwargs["tool_choice"] = self.execution.tool_choice
 
-        try:
-            response = self.llm.generate(**generate_kwargs)
-        except Exception as exc:  # noqa: BLE001
-            raise AgentError(str(exc)) from exc
+        # before_llm_call hook dispatch. Hooks fire inside this activity (rather
+        # than in the workflow body) so they can perform non-deterministic work
+        # like web search; the activity boundary records the final assistant
+        # message so replays use the recorded output rather than re-running the
+        # hook. First non-Proceed decision wins, mirroring before_tool_call.
+        llm_decision: Optional[HookDecision] = None
+        if self._hooks and self._hooks.before_llm_call:
+            before_ctx = HookContext(
+                step_name="llm",
+                step_kind="llm",
+                source="agent",
+                payload=generate_kwargs,
+                tool_call_id="",
+            )
+            for hook in self._hooks.before_llm_call:
+                result = hook(before_ctx)
+                if result is not None and not isinstance(result, Proceed):
+                    llm_decision = result
+                    break
 
-        # Handle structured output response (Pydantic model) vs regular chat response
-        if response_model is not None:
-            # Structured output: response is the Pydantic model itself
-            if hasattr(response, "model_dump"):
-                # Response is the structured Pydantic object
-                content = json.dumps(response.model_dump())
-            else:
-                # Fallback: try to serialize as-is
-                content = json.dumps(response)
+        if isinstance(llm_decision, RequireApproval):
+            raise NotImplementedError(
+                "RequireApproval is not supported on before_llm_call. LLM hooks "
+                "run inside the call_llm activity so they can perform non-"
+                "deterministic work (e.g. web search). Workflow yields for "
+                "external approval require the deterministic workflow body, "
+                "where such hooks would not be replay-safe. Use RequireApproval "
+                "on before_tool_call for HITL on tool dispatch instead."
+            )
 
-            assistant_message = {
+        synthesized_message: Optional[Dict[str, Any]] = None
+        if isinstance(llm_decision, Skip):
+            skip_content = (
+                str(llm_decision.result) if llm_decision.result is not None else ""
+            )
+            synthesized_message = {"role": "assistant", "content": skip_content}
+        elif isinstance(llm_decision, Deny):
+            deny_reason = llm_decision.reason or "policy denial"
+            synthesized_message = {
                 "role": "assistant",
-                "content": content,
+                "content": f"LLM call blocked: {deny_reason}",
             }
+        elif isinstance(llm_decision, Modify) and llm_decision.payload is not None:
+            generate_kwargs = llm_decision.payload
+
+        if synthesized_message is not None:
+            assistant_message = synthesized_message
         else:
-            # Regular chat response
-            assistant_message = response.get_message()
-            if assistant_message is None:
-                raise AgentError("LLM returned no assistant message.")
-            assistant_message = assistant_message.model_dump()
+            try:
+                response = self.llm.generate(**generate_kwargs)
+            except Exception as exc:  # noqa: BLE001
+                raise AgentError(str(exc)) from exc
+
+            # Handle structured output response (Pydantic model) vs regular chat response
+            if response_model is not None:
+                # Structured output: response is the Pydantic model itself
+                if hasattr(response, "model_dump"):
+                    # Response is the structured Pydantic object
+                    content = json.dumps(response.model_dump())
+                else:
+                    # Fallback: try to serialize as-is
+                    content = json.dumps(response)
+
+                assistant_message = {
+                    "role": "assistant",
+                    "content": content,
+                }
+            else:
+                # Regular chat response
+                assistant_message = response.get_message()
+                if assistant_message is None:
+                    raise AgentError("LLM returned no assistant message.")
+                assistant_message = assistant_message.model_dump()
+
+        # after_llm_call hook dispatch. Receives the built assistant_message and
+        # may return Modify(payload=<replacement dict>) to mutate it before
+        # persistence. Skip / Deny / RequireApproval are no-ops on the after-path
+        # since the LLM has already produced output.
+        if self._hooks and self._hooks.after_llm_call:
+            after_ctx = HookContext(
+                step_name="llm",
+                step_kind="llm",
+                source="agent",
+                payload=generate_kwargs,
+                tool_call_id="",
+            )
+            for hook in self._hooks.after_llm_call:
+                result = hook(after_ctx, assistant_message)
+                if isinstance(result, Modify) and result.payload is not None:
+                    assistant_message = result.payload
+                    break
 
         self._save_assistant_message(
             instance_id, assistant_message, entry=entry, skip_save=True

--- a/dapr_agents/hooks.py
+++ b/dapr_agents/hooks.py
@@ -109,10 +109,21 @@ class Hooks:
     container for all hook callbacks you want to register on a DurableAgent.
     each slot holds a list of callables so multiple hooks can be chained.
 
-    example::
+    tool hooks (``before_tool_call`` / ``after_tool_call``) fire in the workflow
+    body and must be deterministic; non-determinism is deferred to the activity
+    that actually runs the tool. ``RequireApproval`` is supported here.
 
-        from dapr_agents.hooks import Hooks, HookContext, HookDecision
-        from dapr_agents.hooks import Proceed, RequireApproval, Deny
+    llm hooks (``before_llm_call`` / ``after_llm_call``) fire inside the
+    ``call_llm`` activity and may perform non-deterministic work such as web
+    search; the activity's recorded output makes replays safe.
+    ``RequireApproval`` is NOT supported on llm hooks for this reason.
+
+    tool-hook example::
+
+        from dapr_agents.hooks import (
+            Hooks, HookContext, HookDecision,
+            Proceed, RequireApproval, Deny,
+        )
 
         def before_tool(ctx: HookContext) -> HookDecision:
             # gate any mcp delete_ call through human approval
@@ -130,16 +141,48 @@ class Hooks:
             ...,
             hooks=Hooks(before_tool_call=[before_tool]),
         )
+
+    llm-hook example (RAG via hook — inject fresh web context on every turn)::
+
+        from dapr_agents.hooks import Hooks, HookContext, HookDecision, Proceed, Modify
+        from tavily import TavilyClient
+
+        tavily = TavilyClient(api_key=os.environ["TAVILY_API_KEY"])
+
+        def enrich(ctx: HookContext) -> HookDecision:
+            messages = ctx.payload.get("messages", [])
+            if not messages or messages[-1].get("role") != "user":
+                return Proceed()
+            results = tavily.search(query=messages[-1]["content"], max_results=3)
+            snippets = "\\n".join(f"- {r['title']}: {r['content']}" for r in results["results"])
+            enriched = [
+                *messages[:-1],
+                {"role": "system", "content": f"Fresh web context:\\n{snippets}"},
+                messages[-1],
+            ]
+            return Modify(payload={**ctx.payload, "messages": enriched})
+
+        agent = DurableAgent(
+            ...,
+            hooks=Hooks(before_llm_call=[enrich]),
+        )
     """
 
     before_tool_call: List[BeforeHook] = field(default_factory=list)
-    """called before every tool dispatch. return a HookDecision to control execution."""
+    """called before every tool dispatch. return a HookDecision to control execution.
+    runs in the deterministic workflow body. supports Proceed / Skip / Modify /
+    RequireApproval / Deny."""
 
     after_tool_call: List[AfterHook] = field(default_factory=list)
-    """called after a tool completes. return Modify(result=...) to replace the output."""
+    """called after a tool completes. return Modify(payload=...) to replace the output."""
 
     before_llm_call: List[BeforeHook] = field(default_factory=list)
-    """called before every llm call."""
+    """called before every llm call from inside the call_llm activity. supports
+    Proceed / Skip / Modify / Deny. RequireApproval is NOT supported because the
+    activity boundary cannot yield for external events — use before_tool_call
+    for HITL flows."""
 
     after_llm_call: List[AfterHook] = field(default_factory=list)
-    """called after every llm response."""
+    """called after every llm response. return Modify(payload=<assistant_message dict>)
+    to mutate the message that gets persisted and returned. Skip / Deny / RequireApproval
+    are no-ops on this slot (the LLM has already produced output)."""

--- a/tests/agents/durableagent/test_llm_hooks.py
+++ b/tests/agents/durableagent/test_llm_hooks.py
@@ -1,0 +1,400 @@
+#
+# Copyright 2026 The Dapr Authors
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#     http://www.apache.org/licenses/LICENSE-2.0
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+"""Unit tests for the before_llm_call / after_llm_call hook wiring in call_llm."""
+
+import os
+from datetime import timedelta
+from typing import Optional
+from unittest.mock import MagicMock, Mock, patch
+
+import pytest
+from dapr.ext.workflow import WorkflowActivityContext
+
+from dapr_agents.agents.configs import (
+    AgentExecutionConfig,
+    AgentPubSubConfig,
+    AgentStateConfig,
+)
+from dapr_agents.agents.durable import DurableAgent
+from dapr_agents.hooks import (
+    Deny,
+    HookContext,
+    Hooks,
+    Modify,
+    Proceed,
+    RequireApproval,
+    Skip,
+)
+from dapr_agents.llm import OpenAIChatClient
+from dapr_agents.storage.daprstores.stateservice import StateStoreService
+
+
+@pytest.fixture(autouse=True)
+def patch_dapr_check(monkeypatch):
+    import dapr.ext.workflow as wf
+
+    mock_runtime = Mock(spec=wf.WorkflowRuntime)
+    monkeypatch.setattr(wf, "WorkflowRuntime", lambda: mock_runtime)
+
+    class MockRetryPolicy:
+        def __init__(
+            self,
+            max_number_of_attempts=1,
+            first_retry_interval=timedelta(seconds=1),
+            max_retry_interval=timedelta(seconds=60),
+            backoff_coefficient=2.0,
+            retry_timeout: Optional[timedelta] = None,
+        ):
+            pass
+
+    monkeypatch.setattr(wf, "RetryPolicy", MockRetryPolicy)
+    yield mock_runtime
+
+
+class _MockDaprClient:
+    def __init__(self, *_, **__):
+        self.get_state = MagicMock(return_value=Mock(data=None, json=lambda: {}))
+        self.save_state = MagicMock()
+        self.delete_state = MagicMock()
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, *_):
+        pass
+
+    def __call__(self, *_, **__):
+        return self
+
+    def get_metadata(self):
+        resp = MagicMock()
+        resp.registered_components = []
+        resp.application_id = "test-app"
+        return resp
+
+
+@pytest.fixture(autouse=True)
+def setup_env(monkeypatch):
+    os.environ["OPENAI_API_KEY"] = "test-key"
+    client = _MockDaprClient()
+    monkeypatch.setattr("dapr.clients.DaprClient", lambda *a, **kw: client)
+    monkeypatch.setattr(
+        "dapr_agents.storage.daprstores.statestore.DaprClient",
+        lambda *a, **kw: client,
+    )
+    yield
+    os.environ.pop("OPENAI_API_KEY", None)
+
+
+def _mock_llm_response(content: str = "ok"):
+    """Build a fake llm.generate(...) return value that behaves like a chat response."""
+    fake_assistant = Mock()
+    fake_assistant.model_dump.return_value = {"role": "assistant", "content": content}
+    fake_response = Mock()
+    fake_response.get_message.return_value = fake_assistant
+    return fake_response
+
+
+@pytest.fixture
+def mock_llm():
+    m = Mock(spec=OpenAIChatClient)
+    m.generate = Mock(return_value=_mock_llm_response("from-llm"))
+    m.prompt_template = None
+    m.__class__.__name__ = "MockLLMClient"
+    m.provider = "MockProvider"
+    m.api = "MockAPI"
+    m.model = "gpt-4o-mock"
+    return m
+
+
+@pytest.fixture
+def mock_activity_ctx():
+    return Mock(spec=WorkflowActivityContext)
+
+
+def _make_agent(mock_llm, hooks=None):
+    return DurableAgent(
+        name="LLMHookTestAgent",
+        role="LLM Hook Tester",
+        goal="Test hook dispatch",
+        instructions=[],
+        llm=mock_llm,
+        tools=[],
+        pubsub=AgentPubSubConfig(
+            pubsub_name="testpubsub",
+            agent_topic="LLMHookTestAgent",
+        ),
+        state=AgentStateConfig(store=StateStoreService(store_name="teststatestore")),
+        execution=AgentExecutionConfig(max_iterations=1),
+        hooks=hooks,
+    )
+
+
+def _patch_activity_deps(agent):
+    """
+    Patch the parent-class collaborators call_llm depends on so the activity
+    body can run end-to-end against in-memory fakes. Returns the patcher list;
+    each must be __enter__'d (or use as context manager).
+    """
+    fake_entry = MagicMock()
+    history_msgs = [
+        {"role": "system", "content": "you are a helpful assistant"},
+    ]
+    initial_msgs = [
+        {"role": "system", "content": "you are a helpful assistant"},
+        {"role": "user", "content": "what is dapr?"},
+    ]
+    return [
+        patch.object(agent._infra, "get_state", return_value=fake_entry),
+        patch.object(
+            agent,
+            "_reconstruct_conversation_history",
+            return_value=history_msgs,
+        ),
+        patch.object(
+            agent.prompting_helper,
+            "build_initial_messages",
+            return_value=initial_msgs,
+        ),
+        patch.object(agent, "_sync_system_messages_with_state"),
+        patch.object(agent, "_process_user_message"),
+        patch.object(agent, "_get_last_user_message", return_value=initial_msgs[-1]),
+        patch.object(agent, "get_llm_tools", return_value=[]),
+        patch.object(agent, "_save_assistant_message"),
+        patch.object(agent, "save_state"),
+        patch.object(agent.text_formatter, "print_message"),
+    ]
+
+
+def _run_call_llm(agent, mock_ctx, payload=None):
+    """Invoke agent.call_llm with all collaborators patched out."""
+    payload = payload or {"instance_id": "wf-test", "task": "what is dapr?"}
+    patchers = _patch_activity_deps(agent)
+    for p in patchers:
+        p.start()
+    try:
+        return agent.call_llm(mock_ctx, payload)
+    finally:
+        for p in patchers:
+            p.stop()
+
+
+class TestBeforeLLMCallHook:
+    def test_no_hooks_calls_llm_normally(self, mock_llm, mock_activity_ctx):
+        agent = _make_agent(mock_llm)
+        result = _run_call_llm(agent, mock_activity_ctx)
+
+        assert mock_llm.generate.call_count == 1
+        assert result == {"role": "assistant", "content": "from-llm"}
+
+    def test_proceed_does_not_block(self, mock_llm, mock_activity_ctx):
+        captured: list[HookContext] = []
+
+        def hook(ctx):
+            captured.append(ctx)
+            return Proceed()
+
+        agent = _make_agent(mock_llm, Hooks(before_llm_call=[hook]))
+        result = _run_call_llm(agent, mock_activity_ctx)
+
+        assert len(captured) == 1
+        assert captured[0].step_kind == "llm"
+        assert captured[0].step_name == "llm"
+        assert captured[0].source == "agent"
+        assert "messages" in captured[0].payload
+        assert mock_llm.generate.call_count == 1
+        assert result == {"role": "assistant", "content": "from-llm"}
+
+    def test_modify_replaces_messages_seen_by_llm(self, mock_llm, mock_activity_ctx):
+        new_messages = [
+            {"role": "system", "content": "REWRITTEN system"},
+            {"role": "user", "content": "REWRITTEN user"},
+        ]
+
+        def hook(ctx):
+            return Modify(payload={**ctx.payload, "messages": new_messages})
+
+        agent = _make_agent(mock_llm, Hooks(before_llm_call=[hook]))
+        _run_call_llm(agent, mock_activity_ctx)
+
+        # LLM client must have seen the rewritten messages, not the originals
+        called_kwargs = mock_llm.generate.call_args.kwargs
+        assert called_kwargs["messages"] == new_messages
+
+    def test_skip_short_circuits_and_returns_canned_result(
+        self, mock_llm, mock_activity_ctx
+    ):
+        def hook(_):
+            return Skip(result="cached answer")
+
+        agent = _make_agent(mock_llm, Hooks(before_llm_call=[hook]))
+        result = _run_call_llm(agent, mock_activity_ctx)
+
+        assert mock_llm.generate.call_count == 0
+        assert result == {"role": "assistant", "content": "cached answer"}
+
+    def test_deny_synthesizes_blocked_assistant_message(
+        self, mock_llm, mock_activity_ctx
+    ):
+        def hook(_):
+            return Deny(reason="off-topic")
+
+        agent = _make_agent(mock_llm, Hooks(before_llm_call=[hook]))
+        result = _run_call_llm(agent, mock_activity_ctx)
+
+        assert mock_llm.generate.call_count == 0
+        assert result["role"] == "assistant"
+        assert "LLM call blocked: off-topic" in result["content"]
+
+    def test_require_approval_raises_notimplementederror(
+        self, mock_llm, mock_activity_ctx
+    ):
+        def hook(_):
+            return RequireApproval(timeout_seconds=30)
+
+        agent = _make_agent(mock_llm, Hooks(before_llm_call=[hook]))
+        with pytest.raises(NotImplementedError) as exc_info:
+            _run_call_llm(agent, mock_activity_ctx)
+
+        msg = str(exc_info.value)
+        # Error message must reference non-determinism so callers know why
+        assert "non-deterministic" in msg or "deterministic" in msg
+        assert "before_tool_call" in msg
+
+    def test_first_nonproceed_decision_wins(self, mock_llm, mock_activity_ctx):
+        def hook_a(_):
+            return Modify(payload={"messages": [{"role": "user", "content": "from A"}]})
+
+        def hook_b_unreached(_):
+            return Skip(result="should not be reached")
+
+        agent = _make_agent(mock_llm, Hooks(before_llm_call=[hook_a, hook_b_unreached]))
+        _run_call_llm(agent, mock_activity_ctx)
+
+        # Modify won — LLM was called with hook_a's payload, not Skip-ed
+        assert mock_llm.generate.call_count == 1
+        called_messages = mock_llm.generate.call_args.kwargs["messages"]
+        assert called_messages == [{"role": "user", "content": "from A"}]
+
+    def test_proceed_then_modify_chains(self, mock_llm, mock_activity_ctx):
+        """First hook returns Proceed → second hook still runs."""
+        new_messages = [{"role": "user", "content": "from B"}]
+
+        def hook_a(_):
+            return Proceed()
+
+        def hook_b(ctx):
+            return Modify(payload={**ctx.payload, "messages": new_messages})
+
+        agent = _make_agent(mock_llm, Hooks(before_llm_call=[hook_a, hook_b]))
+        _run_call_llm(agent, mock_activity_ctx)
+
+        called_messages = mock_llm.generate.call_args.kwargs["messages"]
+        assert called_messages == new_messages
+
+
+class TestAfterLLMCallHook:
+    def test_modify_replaces_assistant_message(self, mock_llm, mock_activity_ctx):
+        replacement = {"role": "assistant", "content": "rewritten by after-hook"}
+
+        def hook(_, _msg):
+            return Modify(payload=replacement)
+
+        agent = _make_agent(mock_llm, Hooks(after_llm_call=[hook]))
+        result = _run_call_llm(agent, mock_activity_ctx)
+
+        assert mock_llm.generate.call_count == 1
+        assert result == replacement
+
+    def test_after_hook_receives_built_message(self, mock_llm, mock_activity_ctx):
+        captured: list = []
+
+        def hook(ctx, msg):
+            captured.append((ctx, msg))
+            return None
+
+        agent = _make_agent(mock_llm, Hooks(after_llm_call=[hook]))
+        result = _run_call_llm(agent, mock_activity_ctx)
+
+        assert len(captured) == 1
+        seen_ctx, seen_msg = captured[0]
+        assert seen_ctx.step_kind == "llm"
+        assert seen_msg == {"role": "assistant", "content": "from-llm"}
+        # Hook returned None → message unchanged
+        assert result == {"role": "assistant", "content": "from-llm"}
+
+    def test_proceed_means_no_op(self, mock_llm, mock_activity_ctx):
+        def hook(_, _msg):
+            return Proceed()
+
+        agent = _make_agent(mock_llm, Hooks(after_llm_call=[hook]))
+        result = _run_call_llm(agent, mock_activity_ctx)
+
+        assert result == {"role": "assistant", "content": "from-llm"}
+
+    def test_skip_on_after_path_is_noop(self, mock_llm, mock_activity_ctx):
+        """Skip / Deny / RequireApproval are documented no-ops on after_llm_call."""
+
+        def hook(_, _msg):
+            return Skip(result="ignored")
+
+        agent = _make_agent(mock_llm, Hooks(after_llm_call=[hook]))
+        result = _run_call_llm(agent, mock_activity_ctx)
+
+        assert result == {"role": "assistant", "content": "from-llm"}
+
+
+class TestBeforeAfterCombined:
+    def test_modify_kwargs_then_modify_response(self, mock_llm, mock_activity_ctx):
+        before_messages = [{"role": "user", "content": "BEFORE"}]
+        after_message = {"role": "assistant", "content": "AFTER"}
+
+        def before_hook(ctx):
+            return Modify(payload={**ctx.payload, "messages": before_messages})
+
+        def after_hook(_, _msg):
+            return Modify(payload=after_message)
+
+        agent = _make_agent(
+            mock_llm,
+            Hooks(before_llm_call=[before_hook], after_llm_call=[after_hook]),
+        )
+        result = _run_call_llm(agent, mock_activity_ctx)
+
+        assert mock_llm.generate.call_args.kwargs["messages"] == before_messages
+        assert result == after_message
+
+    def test_skip_short_circuit_skips_after_hook_too(self, mock_llm, mock_activity_ctx):
+        """When before-hook short-circuits with Skip, after-hooks still see the synthesized message."""
+        after_seen: list = []
+
+        def before_hook(_):
+            return Skip(result="canned")
+
+        def after_hook(_, msg):
+            after_seen.append(msg)
+            return None
+
+        agent = _make_agent(
+            mock_llm,
+            Hooks(before_llm_call=[before_hook], after_llm_call=[after_hook]),
+        )
+        result = _run_call_llm(agent, mock_activity_ctx)
+
+        # LLM was skipped, but the synthesized assistant message still flowed
+        # through the after-hook chain — that's the intended behavior because
+        # the after-path operates on assistant_message regardless of origin.
+        assert mock_llm.generate.call_count == 0
+        assert after_seen == [{"role": "assistant", "content": "canned"}]
+        assert result == {"role": "assistant", "content": "canned"}


### PR DESCRIPTION
# Description

Follow-up to #571. The Hooks dataclass introduced LLM hook slots but only the tool slots were wired into the agent runtime. This PR completes the contract by dispatching before_llm_call and           
after_llm_call inside the call_llm activity in dapr_agents/agents/durable.py.          
                                                                                                                                                                                                        
Why inside the activity (not the workflow body): LLM hooks can perform non-deterministic work like web search; the activity boundary records the assistant message so replays use the recorded output 
instead of re-running the hook. Tool hooks stay in the workflow body where they must be replay-safe.                                                                                                    
                                                                                      
Semantics:                                                         
- before_llm_call: Proceed (default), Modify(payload=<new kwargs>), Skip(result=...), Deny(reason=...). First non-Proceed wins.
- after_llm_call: Modify(payload=<assistant_message dict>). Skip/Deny/RequireApproval are no-ops (LLM already ran).                                                                                     
- RequireApproval on before_llm_call raises NotImplementedError with the non-determinism rationale and points to before_tool_call for HITL.
                                                                                                                                                                                                        
Tests: 14 new cases in tests/agents/durableagent/test_llm_hooks.py.                                                                                                                                     
                                                                             
Docs: Hooks docstring gains a Tavily enrichment example.  

## Issue reference

We strive to have all PR being opened based on an issue, where the problem or feature have been discussed prior to implementation.

Please reference the issue this PR closes: N/A

## Checklist

Please make sure you've completed the relevant tasks for this PR, out of the following list:

* [x] Created/updated tests
* [ ] Tested this change against all the quickstarts
* [ ] Extended the documentation
    * [ ] Created the [dapr/docs](https://github.com/dapr/docs) PR: <insert PR link here>

**Note:** We expect contributors to open a corresponding documentation PR in the [dapr/docs](https://github.com/dapr/docs/) repository. As the implementer, you are the best person to document your work! Implementation PRs will not be merged until the documentation PR is opened and ready for review.
