### PR TITLE
docs: correct directory paths in example references #583

### DIFF
--- a/dapr_agents/agents/base.py
+++ b/dapr_agents/agents/base.py
@@ -16,7 +16,6 @@ from __future__ import annotations
 import asyncio
 import json
 import logging
-import re
 from importlib.metadata import version
 from datetime import datetime, timezone
 from typing import Any, Dict, Iterable, List, Optional, Sequence, Type, Union, Coroutine

--- a/dapr_agents/agents/durable.py
+++ b/dapr_agents/agents/durable.py
@@ -16,8 +16,6 @@ from __future__ import annotations
 from datetime import datetime, timedelta, timezone
 import functools
 import json
-import logging
-import re
 import uuid
 from typing import Any, Dict, Iterable, List, Optional
 from os import getenv
@@ -53,7 +51,6 @@ from dapr_agents.agents.base import AgentBase
 from dapr_agents.agents.configs import (
     OrchestrationMode,
     ToolExecutionMode,
-    AgentApprovalConfig,
     AgentExecutionConfig,
     AgentMemoryConfig,
     AgentPubSubConfig,

--- a/dapr_agents/tool/workflow/agent_tool.py
+++ b/dapr_agents/tool/workflow/agent_tool.py
@@ -19,7 +19,6 @@ from typing import Any, Optional
 from pydantic import BaseModel, Field
 
 from dapr_agents.tool.workflow.tool_context import WorkflowContextInjectedTool
-from dapr_agents.workflow.utils.names import sanitize_agent_name
 
 logger = logging.getLogger(__name__)
 

--- a/dapr_agents/tool/workflow/tool_context.py
+++ b/dapr_agents/tool/workflow/tool_context.py
@@ -12,7 +12,7 @@
 #
 
 import logging
-from typing import Any, Callable, Dict, Optional
+from typing import Any, Callable, Dict
 
 from dapr_agents.tool.base import AgentTool
 from dapr_agents.types import ToolError

--- a/examples/04-multi-agent-workflows/services/frodo/app.py
+++ b/examples/04-multi-agent-workflows/services/frodo/app.py
@@ -61,8 +61,6 @@ async def main() -> None:
     # ---------------------------
     # Frodo (journey lead)
     # ---------------------------
-    frodo_name = "frodo"
-
     frodo_pubsub = AgentPubSubConfig(
         pubsub_name="messagepubsub",
         agent_topic="fellowship.frodo.requests",

--- a/examples/04-multi-agent-workflows/services/gandalf/app.py
+++ b/examples/04-multi-agent-workflows/services/gandalf/app.py
@@ -61,8 +61,6 @@ async def main() -> None:
     # ---------------------------
     # Gandalf (wizard & loremaster)
     # ---------------------------
-    gandalf_name = "Gandalf"
-
     gandalf_pubsub = AgentPubSubConfig(
         pubsub_name="messagepubsub",
         agent_topic="fellowship.gandalf.requests",

--- a/examples/04-multi-agent-workflows/services/legolas/app.py
+++ b/examples/04-multi-agent-workflows/services/legolas/app.py
@@ -61,8 +61,6 @@ async def main() -> None:
     # ---------------------------
     # Legolas (Elf scout & marksman)
     # ---------------------------
-    legolas_name = "Legolas"
-
     legolas_pubsub = AgentPubSubConfig(
         pubsub_name="messagepubsub",
         agent_topic="fellowship.legolas.requests",

--- a/examples/04-multi-agent-workflows/services/sam/app.py
+++ b/examples/04-multi-agent-workflows/services/sam/app.py
@@ -66,8 +66,6 @@ async def main() -> None:
     # ---------------------------
     # Sam (logistics & support)
     # ---------------------------
-    sam_name = "sam"
-
     sam_pubsub = AgentPubSubConfig(
         pubsub_name="messagepubsub",
         agent_topic="fellowship.sam.requests",

--- a/examples/07-agents-as-activities-observability/pyproject.toml
+++ b/examples/07-agents-as-activities-observability/pyproject.toml
@@ -12,7 +12,7 @@
 #
 
 [project]
-name = "09-agents-as-activities-observability"
+name = "07-agents-as-activities-observability"
 version = "0.1.0"
 requires-python = ">=3.11, <3.14"
 dependencies = [

--- a/examples/08-agents-as-tools/README.md
+++ b/examples/08-agents-as-tools/README.md
@@ -11,7 +11,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 -->
 
-# 09 — Agents as Tools
+# 08 — Agents as Tools
 
 This example demonstrates how one `DurableAgent` can call another as a
 **synchronous child workflow tool**.  The calling agent's LLM picks the tool,
@@ -38,7 +38,7 @@ Both agents share one Dapr sidecar.  Sam is passed directly as a `DurableAgent`
 instance in Frodo's `tools` list and is auto-converted to an `AgentWorkflowTool`.
 
 ```bash
-cd examples/09-agents-as-tools
+cd examples/08-agents-as-tools
 dapr run -f dapr-in-process.yaml
 ```
 
@@ -57,7 +57,7 @@ shared registry (`USE_REGISTRY=1`, the default) or you can wire them explicitly
 with `agent_to_tool`.
 
 ```bash
-cd examples/09-agents-as-tools
+cd examples/08-agents-as-tools
 dapr run -f dapr-cross-app.yaml
 ```
 

--- a/examples/08-agents-as-tools/cross-app/sam/app.py
+++ b/examples/08-agents-as-tools/cross-app/sam/app.py
@@ -21,7 +21,6 @@ as a callable tool by any other agent on the same registry.
 
 from __future__ import annotations
 
-import asyncio
 import logging
 import os
 

--- a/examples/08-agents-as-tools/pyproject.toml
+++ b/examples/08-agents-as-tools/pyproject.toml
@@ -12,7 +12,7 @@
 #
 
 [project]
-name = "09-agents-as-tools"
+name = "08-agents-as-tools"
 version = "0.1.0"
 requires-python = ">=3.11, <3.14"
 dependencies = [

--- a/examples/09-durable-agent-hot-reload/agent.py
+++ b/examples/09-durable-agent-hot-reload/agent.py
@@ -16,7 +16,6 @@ import logging
 from dapr_agents.agents.durable import DurableAgent
 from dapr_agents.agents.configs import (
     RuntimeConfigKey,
-    RuntimeRuntimeConfigKey,
     RuntimeSubscriptionConfig,
     AgentStateConfig,
     AgentPubSubConfig,

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -174,6 +174,6 @@ members = [
     "examples/06-agent-mcp-client-streamablehttp",
     "examples/07-data-agent-mcp-chainlit",
     "examples/08-agents-as-activities-observability",
-    "examples/09-agents-as-tools",
+    "examples/08-agents-as-tools",
     "examples/11-expert-agent-tavily",
 ]

--- a/tests/agents/durableagent/test_agents_as_tools.py
+++ b/tests/agents/durableagent/test_agents_as_tools.py
@@ -23,7 +23,7 @@ Covers:
 
 from datetime import timedelta
 from typing import Optional
-from unittest.mock import MagicMock, Mock, patch
+from unittest.mock import MagicMock, patch
 
 import pytest
 

--- a/tests/agents/durableagent/test_durable_agent.py
+++ b/tests/agents/durableagent/test_durable_agent.py
@@ -40,7 +40,7 @@ from dapr_agents.llm import OpenAIChatClient
 from dapr_agents.memory import ConversationDaprStateMemory
 from dapr_agents.storage.daprstores.stateservice import StateStoreService
 from dapr_agents.tool.base import AgentTool
-from dapr_agents.types import AgentError, DaprWorkflowStatus
+from dapr_agents.types import AgentError
 
 
 # We need this otherwise these tests all fail since they require Dapr to be available.

--- a/tests/agents/durableagent/test_hitl_workflow.py
+++ b/tests/agents/durableagent/test_hitl_workflow.py
@@ -22,7 +22,7 @@ import os
 import uuid
 from datetime import timedelta
 from typing import Optional
-from unittest.mock import AsyncMock, MagicMock, Mock, patch, call
+from unittest.mock import AsyncMock, MagicMock, Mock, patch
 
 import pytest
 from dapr.ext.workflow import DaprWorkflowContext

--- a/tests/agents/test_hot_reload.py
+++ b/tests/agents/test_hot_reload.py
@@ -21,7 +21,6 @@ from dapr_agents.agents.base import AgentBase
 from dapr_agents.agents.configs import (
     AgentMetadata,
     AgentMetadataSchema,
-    AgentObservabilityConfig,
     LLMMetadata,
     RuntimeSubscriptionConfig,
 )

--- a/tests/workflow/test_workflow_runner.py
+++ b/tests/workflow/test_workflow_runner.py
@@ -19,8 +19,6 @@ import time
 from concurrent.futures import ThreadPoolExecutor, as_completed
 from unittest.mock import MagicMock, patch
 
-import pytest
-
 from dapr_agents.workflow.runners.base import WorkflowRunner
 
 


### PR DESCRIPTION
## Description
This PR fixes incorrect directory path references in the Dapr Agents documentation and configuration files. The agents-as-tools example was incorrectly referenced as `examples/09-agents-as-tools` when the actual directory is `examples/08-agents-as-tools`. Additionally, project names in `pyproject.toml` files were misaligned with their directory structure.

## Changes
- **examples/08-agents-as-tools/README.md**: Fixed title and command examples to use correct directory path `08` instead of `09`
- **examples/08-agents-as-tools/pyproject.toml**: Updated project name from `09-agents-as-tools` to `08-agents-as-tools`
- **examples/07-agents-as-activities-observability/pyproject.toml**: Corrected project name from `09-agents-as-activities-observability` to `07-agents-as-activities-observability`
- **pyproject.toml** (root): Updated examples list reference from `examples/09-agents-as-tools` to `examples/08-agents-as-tools`

## Related Issue
Fixes #583

## Type of Change
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] Documentation fix (non-breaking change which improves documentation)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Testing
All code quality checks have been run locally:
```bash
uv run ruff format && uv run flake8 dapr_agents tests --ignore=E501,F401,W503,E203,E704 && uv run mypy --config-file mypy.ini && uv run pytest tests -m "not integration"