### PR TITLE
fix: handle unexpected status types in _normalize_status

### DIFF
--- a/dapr_agents/workflow/utils/subscription.py
+++ b/dapr_agents/workflow/utils/subscription.py
@@ -304,6 +304,8 @@ def _normalize_status(status: str | TopicEventResponseStatus) -> str | None:
             raw = status.name
         case str():
             raw = status
+        case _:
+            return None
     lowered = raw.lower()
     for known in (STATUS_SUCCESS, STATUS_RETRY, STATUS_DROP):
         if known in lowered:

--- a/tests/workflow/test_message_router.py
+++ b/tests/workflow/test_message_router.py
@@ -1564,6 +1564,10 @@ def test_normalize_status_unknown_returns_none():
     assert _normalize_status("teapot") is None
 
 
+def test_normalize_status_non_str_non_enum_returns_none():
+    assert _normalize_status(None) is None
+
+
 # ---- _filter_accepts -------------------------------------------------------
 
 


### PR DESCRIPTION
# Description

`_normalize_status` matches on `TopicEventResponseStatus()` and `str()` but has no wildcard case, so `raw` is left unbound when a status of any other type comes through. The following `raw.lower()` then raises `UnboundLocalError` instead of returning `None`. The async stream path already documents that unknown statuses should fall through to retry (and checks `status is None`), so returning `None` here matches the intended contract.

Added a `case _: return None` and a regression test for the non-str/non-enum input.

## Issue reference

We strive to have all PR being opened based on an issue, where the problem or feature have been discussed prior to implementation.

Please reference the issue this PR closes: #652

## Checklist

Please make sure you've completed the relevant tasks for this PR, out of the following list:

* [x] Created/updated tests
* [ ] Tested this change against all the quickstarts
* [ ] Extended the documentation
    * [ ] Created the [dapr/docs](https://github.com/dapr/docs) PR: <insert PR link here>

**Note:** We expect contributors to open a corresponding documentation PR in the [dapr/docs](https://github.com/dapr/docs/) repository. As the implementer, you are the best person to document your work! Implementation PRs will not be merged until the documentation PR is opened and ready for review.
