### PR TITLE
fix(workflow): add default case to _normalize_status match statement

### DIFF
--- a/dapr_agents/workflow/utils/subscription.py
+++ b/dapr_agents/workflow/utils/subscription.py
@@ -304,6 +304,8 @@ def _normalize_status(status: str | TopicEventResponseStatus) -> str | None:
             raw = status.name
         case str():
             raw = status
+        case _:
+            return None
     lowered = raw.lower()
     for known in (STATUS_SUCCESS, STATUS_RETRY, STATUS_DROP):
         if known in lowered:


### PR DESCRIPTION
## Summary

Fixes #652.

The `match` statement in `_normalize_status` had no default arm. Any `status` value that is neither a `TopicEventResponseStatus` instance nor a plain `str` left `raw` undefined, causing a `NameError` on `raw.lower()`.

**Fix:** add `case _: return None` to short-circuit cleanly for unrecognised input, consistent with the function's declared return type of `str | None`.

## Change

```python
# Before
match status:
    case TopicEventResponseStatus():
        raw = status.name
    case str():
        raw = status
lowered = raw.lower()  # NameError if neither case matched

# After
match status:
    case TopicEventResponseStatus():
        raw = status.name
    case str():
        raw = status
    case _:
        return None
lowered = raw.lower()  # safe — only reached when raw is defined
```

🤖 Generated with [Claude Code](https://claude.ai/claude-code)