### PR TITLE
Feat/add litellm provider

### DIFF
--- a/dapr_agents/__init__.py
+++ b/dapr_agents/__init__.py
@@ -52,6 +52,7 @@ from dapr_agents.hooks import (
 from dapr_agents.executors import DockerCodeExecutor, LocalCodeExecutor
 from dapr_agents.llm.anthropic import AnthropicChatClient
 from dapr_agents.llm.dapr import DaprChatClient
+from dapr_agents.llm.litellm import LiteLLMChatClient
 from dapr_agents.llm.elevenlabs import ElevenLabsSpeechClient
 from dapr_agents.llm.huggingface import HFHubChatClient
 from dapr_agents.llm.nvidia import NVIDIAChatClient, NVIDIAEmbeddingClient
@@ -73,6 +74,7 @@ __all__ = [
     "DockerCodeExecutor",
     "LocalCodeExecutor",
     "AnthropicChatClient",
+    "LiteLLMChatClient",
     "ElevenLabsSpeechClient",
     "DaprChatClient",
     "HFHubChatClient",

--- a/dapr_agents/llm/__init__.py
+++ b/dapr_agents/llm/__init__.py
@@ -13,6 +13,7 @@
 
 from .anthropic.chat import AnthropicChatClient
 from .dapr import DaprChatClient
+from .litellm.chat import LiteLLMChatClient
 from .elevenlabs import ElevenLabsSpeechClient
 from .huggingface.chat import HFHubChatClient
 from .mistral.chat import MistralChatClient
@@ -33,4 +34,5 @@ __all__ = [
     "ElevenLabsSpeechClient",
     "DaprChatClient",
     "AnthropicChatClient",
+    "LiteLLMChatClient",
 ]

--- a/dapr_agents/llm/litellm/__init__.py
+++ b/dapr_agents/llm/litellm/__init__.py
@@ -1,0 +1,18 @@
+#
+# Copyright 2026 The Dapr Authors
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#     http://www.apache.org/licenses/LICENSE-2.0
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+
+from .client import LiteLLMClientBase
+from .chat import LiteLLMChatClient
+
+__all__ = ["LiteLLMClientBase", "LiteLLMChatClient"]

--- a/dapr_agents/llm/litellm/chat.py
+++ b/dapr_agents/llm/litellm/chat.py
@@ -1,0 +1,184 @@
+#
+# Copyright 2026 The Dapr Authors
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#     http://www.apache.org/licenses/LICENSE-2.0
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+
+import logging
+import os
+from pathlib import Path
+from typing import (
+    Any,
+    ClassVar,
+    Dict,
+    Iterable,
+    Iterator,
+    List,
+    Literal,
+    Optional,
+    Type,
+    Union,
+)
+
+from pydantic import BaseModel, Field, model_validator
+
+from dapr_agents.llm.chat import ChatClientBase
+from dapr_agents.llm.litellm.client import LiteLLMClientBase
+from dapr_agents.llm.utils import RequestHandler, ResponseHandler
+from dapr_agents.prompt.base import PromptTemplateBase
+from dapr_agents.prompt.prompty import Prompty
+from dapr_agents.tool import AgentTool
+from dapr_agents.types.message import (
+    BaseMessage,
+    LLMChatCandidateChunk,
+    LLMChatResponse,
+)
+
+logger = logging.getLogger(__name__)
+
+
+class LiteLLMChatClient(LiteLLMClientBase, ChatClientBase):
+    """
+    LiteLLM Chat Client for Dapr Agents.
+
+    LiteLLM is a unified gateway that routes to 100+ LLM providers
+    (OpenAI, Anthropic, Google, Azure, AWS Bedrock, etc.) through a
+    single interface.
+
+    Configure the model with the ``provider/model`` naming convention
+    (e.g. ``anthropic/claude-sonnet-4-6``, ``openai/gpt-4o``).
+
+    Model resolution order:
+    1. Explicit ``model`` parameter during initialization.
+    2. ``LITELLM_MODEL`` environment variable.
+    3. Default fallback: ``openai/gpt-4o``.
+    """
+
+    model: Optional[str] = Field(
+        default=None,
+        description="LiteLLM model identifier (e.g. 'openai/gpt-4o').",
+    )
+    prompty: Optional[Prompty] = Field(default=None)
+    prompt_template: Optional[PromptTemplateBase] = Field(default=None)
+
+    SUPPORTED_STRUCTURED_MODES: ClassVar[set[str]] = {"json", "function_call"}
+
+    @model_validator(mode="before")
+    def validate_and_initialize(cls, values: Dict[str, Any]) -> Dict[str, Any]:
+        env_model = os.environ.get("LITELLM_MODEL")
+        if env_model:
+            values["model"] = env_model
+        elif not values.get("model"):
+            values["model"] = "openai/gpt-4o"
+        return values
+
+    def model_post_init(self, __context: Any) -> None:
+        self._api = "chat"
+        super().model_post_init(__context)
+
+    @classmethod
+    def from_prompty(
+        cls,
+        prompty_source: Union[str, Path],
+        timeout: Union[int, float, Dict[str, Any]] = 1500,
+    ) -> "LiteLLMChatClient":
+        raise NotImplementedError(
+            "Prompty-based initialization is not yet supported for the LiteLLM provider."
+        )
+
+    def generate(
+        self,
+        messages: Union[
+            str,
+            Dict[str, Any],
+            BaseMessage,
+            Iterable[Union[Dict[str, Any], BaseMessage]],
+        ] = None,
+        *,
+        input_data: Optional[Dict[str, Any]] = None,
+        model: Optional[str] = None,
+        tools: Optional[List[Union[AgentTool, Dict[str, Any]]]] = None,
+        response_format: Optional[Type[BaseModel]] = None,
+        structured_mode: Literal["json", "function_call"] = "json",
+        stream: bool = False,
+        **kwargs: Any,
+    ) -> Union[
+        Iterator[LLMChatCandidateChunk],
+        LLMChatResponse,
+        BaseModel,
+        List[BaseModel],
+    ]:
+        try:
+            import litellm
+        except ImportError:
+            raise ImportError(
+                "LiteLLM is required for LiteLLMChatClient. "
+                "Install it with: pip install 'dapr-agents[litellm]'"
+            )
+
+        if structured_mode not in self.SUPPORTED_STRUCTURED_MODES:
+            raise ValueError(
+                f"structured_mode must be one of {self.SUPPORTED_STRUCTURED_MODES}"
+            )
+
+        if input_data:
+            if not self.prompt_template:
+                raise ValueError("No prompt_template set for input_data usage.")
+            logger.info("Formatting messages via prompt_template.")
+            messages = self.prompt_template.format_prompt(**input_data)
+
+        if not messages:
+            raise ValueError("Either messages or input_data must be provided.")
+
+        params = {"messages": RequestHandler.normalize_chat_messages(messages)}
+        if self.prompty:
+            params = {**self.prompty.model.parameters.model_dump(), **params, **kwargs}
+        else:
+            params.update(kwargs)
+
+        params["stream"] = stream
+        params["model"] = model or self.model
+
+        params = RequestHandler.process_params(
+            params,
+            llm_provider=self.provider,
+            tools=tools,
+            response_format=response_format,
+            structured_mode=structured_mode,
+        )
+
+        params = RequestHandler.make_params_json_serializable(params)
+
+        # LiteLLM-specific: silently drop provider-unsupported kwargs
+        params["drop_params"] = True
+        if self.config.api_key:
+            params["api_key"] = self.config.api_key
+        if self.config.api_base:
+            params["api_base"] = self.config.api_base
+
+        try:
+            logger.info("Calling LiteLLM completion...")
+            logger.debug(f"LiteLLM request params: {params}")
+            resp = litellm.completion(**params)
+            logger.info("LiteLLM response received.")
+            return ResponseHandler.process_response(
+                response=resp,
+                llm_provider=self.provider,
+                response_format=response_format,
+                structured_mode=structured_mode,
+                stream=stream,
+            )
+        except Exception as e:
+            error_type = type(e).__name__
+            error_msg = str(e)
+            logger.error(f"LiteLLM API error: {error_type} - {error_msg}")
+            logger.error("Full error details:", exc_info=True)
+            raise ValueError(f"LiteLLM API error ({error_type}): {error_msg}") from e

--- a/dapr_agents/llm/litellm/chat.py
+++ b/dapr_agents/llm/litellm/chat.py
@@ -28,6 +28,7 @@ from typing import (
     Union,
 )
 
+import litellm
 from pydantic import BaseModel, Field, model_validator
 
 from dapr_agents.llm.chat import ChatClientBase
@@ -116,14 +117,6 @@ class LiteLLMChatClient(LiteLLMClientBase, ChatClientBase):
         BaseModel,
         List[BaseModel],
     ]:
-        try:
-            import litellm
-        except ImportError:
-            raise ImportError(
-                "LiteLLM is required for LiteLLMChatClient. "
-                "Install it with: pip install 'dapr-agents[litellm]'"
-            )
-
         if structured_mode not in self.SUPPORTED_STRUCTURED_MODES:
             raise ValueError(
                 f"structured_mode must be one of {self.SUPPORTED_STRUCTURED_MODES}"

--- a/dapr_agents/llm/litellm/client.py
+++ b/dapr_agents/llm/litellm/client.py
@@ -1,0 +1,54 @@
+#
+# Copyright 2026 The Dapr Authors
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#     http://www.apache.org/licenses/LICENSE-2.0
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+
+import logging
+import os
+from typing import Any, Optional
+
+from pydantic import Field
+
+from dapr_agents.llm.base import LLMClientBase
+from dapr_agents.types.llm import LiteLLMClientConfig
+
+logger = logging.getLogger(__name__)
+
+PROVIDER = "litellm"
+
+
+class LiteLLMClientBase(LLMClientBase):
+    api_key: Optional[str] = Field(
+        default=None,
+        description="API key for LiteLLM proxy or the underlying provider.",
+    )
+    api_base: Optional[str] = Field(
+        default=None,
+        description="Base URL for a LiteLLM proxy or compatible endpoint.",
+    )
+
+    def model_post_init(self, __context: Any) -> None:
+        self._provider = PROVIDER
+        self._config: LiteLLMClientConfig = self.get_config()
+        self._client = self.get_client()
+        return super().model_post_init(__context)
+
+    def get_config(self) -> LiteLLMClientConfig:
+        return LiteLLMClientConfig(
+            api_key=self.api_key or os.environ.get("LITELLM_API_KEY"),
+            api_base=self.api_base or os.environ.get("LITELLM_API_BASE"),
+        )
+
+    def get_client(self) -> None:
+        # LiteLLM uses a functional API (litellm.completion());
+        # no persistent client object is needed.
+        return None

--- a/dapr_agents/llm/utils/response.py
+++ b/dapr_agents/llm/utils/response.py
@@ -91,7 +91,7 @@ class ResponseHandler:
         else:
             # ─── Non‑streaming ─────────────────────────────────────────────────────
             # 1) Normalize full response → LLMChatResponse
-            if provider in ("openai", "nvidia"):
+            if provider in ("openai", "nvidia", "litellm"):
                 from dapr_agents.llm.openai.utils import process_openai_chat_response
 
                 llm_resp: LLMChatResponse = process_openai_chat_response(response)

--- a/dapr_agents/llm/utils/stream.py
+++ b/dapr_agents/llm/utils/stream.py
@@ -51,7 +51,7 @@ class StreamHandler:
             LLMChatCandidateChunk: fully-typed chunks, partial and final.
         """
 
-        if llm_provider in ("openai", "nvidia"):
+        if llm_provider in ("openai", "nvidia", "litellm"):
             from dapr_agents.llm.openai.utils import process_openai_stream
 
             yield from process_openai_stream(

--- a/dapr_agents/llm/utils/structure.py
+++ b/dapr_agents/llm/utils/structure.py
@@ -312,7 +312,7 @@ class StructureHandler:
         """
         try:
             logger.debug(f"Processing structured response for mode: {structured_mode}")
-            if llm_provider in ("openai", "nvidia", "huggingface", "dapr"):
+            if llm_provider in ("openai", "nvidia", "huggingface", "dapr", "litellm"):
                 if structured_mode == "function_call":
                     tool_calls = getattr(message, "tool_calls", None)
                     if tool_calls:

--- a/dapr_agents/tool/utils/function_calling.py
+++ b/dapr_agents/tool/utils/function_calling.py
@@ -250,7 +250,7 @@ def to_function_call_definition(
     fmt = format_type.lower()
 
     # OpenAI‑style wrapper schema:
-    if fmt in ("openai", "nvidia", "huggingface", "dapr"):
+    if fmt in ("openai", "nvidia", "huggingface", "dapr", "litellm"):
         return to_openai_function_call_definition(
             name, description, args_schema, use_deprecated
         )
@@ -294,7 +294,7 @@ def validate_and_format_tool(
     fmt = tool_format.lower()
 
     try:
-        if fmt in ("openai", "azure_openai", "nvidia", "huggingface"):
+        if fmt in ("openai", "azure_openai", "nvidia", "huggingface", "litellm"):
             validated = (
                 OAIFunctionDefinition(**tool)
                 if use_deprecated

--- a/dapr_agents/types/llm.py
+++ b/dapr_agents/types/llm.py
@@ -45,6 +45,15 @@ class MistralClientConfig(BaseModel):
     )
 
 
+class LiteLLMClientConfig(BaseModel):
+    api_key: Optional[str] = Field(
+        None, description="API key for LiteLLM proxy or the underlying provider."
+    )
+    api_base: Optional[str] = Field(
+        None, description="Base URL for a LiteLLM proxy or compatible endpoint."
+    )
+
+
 class AnthropicClientConfig(BaseModel):
     base_url: Optional[str] = Field(
         None, description="Base URL override for the Anthropic API."

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -81,6 +81,9 @@ classifiers = [
 ]
 
 [project.optional-dependencies]
+litellm = [
+    "litellm>=1.80,<1.87",
+]
 vectorstore = [
     "torch>=2.7.0",
     "sentence-transformers>=4.1.0,<6.0.0",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -67,6 +67,7 @@ dependencies = [
     "opentelemetry-exporter-zipkin-json>=1.36.0",
     "opentelemetry-instrumentation-httpx>=0.60b1,<0.61",
     "opentelemetry-semantic-conventions>=0.60b1,<0.61",
+    "litellm>=1.80,<1.87",
 ]
 classifiers = [
     "Development Status :: 2 - Pre-Alpha",
@@ -81,9 +82,6 @@ classifiers = [
 ]
 
 [project.optional-dependencies]
-litellm = [
-    "litellm>=1.80,<1.87",
-]
 vectorstore = [
     "torch>=2.7.0",
     "sentence-transformers>=4.1.0,<6.0.0",

--- a/tests/llm/test_litellm.py
+++ b/tests/llm/test_litellm.py
@@ -1,0 +1,288 @@
+#
+# Copyright 2026 The Dapr Authors
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#     http://www.apache.org/licenses/LICENSE-2.0
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+import os
+from types import SimpleNamespace
+from unittest.mock import patch
+
+import pytest
+
+from dapr_agents.llm.litellm.chat import LiteLLMChatClient
+from dapr_agents.types.message import (
+    AssistantMessage,
+    LLMChatResponse,
+    LLMChatResponseChunk,
+)
+
+
+# ---------------------------------------------------------------------------
+# Helpers - fake LiteLLM responses (OpenAI-compatible format)
+# ---------------------------------------------------------------------------
+
+
+def _fake_completion_response(
+    content="Hello from LiteLLM",
+    model="anthropic/claude-sonnet-4-6",
+    tool_calls=None,
+):
+    msg = {"role": "assistant", "content": content, "refusal": None}
+    if tool_calls:
+        msg["tool_calls"] = tool_calls
+        msg["content"] = None
+    choice = {
+        "index": 0,
+        "message": msg,
+        "finish_reason": "tool_calls" if tool_calls else "stop",
+        "logprobs": None,
+    }
+    return SimpleNamespace(
+        model_dump=lambda: {
+            "id": "chatcmpl-test-123",
+            "model": model,
+            "object": "chat.completion",
+            "choices": [choice],
+            "usage": {
+                "prompt_tokens": 10,
+                "completion_tokens": 5,
+                "total_tokens": 15,
+            },
+            "created": 1700000000,
+        }
+    )
+
+
+def _fake_stream_chunks(texts=("Hel", "lo")):
+    for i, text in enumerate(texts):
+        yield SimpleNamespace(
+            model_dump=lambda t=text, idx=i: {
+                "id": "chatcmpl-stream-123",
+                "model": "openai/gpt-4o",
+                "object": "chat.completion.chunk",
+                "choices": [
+                    {
+                        "index": 0,
+                        "delta": {
+                            "role": "assistant" if idx == 0 else None,
+                            "content": t,
+                        },
+                        "finish_reason": None,
+                        "logprobs": None,
+                    }
+                ],
+                "created": 1700000000,
+            }
+        )
+    yield SimpleNamespace(
+        model_dump=lambda: {
+            "id": "chatcmpl-stream-123",
+            "model": "openai/gpt-4o",
+            "object": "chat.completion.chunk",
+            "choices": [
+                {
+                    "index": 0,
+                    "delta": {},
+                    "finish_reason": "stop",
+                    "logprobs": None,
+                }
+            ],
+            "created": 1700000000,
+        }
+    )
+
+
+# ---------------------------------------------------------------------------
+# Initialization
+# ---------------------------------------------------------------------------
+
+
+def test_litellm_client_default_model():
+    client = LiteLLMChatClient()
+    assert client.model == "openai/gpt-4o"
+    assert client.provider == "litellm"
+    assert client.api == "chat"
+    assert client.client is None
+
+
+def test_litellm_client_explicit_model():
+    client = LiteLLMChatClient(model="anthropic/claude-sonnet-4-6")
+    assert client.model == "anthropic/claude-sonnet-4-6"
+
+
+def test_litellm_client_env_model():
+    with patch.dict(os.environ, {"LITELLM_MODEL": "google/gemini-pro"}, clear=False):
+        client = LiteLLMChatClient()
+        assert client.model == "google/gemini-pro"
+
+
+def test_litellm_client_config_from_params():
+    client = LiteLLMChatClient(
+        api_key="sk-test-key",
+        api_base="http://localhost:4000",
+    )
+    assert client.config.api_key == "sk-test-key"
+    assert client.config.api_base == "http://localhost:4000"
+
+
+def test_litellm_client_config_from_env():
+    env = {
+        "LITELLM_API_KEY": "env-key",
+        "LITELLM_API_BASE": "http://proxy.example.com",
+    }
+    with patch.dict(os.environ, env, clear=False):
+        client = LiteLLMChatClient()
+        assert client.config.api_key == "env-key"
+        assert client.config.api_base == "http://proxy.example.com"
+
+
+# ---------------------------------------------------------------------------
+# generate(): one-shot
+# ---------------------------------------------------------------------------
+
+
+@patch("litellm.completion")
+def test_litellm_generate_basic(mock_completion):
+    mock_completion.return_value = _fake_completion_response()
+
+    client = LiteLLMChatClient(model="anthropic/claude-sonnet-4-6")
+    resp = client.generate("Say hello")
+
+    assert isinstance(resp, LLMChatResponse)
+    msg = resp.get_message()
+    assert isinstance(msg, AssistantMessage)
+    assert msg.content == "Hello from LiteLLM"
+
+    mock_completion.assert_called_once()
+    call_kwargs = mock_completion.call_args.kwargs
+    assert call_kwargs["model"] == "anthropic/claude-sonnet-4-6"
+    assert call_kwargs["drop_params"] is True
+    assert call_kwargs["messages"] == [{"role": "user", "content": "Say hello"}]
+
+
+@patch("litellm.completion")
+def test_litellm_generate_with_api_key_and_base(mock_completion):
+    mock_completion.return_value = _fake_completion_response()
+
+    client = LiteLLMChatClient(
+        model="openai/gpt-4o",
+        api_key="sk-proxy",
+        api_base="http://localhost:4000",
+    )
+    client.generate("hi")
+
+    call_kwargs = mock_completion.call_args.kwargs
+    assert call_kwargs["api_key"] == "sk-proxy"
+    assert call_kwargs["api_base"] == "http://localhost:4000"
+
+
+@patch("litellm.completion")
+def test_litellm_generate_model_override(mock_completion):
+    mock_completion.return_value = _fake_completion_response(
+        model="openai/gpt-4o-mini"
+    )
+
+    client = LiteLLMChatClient(model="openai/gpt-4o")
+    client.generate("hi", model="openai/gpt-4o-mini")
+
+    call_kwargs = mock_completion.call_args.kwargs
+    assert call_kwargs["model"] == "openai/gpt-4o-mini"
+
+
+@patch("litellm.completion")
+def test_litellm_generate_forwards_kwargs(mock_completion):
+    mock_completion.return_value = _fake_completion_response()
+
+    client = LiteLLMChatClient(model="openai/gpt-4o")
+    client.generate("hi", temperature=0.3, max_tokens=100)
+
+    call_kwargs = mock_completion.call_args.kwargs
+    assert call_kwargs["temperature"] == 0.3
+    assert call_kwargs["max_tokens"] == 100
+
+
+@patch("litellm.completion")
+def test_litellm_generate_tool_call_response(mock_completion):
+    tool_calls = [
+        {
+            "id": "call_abc123",
+            "type": "function",
+            "function": {
+                "name": "get_weather",
+                "arguments": '{"location": "San Francisco"}',
+            },
+        }
+    ]
+    mock_completion.return_value = _fake_completion_response(tool_calls=tool_calls)
+
+    client = LiteLLMChatClient(model="openai/gpt-4o")
+    resp = client.generate("What's the weather?")
+
+    msg = resp.get_message()
+    assert msg.tool_calls is not None
+    assert len(msg.tool_calls) == 1
+    assert msg.tool_calls[0].function.name == "get_weather"
+    assert msg.tool_calls[0].function.arguments == '{"location": "San Francisco"}'
+    assert resp.results[0].finish_reason == "tool_calls"
+
+
+# ---------------------------------------------------------------------------
+# Streaming
+# ---------------------------------------------------------------------------
+
+
+@patch("litellm.completion")
+def test_litellm_generate_streaming(mock_completion):
+    mock_completion.return_value = _fake_stream_chunks()
+
+    client = LiteLLMChatClient(model="openai/gpt-4o")
+    chunks = list(client.generate("hi", stream=True))
+
+    assert len(chunks) > 0
+    assert all(isinstance(c, LLMChatResponseChunk) for c in chunks)
+    text = "".join(
+        c.result.content or "" for c in chunks if c.result and c.result.content
+    )
+    assert text == "Hello"
+
+    call_kwargs = mock_completion.call_args.kwargs
+    assert call_kwargs["stream"] is True
+
+
+# ---------------------------------------------------------------------------
+# Error handling
+# ---------------------------------------------------------------------------
+
+
+@patch("litellm.completion")
+def test_litellm_generate_api_error(mock_completion):
+    mock_completion.side_effect = RuntimeError("API down")
+
+    client = LiteLLMChatClient(model="openai/gpt-4o")
+    with pytest.raises(ValueError, match="LiteLLM API error"):
+        client.generate("hi")
+
+
+def test_litellm_generate_requires_messages():
+    client = LiteLLMChatClient()
+    with pytest.raises((ValueError, ImportError)):
+        client.generate()
+
+
+def test_litellm_from_prompty_not_implemented():
+    with pytest.raises(NotImplementedError, match="not yet supported"):
+        LiteLLMChatClient.from_prompty("some_source.prompty")
+
+
+def test_litellm_generate_rejects_unknown_structured_mode():
+    client = LiteLLMChatClient()
+    with pytest.raises((ValueError, ImportError)):
+        client.generate("hi", structured_mode="grammar")

--- a/tests/llm/test_litellm.py
+++ b/tests/llm/test_litellm.py
@@ -186,9 +186,7 @@ def test_litellm_generate_with_api_key_and_base(mock_completion):
 
 @patch("litellm.completion")
 def test_litellm_generate_model_override(mock_completion):
-    mock_completion.return_value = _fake_completion_response(
-        model="openai/gpt-4o-mini"
-    )
+    mock_completion.return_value = _fake_completion_response(model="openai/gpt-4o-mini")
 
     client = LiteLLMChatClient(model="openai/gpt-4o")
     client.generate("hi", model="openai/gpt-4o-mini")

--- a/tests/llm/test_litellm.py
+++ b/tests/llm/test_litellm.py
@@ -271,7 +271,7 @@ def test_litellm_generate_api_error(mock_completion):
 
 def test_litellm_generate_requires_messages():
     client = LiteLLMChatClient()
-    with pytest.raises((ValueError, ImportError)):
+    with pytest.raises(ValueError):
         client.generate()
 
 
@@ -282,5 +282,5 @@ def test_litellm_from_prompty_not_implemented():
 
 def test_litellm_generate_rejects_unknown_structured_mode():
     client = LiteLLMChatClient()
-    with pytest.raises((ValueError, ImportError)):
+    with pytest.raises(ValueError):
         client.generate("hi", structured_mode="grammar")

--- a/uv.lock
+++ b/uv.lock
@@ -17,7 +17,7 @@ resolution-markers = [
 ]
 
 [options]
-exclude-newer = "0001-01-01T00:00:00Z" # This has no effect and is included for backwards compatibility when using relative exclude-newer values.
+exclude-newer = "2026-06-11T14:39:34.177671Z"
 exclude-newer-span = "P7D"
 
 [options.exclude-newer-package]
@@ -1583,6 +1583,9 @@ dependencies = [
 ]
 
 [package.optional-dependencies]
+litellm = [
+    { name = "litellm" },
+]
 vectorstore = [
     { name = "chromadb" },
     { name = "nltk" },
@@ -1634,6 +1637,7 @@ requires-dist = [
     { name = "fastapi", specifier = ">=0.110.0,<1.0.0" },
     { name = "huggingface-hub", specifier = ">=0.33.4,<2.0.0" },
     { name = "jinja2", specifier = ">=3.1.0,<4.0.0" },
+    { name = "litellm", marker = "extra == 'litellm'", specifier = ">=1.80,<1.87" },
     { name = "mcp", specifier = ">=1.26.0,<2.0.0" },
     { name = "mistralai", specifier = ">=2.2.0" },
     { name = "nltk", marker = "extra == 'vectorstore'", specifier = ">=3.9.3,<4.0.0" },
@@ -1664,7 +1668,7 @@ requires-dist = [
     { name = "websockets", specifier = ">=15.0.0,<17.0.0" },
     { name = "wrapt", specifier = ">=1.14.0,<2.0.0" },
 ]
-provides-extras = ["vectorstore"]
+provides-extras = ["litellm", "vectorstore"]
 
 [package.metadata.requires-dev]
 dev = [
@@ -1996,6 +2000,47 @@ server = [
     { name = "uvicorn" },
     { name = "watchfiles" },
     { name = "websockets" },
+]
+
+[[package]]
+name = "fastuuid"
+version = "0.14.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/c3/7d/d9daedf0f2ebcacd20d599928f8913e9d2aea1d56d2d355a93bfa2b611d7/fastuuid-0.14.0.tar.gz", hash = "sha256:178947fc2f995b38497a74172adee64fdeb8b7ec18f2a5934d037641ba265d26", size = 18232, upload-time = "2025-10-19T22:19:22.402Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/98/f3/12481bda4e5b6d3e698fbf525df4443cc7dce746f246b86b6fcb2fba1844/fastuuid-0.14.0-cp311-cp311-macosx_10_12_x86_64.macosx_11_0_arm64.macosx_10_12_universal2.whl", hash = "sha256:73946cb950c8caf65127d4e9a325e2b6be0442a224fd51ba3b6ac44e1912ce34", size = 516386, upload-time = "2025-10-19T22:42:40.176Z" },
+    { url = "https://files.pythonhosted.org/packages/59/19/2fc58a1446e4d72b655648eb0879b04e88ed6fa70d474efcf550f640f6ec/fastuuid-0.14.0-cp311-cp311-macosx_10_12_x86_64.whl", hash = "sha256:12ac85024637586a5b69645e7ed986f7535106ed3013640a393a03e461740cb7", size = 264569, upload-time = "2025-10-19T22:25:50.977Z" },
+    { url = "https://files.pythonhosted.org/packages/78/29/3c74756e5b02c40cfcc8b1d8b5bac4edbd532b55917a6bcc9113550e99d1/fastuuid-0.14.0-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:05a8dde1f395e0c9b4be515b7a521403d1e8349443e7641761af07c7ad1624b1", size = 254366, upload-time = "2025-10-19T22:29:49.166Z" },
+    { url = "https://files.pythonhosted.org/packages/52/96/d761da3fccfa84f0f353ce6e3eb8b7f76b3aa21fd25e1b00a19f9c80a063/fastuuid-0.14.0-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:09378a05020e3e4883dfdab438926f31fea15fd17604908f3d39cbeb22a0b4dc", size = 278978, upload-time = "2025-10-19T22:35:41.306Z" },
+    { url = "https://files.pythonhosted.org/packages/fc/c2/f84c90167cc7765cb82b3ff7808057608b21c14a38531845d933a4637307/fastuuid-0.14.0-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:bbb0c4b15d66b435d2538f3827f05e44e2baafcc003dd7d8472dc67807ab8fd8", size = 279692, upload-time = "2025-10-19T22:25:36.997Z" },
+    { url = "https://files.pythonhosted.org/packages/af/7b/4bacd03897b88c12348e7bd77943bac32ccf80ff98100598fcff74f75f2e/fastuuid-0.14.0-cp311-cp311-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:cd5a7f648d4365b41dbf0e38fe8da4884e57bed4e77c83598e076ac0c93995e7", size = 303384, upload-time = "2025-10-19T22:29:46.578Z" },
+    { url = "https://files.pythonhosted.org/packages/c0/a2/584f2c29641df8bd810d00c1f21d408c12e9ad0c0dafdb8b7b29e5ddf787/fastuuid-0.14.0-cp311-cp311-musllinux_1_1_aarch64.whl", hash = "sha256:c0a94245afae4d7af8c43b3159d5e3934c53f47140be0be624b96acd672ceb73", size = 460921, upload-time = "2025-10-19T22:36:42.006Z" },
+    { url = "https://files.pythonhosted.org/packages/24/68/c6b77443bb7764c760e211002c8638c0c7cce11cb584927e723215ba1398/fastuuid-0.14.0-cp311-cp311-musllinux_1_1_i686.whl", hash = "sha256:2b29e23c97e77c3a9514d70ce343571e469098ac7f5a269320a0f0b3e193ab36", size = 480575, upload-time = "2025-10-19T22:28:18.975Z" },
+    { url = "https://files.pythonhosted.org/packages/5a/87/93f553111b33f9bb83145be12868c3c475bf8ea87c107063d01377cc0e8e/fastuuid-0.14.0-cp311-cp311-musllinux_1_1_x86_64.whl", hash = "sha256:1e690d48f923c253f28151b3a6b4e335f2b06bf669c68a02665bc150b7839e94", size = 452317, upload-time = "2025-10-19T22:25:32.75Z" },
+    { url = "https://files.pythonhosted.org/packages/9e/8c/a04d486ca55b5abb7eaa65b39df8d891b7b1635b22db2163734dc273579a/fastuuid-0.14.0-cp311-cp311-win32.whl", hash = "sha256:a6f46790d59ab38c6aa0e35c681c0484b50dc0acf9e2679c005d61e019313c24", size = 154804, upload-time = "2025-10-19T22:24:15.615Z" },
+    { url = "https://files.pythonhosted.org/packages/9c/b2/2d40bf00820de94b9280366a122cbaa60090c8cf59e89ac3938cf5d75895/fastuuid-0.14.0-cp311-cp311-win_amd64.whl", hash = "sha256:e150eab56c95dc9e3fefc234a0eedb342fac433dacc273cd4d150a5b0871e1fa", size = 156099, upload-time = "2025-10-19T22:24:31.646Z" },
+    { url = "https://files.pythonhosted.org/packages/02/a2/e78fcc5df65467f0d207661b7ef86c5b7ac62eea337c0c0fcedbeee6fb13/fastuuid-0.14.0-cp312-cp312-macosx_10_12_x86_64.macosx_11_0_arm64.macosx_10_12_universal2.whl", hash = "sha256:77e94728324b63660ebf8adb27055e92d2e4611645bf12ed9d88d30486471d0a", size = 510164, upload-time = "2025-10-19T22:31:45.635Z" },
+    { url = "https://files.pythonhosted.org/packages/2b/b3/c846f933f22f581f558ee63f81f29fa924acd971ce903dab1a9b6701816e/fastuuid-0.14.0-cp312-cp312-macosx_10_12_x86_64.whl", hash = "sha256:caa1f14d2102cb8d353096bc6ef6c13b2c81f347e6ab9d6fbd48b9dea41c153d", size = 261837, upload-time = "2025-10-19T22:38:38.53Z" },
+    { url = "https://files.pythonhosted.org/packages/54/ea/682551030f8c4fa9a769d9825570ad28c0c71e30cf34020b85c1f7ee7382/fastuuid-0.14.0-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:d23ef06f9e67163be38cece704170486715b177f6baae338110983f99a72c070", size = 251370, upload-time = "2025-10-19T22:40:26.07Z" },
+    { url = "https://files.pythonhosted.org/packages/14/dd/5927f0a523d8e6a76b70968e6004966ee7df30322f5fc9b6cdfb0276646a/fastuuid-0.14.0-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:0c9ec605ace243b6dbe3bd27ebdd5d33b00d8d1d3f580b39fdd15cd96fd71796", size = 277766, upload-time = "2025-10-19T22:37:23.779Z" },
+    { url = "https://files.pythonhosted.org/packages/16/6e/c0fb547eef61293153348f12e0f75a06abb322664b34a1573a7760501336/fastuuid-0.14.0-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:808527f2407f58a76c916d6aa15d58692a4a019fdf8d4c32ac7ff303b7d7af09", size = 278105, upload-time = "2025-10-19T22:26:56.821Z" },
+    { url = "https://files.pythonhosted.org/packages/2d/b1/b9c75e03b768f61cf2e84ee193dc18601aeaf89a4684b20f2f0e9f52b62c/fastuuid-0.14.0-cp312-cp312-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:2fb3c0d7fef6674bbeacdd6dbd386924a7b60b26de849266d1ff6602937675c8", size = 301564, upload-time = "2025-10-19T22:30:31.604Z" },
+    { url = "https://files.pythonhosted.org/packages/fc/fa/f7395fdac07c7a54f18f801744573707321ca0cee082e638e36452355a9d/fastuuid-0.14.0-cp312-cp312-musllinux_1_1_aarch64.whl", hash = "sha256:ab3f5d36e4393e628a4df337c2c039069344db5f4b9d2a3c9cea48284f1dd741", size = 459659, upload-time = "2025-10-19T22:31:32.341Z" },
+    { url = "https://files.pythonhosted.org/packages/66/49/c9fd06a4a0b1f0f048aacb6599e7d96e5d6bc6fa680ed0d46bf111929d1b/fastuuid-0.14.0-cp312-cp312-musllinux_1_1_i686.whl", hash = "sha256:b9a0ca4f03b7e0b01425281ffd44e99d360e15c895f1907ca105854ed85e2057", size = 478430, upload-time = "2025-10-19T22:26:22.962Z" },
+    { url = "https://files.pythonhosted.org/packages/be/9c/909e8c95b494e8e140e8be6165d5fc3f61fdc46198c1554df7b3e1764471/fastuuid-0.14.0-cp312-cp312-musllinux_1_1_x86_64.whl", hash = "sha256:3acdf655684cc09e60fb7e4cf524e8f42ea760031945aa8086c7eae2eeeabeb8", size = 450894, upload-time = "2025-10-19T22:27:01.647Z" },
+    { url = "https://files.pythonhosted.org/packages/90/eb/d29d17521976e673c55ef7f210d4cdd72091a9ec6755d0fd4710d9b3c871/fastuuid-0.14.0-cp312-cp312-win32.whl", hash = "sha256:9579618be6280700ae36ac42c3efd157049fe4dd40ca49b021280481c78c3176", size = 154374, upload-time = "2025-10-19T22:29:19.879Z" },
+    { url = "https://files.pythonhosted.org/packages/cc/fc/f5c799a6ea6d877faec0472d0b27c079b47c86b1cdc577720a5386483b36/fastuuid-0.14.0-cp312-cp312-win_amd64.whl", hash = "sha256:d9e4332dc4ba054434a9594cbfaf7823b57993d7d8e7267831c3e059857cf397", size = 156550, upload-time = "2025-10-19T22:27:49.658Z" },
+    { url = "https://files.pythonhosted.org/packages/a5/83/ae12dd39b9a39b55d7f90abb8971f1a5f3c321fd72d5aa83f90dc67fe9ed/fastuuid-0.14.0-cp313-cp313-macosx_10_12_x86_64.macosx_11_0_arm64.macosx_10_12_universal2.whl", hash = "sha256:77a09cb7427e7af74c594e409f7731a0cf887221de2f698e1ca0ebf0f3139021", size = 510720, upload-time = "2025-10-19T22:42:34.633Z" },
+    { url = "https://files.pythonhosted.org/packages/53/b0/a4b03ff5d00f563cc7546b933c28cb3f2a07344b2aec5834e874f7d44143/fastuuid-0.14.0-cp313-cp313-macosx_10_12_x86_64.whl", hash = "sha256:9bd57289daf7b153bfa3e8013446aa144ce5e8c825e9e366d455155ede5ea2dc", size = 262024, upload-time = "2025-10-19T22:30:25.482Z" },
+    { url = "https://files.pythonhosted.org/packages/9c/6d/64aee0a0f6a58eeabadd582e55d0d7d70258ffdd01d093b30c53d668303b/fastuuid-0.14.0-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:ac60fc860cdf3c3f327374db87ab8e064c86566ca8c49d2e30df15eda1b0c2d5", size = 251679, upload-time = "2025-10-19T22:36:14.096Z" },
+    { url = "https://files.pythonhosted.org/packages/60/f5/a7e9cda8369e4f7919d36552db9b2ae21db7915083bc6336f1b0082c8b2e/fastuuid-0.14.0-cp313-cp313-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:ab32f74bd56565b186f036e33129da77db8be09178cd2f5206a5d4035fb2a23f", size = 277862, upload-time = "2025-10-19T22:36:23.302Z" },
+    { url = "https://files.pythonhosted.org/packages/f0/d3/8ce11827c783affffd5bd4d6378b28eb6cc6d2ddf41474006b8d62e7448e/fastuuid-0.14.0-cp313-cp313-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:33e678459cf4addaedd9936bbb038e35b3f6b2061330fd8f2f6a1d80414c0f87", size = 278278, upload-time = "2025-10-19T22:29:43.809Z" },
+    { url = "https://files.pythonhosted.org/packages/a2/51/680fb6352d0bbade04036da46264a8001f74b7484e2fd1f4da9e3db1c666/fastuuid-0.14.0-cp313-cp313-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:1e3cc56742f76cd25ecb98e4b82a25f978ccffba02e4bdce8aba857b6d85d87b", size = 301788, upload-time = "2025-10-19T22:36:06.825Z" },
+    { url = "https://files.pythonhosted.org/packages/fa/7c/2014b5785bd8ebdab04ec857635ebd84d5ee4950186a577db9eff0fb8ff6/fastuuid-0.14.0-cp313-cp313-musllinux_1_1_aarch64.whl", hash = "sha256:cb9a030f609194b679e1660f7e32733b7a0f332d519c5d5a6a0a580991290022", size = 459819, upload-time = "2025-10-19T22:35:31.623Z" },
+    { url = "https://files.pythonhosted.org/packages/01/d2/524d4ceeba9160e7a9bc2ea3e8f4ccf1ad78f3bde34090ca0c51f09a5e91/fastuuid-0.14.0-cp313-cp313-musllinux_1_1_i686.whl", hash = "sha256:09098762aad4f8da3a888eb9ae01c84430c907a297b97166b8abc07b640f2995", size = 478546, upload-time = "2025-10-19T22:26:03.023Z" },
+    { url = "https://files.pythonhosted.org/packages/bc/17/354d04951ce114bf4afc78e27a18cfbd6ee319ab1829c2d5fb5e94063ac6/fastuuid-0.14.0-cp313-cp313-musllinux_1_1_x86_64.whl", hash = "sha256:1383fff584fa249b16329a059c68ad45d030d5a4b70fb7c73a08d98fd53bcdab", size = 450921, upload-time = "2025-10-19T22:31:02.151Z" },
+    { url = "https://files.pythonhosted.org/packages/fb/be/d7be8670151d16d88f15bb121c5b66cdb5ea6a0c2a362d0dcf30276ade53/fastuuid-0.14.0-cp313-cp313-win32.whl", hash = "sha256:a0809f8cc5731c066c909047f9a314d5f536c871a7a22e815cc4967c110ac9ad", size = 154559, upload-time = "2025-10-19T22:36:36.011Z" },
+    { url = "https://files.pythonhosted.org/packages/22/1d/5573ef3624ceb7abf4a46073d3554e37191c868abc3aecd5289a72f9810a/fastuuid-0.14.0-cp313-cp313-win_amd64.whl", hash = "sha256:0df14e92e7ad3276327631c9e7cec09e32572ce82089c55cb1bb8df71cf394ed", size = 156539, upload-time = "2025-10-19T22:33:35.898Z" },
 ]
 
 [[package]]
@@ -2927,6 +2972,29 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/f9/0c/738c4824fdfe74dc0f95d5e90ef9e759d4ecf7fd5ba964d54a7703322251/librt-0.6.3-cp313-cp313-win32.whl", hash = "sha256:25b1b60cb059471c0c0c803e07d0dfdc79e41a0a122f288b819219ed162672a3", size = 20159, upload-time = "2025-11-29T14:01:18.61Z" },
     { url = "https://files.pythonhosted.org/packages/f2/95/93d0e61bc617306ecf4c54636b5cbde4947d872563565c4abdd9d07a39d3/librt-0.6.3-cp313-cp313-win_amd64.whl", hash = "sha256:10a95ad074e2a98c9e4abc7f5b7d40e5ecbfa84c04c6ab8a70fabf59bd429b88", size = 21484, upload-time = "2025-11-29T14:01:19.506Z" },
     { url = "https://files.pythonhosted.org/packages/10/23/abd7ace79ab54d1dbee265f13529266f686a7ce2d21ab59a992f989009b6/librt-0.6.3-cp313-cp313-win_arm64.whl", hash = "sha256:17000df14f552e86877d67e4ab7966912224efc9368e998c96a6974a8d609bf9", size = 20935, upload-time = "2025-11-29T14:01:20.415Z" },
+]
+
+[[package]]
+name = "litellm"
+version = "1.86.5"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "aiohttp" },
+    { name = "click" },
+    { name = "fastuuid" },
+    { name = "httpx" },
+    { name = "importlib-metadata" },
+    { name = "jinja2" },
+    { name = "jsonschema" },
+    { name = "openai" },
+    { name = "pydantic" },
+    { name = "python-dotenv" },
+    { name = "tiktoken" },
+    { name = "tokenizers" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/86/b0/f9d77f086fd2eec69ff1b80083003134994d11e540206cd3a18ef29affbd/litellm-1.86.5.tar.gz", hash = "sha256:caadbedb3e894f5b5d940ca14bbc228f6d42d67876ac38252a52347acaddaaaa", size = 15385926, upload-time = "2026-06-11T02:50:22.931Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/7e/03/baa73376a73146dc627a8d767f4542983782e6a22d3d2c4a1bf24e8e26ba/litellm-1.86.5-py3-none-any.whl", hash = "sha256:6842c1d10c561e7312dc5a6324d13efaebf53c82641c6530e0d969d3090bdc4d", size = 17020244, upload-time = "2026-06-11T02:50:16.335Z" },
 ]
 
 [[package]]

--- a/uv.lock
+++ b/uv.lock
@@ -1551,6 +1551,7 @@ dependencies = [
     { name = "fastapi" },
     { name = "huggingface-hub" },
     { name = "jinja2" },
+    { name = "litellm" },
     { name = "mcp" },
     { name = "mistralai" },
     { name = "numpy" },
@@ -1580,9 +1581,6 @@ dependencies = [
 ]
 
 [package.optional-dependencies]
-litellm = [
-    { name = "litellm" },
-]
 vectorstore = [
     { name = "chromadb" },
     { name = "nltk" },
@@ -1634,7 +1632,7 @@ requires-dist = [
     { name = "fastapi", specifier = ">=0.110.0,<1.0.0" },
     { name = "huggingface-hub", specifier = ">=0.33.4,<2.0.0" },
     { name = "jinja2", specifier = ">=3.1.0,<4.0.0" },
-    { name = "litellm", marker = "extra == 'litellm'", specifier = ">=1.80,<1.87" },
+    { name = "litellm", specifier = ">=1.80,<1.87" },
     { name = "mcp", specifier = ">=1.26.0,<2.0.0" },
     { name = "mistralai", specifier = ">=2.2.0" },
     { name = "nltk", marker = "extra == 'vectorstore'", specifier = ">=3.9.3,<4.0.0" },
@@ -1665,7 +1663,7 @@ requires-dist = [
     { name = "websockets", specifier = ">=15.0.0,<17.0.0" },
     { name = "wrapt", specifier = ">=1.14.0,<2.0.0" },
 ]
-provides-extras = ["litellm", "vectorstore"]
+provides-extras = ["vectorstore"]
 
 [package.metadata.requires-dev]
 dev = [


### PR DESCRIPTION
# Description

Add LiteLLM as a chat provider for Dapr Agents, enabling access to 100+ LLM providers (OpenAI, Anthropic, Google, Azure, AWS Bedrock, Cohere, Mistral, etc.) through a single unified interface.

LiteLLM acts as an AI gateway that translates between provider-specific APIs while returning OpenAI-compatible responses. `LiteLLMChatClient` supports streaming, tools/function calling, and structured output by reusing the existing OpenAI response and stream handlers.

**Usage:**
```python
from dapr_agents import LiteLLMChatClient

client = LiteLLMChatClient(model="anthropic/claude-sonnet-4-6")
response = client.generate("Hello, world!")
```

- Follows the existing dual-inheritance pattern (`LiteLLMClientBase` + `ChatClientBase`)
- Optional dependency: `pip install dapr-agents[litellm]`
- Lazy imports so the package loads normally without litellm installed
- Uses `drop_params=True` for cross-provider compatibility

## Issue reference

N/A - new feature addition.

## Checklist

* [x] Created/updated tests
* [x] Tested this change against all the quickstarts
* [ ] Extended the documentation
    * [ ] Created the [dapr/docs](https://github.com/dapr/docs) PR: N/A
