### PR TITLE
Clarify vulnerability reporting process in SECURITY.md

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -13,4 +13,6 @@ limitations under the License.
 
 ## Security Policy
 
-https://docs.dapr.io/operations/support/support-security-issues/
+To report a vulnerability, [file a private vulnerability report as per the documented process](https://docs.dapr.io/operations/support/support-security-issues/#reporting-process). This report will be privately reviewed by the Dapr security team.
+
+Please do not report security vulnerabilities through public GitHub issues. If you aren't sure if an issue is a security vulnerability, it's best to err on the side of caution and report it privately.


### PR DESCRIPTION
Updated the security policy to clarify the reporting process for vulnerabilities.

# Description

_Please explain the changes you've made_

## Issue reference

We strive to have all PR being opened based on an issue, where the problem or feature have been discussed prior to implementation.

Please reference the issue this PR closes: #_[issue number]_

## Checklist

Please make sure you've completed the relevant tasks for this PR, out of the following list:

* [ ] Created/updated tests
* [ ] Tested this change against all the quickstarts
* [ ] Extended the documentation
    * [ ] Created the [dapr/docs](https://github.com/dapr/docs) PR: <insert PR link here>

**Note:** We expect contributors to open a corresponding documentation PR in the [dapr/docs](https://github.com/dapr/docs/) repository. As the implementer, you are the best person to document your work! Implementation PRs will not be merged until the documentation PR is opened and ready for review.
