### PR TITLE
feat(registry): add backoff handling to manage deregistration of agents in multi-agent-system

### DIFF
--- a/dapr_agents/agents/components.py
+++ b/dapr_agents/agents/components.py
@@ -17,7 +17,7 @@ import logging
 import random
 import time
 from datetime import datetime, timezone
-from typing import Any, Dict, Optional, Sequence
+from typing import Any, Callable, Dict, Optional, Sequence
 
 from dapr.clients.grpc._state import Concurrency, Consistency, StateOptions
 
@@ -38,6 +38,12 @@ logger = logging.getLogger(__name__)
 
 # Registry index key for the list of registered agent names
 _REGISTRY_AGENTS_KEY = "agents"
+
+# Registry index concurrency
+_INDEX_MUTATION_MAX_ATTEMPTS = 50
+_INDEX_MUTATION_BUDGET_SECONDS = 10.0
+_INDEX_BACKOFF_BASE_SECONDS = 0.05
+_INDEX_BACKOFF_CAP_SECONDS = 1.0
 
 
 class DaprInfra:
@@ -605,39 +611,18 @@ class DaprInfra:
         # (etag!=None) cases atomically, so no separate initialization step is needed.
         index_key = self._team_registry_index_key(team)
 
-        attempts = max(1, min(self._max_etag_attempts, 10))
-        for attempt in range(1, attempts + 1):
-            try:
-                current_index, etag = self.registry_state.load_with_etag(
-                    key=index_key,
-                    default={_REGISTRY_AGENTS_KEY: []},
-                    state_metadata=partition_meta,
-                )
-                agents_list = current_index.get(_REGISTRY_AGENTS_KEY, [])
-                if self.name not in agents_list:
-                    agents_list.append(self.name)
-                    self.registry_state.save(
-                        key=index_key,
-                        value={_REGISTRY_AGENTS_KEY: agents_list},
-                        etag=etag,
-                        state_metadata=partition_meta,
-                        state_options=self._save_options,
-                    )
-                break
-            except Exception as exc:  # noqa: BLE001
-                logger.warning(
-                    "Conflict updating registry index (attempt %d/%d) for '%s': %s",
-                    attempt,
-                    attempts,
-                    index_key,
-                    exc,
-                )
-                if attempt == attempts:
-                    logger.exception(
-                        "Failed to update registry index after %d attempts.", attempts
-                    )
-                    return
-                time.sleep(min(0.25 * attempt, 1.0) * (1 + random.uniform(0, 0.25)))
+        def _add(agents_list: list) -> bool:
+            if self.name in agents_list:
+                return False
+            agents_list.append(self.name)
+            return True
+
+        if not self._mutate_team_index(
+            index_key=index_key,
+            partition_meta=partition_meta,
+            mutate=_add,
+        ):
+            return
 
         logger.info(
             "Registered agent '%s' in team '%s' registry",
@@ -769,18 +754,65 @@ class DaprInfra:
 
         # Step 2: Remove agent name from index (ETag-protected)
         index_key = self._team_registry_index_key(team)
-        attempts = max(1, min(self._max_etag_attempts, 10))
-        for attempt in range(1, attempts + 1):
+
+        def _remove(agents_list: list) -> bool:
+            if agent_name not in agents_list:
+                return False
+            agents_list.remove(agent_name)
+            return True
+
+        self._mutate_team_index(
+            index_key=index_key,
+            partition_meta=partition_meta,
+            mutate=_remove,
+        )
+
+        logger.info(
+            "Deregistered agent '%s' from team '%s' registry",
+            agent_name,
+            self._effective_team(team),
+        )
+
+    def _mutate_team_index(
+        self,
+        *,
+        index_key: str,
+        partition_meta: Dict[str, str],
+        mutate: Callable[[list], bool],
+    ) -> bool:
+        """
+        Apply ``mutate`` to the team index's agent-name list under optimistic concurrency.
+
+        Re-reads the index and its ETag on every attempt, lets ``mutate`` edit the
+        list in place (returning True when a write is needed), then saves with the
+        ETag. On a conflict it retries with full-jitter exponential backoff to
+        de-synchronize concurrent writers — essential when an entire team registers
+        or deregisters at once and every agent contends on this single shared
+        document. Bounded by both an attempt count and a wall-clock budget so a
+        mutation never overruns the caller's shutdown grace period.
+
+        Args:
+            index_key: Team index document key.
+            partition_meta: Dapr partition/metadata for the index key.
+            mutate: Callback that edits the agent-name list in place and returns
+                True if the change needs to be written, False if already satisfied.
+
+        Returns:
+            True if the index reached the desired state (written or already
+            correct); False if every attempt failed.
+        """
+        deadline = time.monotonic() + _INDEX_MUTATION_BUDGET_SECONDS
+        last_exc: Optional[Exception] = None
+        for attempt in range(1, _INDEX_MUTATION_MAX_ATTEMPTS + 1):
             try:
                 current_index, etag = self.registry_state.load_with_etag(
                     key=index_key,
                     default={_REGISTRY_AGENTS_KEY: []},
                     state_metadata=partition_meta,
                 )
-                agents_list = current_index.get(_REGISTRY_AGENTS_KEY, [])
-                if agent_name not in agents_list:
-                    break
-                agents_list.remove(agent_name)
+                agents_list = list(current_index.get(_REGISTRY_AGENTS_KEY, []))
+                if not mutate(agents_list):
+                    return True  # already in the desired state; nothing to write
                 self.registry_state.save(
                     key=index_key,
                     value={_REGISTRY_AGENTS_KEY: agents_list},
@@ -788,27 +820,48 @@ class DaprInfra:
                     state_metadata=partition_meta,
                     state_options=self._save_options,
                 )
-                break
+                return True
             except Exception as exc:  # noqa: BLE001
+                last_exc = exc
+                if (
+                    attempt >= _INDEX_MUTATION_MAX_ATTEMPTS
+                    or time.monotonic() >= deadline
+                ):
+                    break
                 logger.warning(
-                    "Conflict updating registry index (attempt %d/%d) for '%s': %s",
-                    attempt,
-                    attempts,
+                    "Conflict updating registry index '%s' (attempt %d/%d): %s",
                     index_key,
+                    attempt,
+                    _INDEX_MUTATION_MAX_ATTEMPTS,
                     exc,
                 )
-                if attempt == attempts:
-                    logger.exception(
-                        "Failed to update registry index after %d attempts.", attempts
-                    )
-                    return
-                time.sleep(min(0.25 * attempt, 1.0) * (1 + random.uniform(0, 0.25)))
+                self._sleep_index_backoff(attempt, deadline)
 
-        logger.info(
-            "Deregistered agent '%s' from team '%s' registry",
-            agent_name,
-            self._effective_team(team),
+        logger.error(
+            "Failed to update registry index '%s' after %d attempt(s): %s",
+            index_key,
+            attempt,
+            last_exc,
         )
+        return False
+
+    @staticmethod
+    def _sleep_index_backoff(attempt: int, deadline: float) -> None:
+        """
+        Sleep with full-jitter exponential backoff, never past ``deadline``.
+
+        Full jitter (a uniform random delay in ``[0, ceiling]``) de-correlates
+        concurrent writers far better than a fixed or linear delay — that is what
+        lets a whole team converge instead of repeatedly colliding in lock-step.
+        """
+        ceiling = min(
+            _INDEX_BACKOFF_CAP_SECONDS,
+            _INDEX_BACKOFF_BASE_SECONDS * (2 ** min(attempt - 1, 20)),
+        )
+        remaining = deadline - time.monotonic()
+        if remaining <= 0:
+            return
+        time.sleep(min(random.uniform(0, ceiling), remaining))
 
     # ------------------------------------------------------------------
     # Internal helpers

--- a/dapr_agents/agents/components.py
+++ b/dapr_agents/agents/components.py
@@ -807,7 +807,7 @@ class DaprInfra:
             correct); False if every attempt failed.
         """
         cfg = self._registry_index_retry
-        deadline = time.monotonic() + cfg.budget_seconds
+        deadline = time.monotonic() + cfg.retry_timeout
         last_exc: Optional[Exception] = None
         for attempt in range(1, cfg.max_attempts + 1):
             try:
@@ -859,8 +859,8 @@ class DaprInfra:
         """
         cfg = self._registry_index_retry
         ceiling = min(
-            cfg.backoff_cap_seconds,
-            cfg.backoff_base_seconds * (2 ** min(attempt - 1, 20)),
+            cfg.max_backoff_seconds,
+            cfg.initial_backoff_seconds * (2 ** min(attempt - 1, 20)),
         )
         remaining = deadline - time.monotonic()
         if remaining <= 0:

--- a/dapr_agents/agents/components.py
+++ b/dapr_agents/agents/components.py
@@ -29,6 +29,7 @@ from dapr_agents.agents.configs import (
     AgentRegistryConfig,
     AgentStateConfig,
     DEFAULT_AGENT_WORKFLOW_BUNDLE,
+    RegistryIndexRetryConfig,
     WorkflowGrpcOptions,
     StateModelBundle,
 )
@@ -38,12 +39,6 @@ logger = logging.getLogger(__name__)
 
 # Registry index key for the list of registered agent names
 _REGISTRY_AGENTS_KEY = "agents"
-
-# Registry index concurrency
-_INDEX_MUTATION_MAX_ATTEMPTS = 50
-_INDEX_MUTATION_BUDGET_SECONDS = 10.0
-_INDEX_BACKOFF_BASE_SECONDS = 0.05
-_INDEX_BACKOFF_CAP_SECONDS = 1.0
 
 
 class DaprInfra:
@@ -79,7 +74,9 @@ class DaprInfra:
             state: Durable state (Dapr state store, key overrides, defaults, hooks).
             registry: Agent registry backing store and team settings.
             base_metadata: Base metadata for Dapr state operations.
-            max_etag_attempts: Max optimistic-concurrency retries on registry mutations.
+            max_etag_attempts: Max optimistic-concurrency retries on per-key
+                workflow-state saves. Registry-index contention is governed
+                separately by ``registry.index_retry``.
             default_bundle: Default state schema bundle (injected by agent/orchestrator class).
         """
         self.name = name
@@ -145,6 +142,9 @@ class DaprInfra:
         # -----------------------------
         self._registry = registry
         self.registry_state = registry.store if registry else None
+        self._registry_index_retry = (
+            registry.index_retry if registry else RegistryIndexRetryConfig()
+        )
         self._registry_prefix = "agents:"
         self._registry_team_override = (
             registry.team_name if registry and registry.team_name else "default"
@@ -761,11 +761,16 @@ class DaprInfra:
             agents_list.remove(agent_name)
             return True
 
-        self._mutate_team_index(
+        if not self._mutate_team_index(
             index_key=index_key,
             partition_meta=partition_meta,
             mutate=_remove,
-        )
+        ):
+            # _mutate_team_index already logged the failure (with traceback). The
+            # per-agent key is already gone, so a leftover index entry is stale and
+            # self-heals on read (get_agents_metadata skips missing per-agent keys);
+            # don't claim a successful deregistration here.
+            return
 
         logger.info(
             "Deregistered agent '%s' from team '%s' registry",
@@ -801,9 +806,10 @@ class DaprInfra:
             True if the index reached the desired state (written or already
             correct); False if every attempt failed.
         """
-        deadline = time.monotonic() + _INDEX_MUTATION_BUDGET_SECONDS
+        cfg = self._registry_index_retry
+        deadline = time.monotonic() + cfg.budget_seconds
         last_exc: Optional[Exception] = None
-        for attempt in range(1, _INDEX_MUTATION_MAX_ATTEMPTS + 1):
+        for attempt in range(1, cfg.max_attempts + 1):
             try:
                 current_index, etag = self.registry_state.load_with_etag(
                     key=index_key,
@@ -823,16 +829,13 @@ class DaprInfra:
                 return True
             except Exception as exc:  # noqa: BLE001
                 last_exc = exc
-                if (
-                    attempt >= _INDEX_MUTATION_MAX_ATTEMPTS
-                    or time.monotonic() >= deadline
-                ):
+                if attempt >= cfg.max_attempts or time.monotonic() >= deadline:
                     break
                 logger.warning(
                     "Conflict updating registry index '%s' (attempt %d/%d): %s",
                     index_key,
                     attempt,
-                    _INDEX_MUTATION_MAX_ATTEMPTS,
+                    cfg.max_attempts,
                     exc,
                 )
                 self._sleep_index_backoff(attempt, deadline)
@@ -842,11 +845,11 @@ class DaprInfra:
             index_key,
             attempt,
             last_exc,
+            exc_info=last_exc,
         )
         return False
 
-    @staticmethod
-    def _sleep_index_backoff(attempt: int, deadline: float) -> None:
+    def _sleep_index_backoff(self, attempt: int, deadline: float) -> None:
         """
         Sleep with full-jitter exponential backoff, never past ``deadline``.
 
@@ -854,9 +857,10 @@ class DaprInfra:
         concurrent writers far better than a fixed or linear delay — that is what
         lets a whole team converge instead of repeatedly colliding in lock-step.
         """
+        cfg = self._registry_index_retry
         ceiling = min(
-            _INDEX_BACKOFF_CAP_SECONDS,
-            _INDEX_BACKOFF_BASE_SECONDS * (2 ** min(attempt - 1, 20)),
+            cfg.backoff_cap_seconds,
+            cfg.backoff_base_seconds * (2 ** min(attempt - 1, 20)),
         )
         remaining = deadline - time.monotonic()
         if remaining <= 0:

--- a/dapr_agents/agents/configs.py
+++ b/dapr_agents/agents/configs.py
@@ -121,6 +121,44 @@ class WorkflowGrpcOptions:
             raise ValueError("keepalive_timeout_ms must be greater than 0")
 
 
+@dataclass(frozen=True)
+class RegistryIndexRetryConfig:
+    """
+    Retry/backoff policy for mutating the shared team-registry ``_index`` document.
+
+    The index is a single document that every agent on a team contends on when it
+    registers or deregisters (acutely so during a coordinated shutdown, where a
+    whole team writes at once). Under that N-way optimistic-concurrency contention a
+    single mutation can need many more attempts than an ordinary per-key state save,
+    which is why this policy is intentionally separate from ``max_etag_attempts``
+    (that knob governs single-writer workflow-state saves and is clamped low). A
+    mutation is bounded by *both* an attempt count and a wall-clock budget so it can
+    never overrun the caller's shutdown grace period, and uses full-jitter
+    exponential backoff to de-correlate concurrent writers so the team converges.
+
+    Attributes:
+        max_attempts: Maximum optimistic-concurrency attempts before giving up.
+        budget_seconds: Wall-clock ceiling across all attempts, including backoff.
+        backoff_base_seconds: Base delay for full-jitter exponential backoff.
+        backoff_cap_seconds: Per-attempt backoff ceiling.
+    """
+
+    max_attempts: int = 50
+    budget_seconds: float = 10.0
+    backoff_base_seconds: float = 0.05
+    backoff_cap_seconds: float = 1.0
+
+    def __post_init__(self) -> None:
+        if self.max_attempts <= 0:
+            raise ValueError("max_attempts must be greater than 0")
+        if self.budget_seconds <= 0:
+            raise ValueError("budget_seconds must be greater than 0")
+        if self.backoff_base_seconds <= 0:
+            raise ValueError("backoff_base_seconds must be greater than 0")
+        if self.backoff_cap_seconds <= 0:
+            raise ValueError("backoff_cap_seconds must be greater than 0")
+
+
 @dataclass
 class AgentStateConfig:
     """
@@ -302,10 +340,20 @@ class RuntimeSubscriptionConfig:
 
 @dataclass
 class AgentRegistryConfig:
-    """Configuration for agent registry storage."""
+    """Configuration for agent registry storage.
+
+    Attributes:
+        store: Dapr state store backing the team registry.
+        team_name: Optional team override; falls back to the configured default.
+        index_retry: Retry/backoff policy for mutating the shared team-index
+            document under multi-agent contention (e.g. coordinated shutdown).
+    """
 
     store: StateStoreService
     team_name: Optional[str] = None
+    index_retry: RegistryIndexRetryConfig = field(
+        default_factory=RegistryIndexRetryConfig
+    )
 
 
 @dataclass

--- a/dapr_agents/agents/configs.py
+++ b/dapr_agents/agents/configs.py
@@ -132,31 +132,39 @@ class RegistryIndexRetryConfig:
     single mutation can need many more attempts than an ordinary per-key state save,
     which is why this policy is intentionally separate from ``max_etag_attempts``
     (that knob governs single-writer workflow-state saves and is clamped low). A
-    mutation is bounded by *both* an attempt count and a wall-clock budget so it can
+    mutation is bounded by *both* an attempt count and a wall-clock timeout so it can
     never overrun the caller's shutdown grace period, and uses full-jitter
     exponential backoff to de-correlate concurrent writers so the team converges.
 
+    Field names mirror :class:`WorkflowRetryPolicy` for consistency across the
+    package's retry configuration.
+
+    .. warning::
+        **Alpha.** These fields are user-facing but not yet stable; the names may
+        change in a future 0.x release.
+
     Attributes:
         max_attempts: Maximum optimistic-concurrency attempts before giving up.
-        budget_seconds: Wall-clock ceiling across all attempts, including backoff.
-        backoff_base_seconds: Base delay for full-jitter exponential backoff.
-        backoff_cap_seconds: Per-attempt backoff ceiling.
+        initial_backoff_seconds: Initial ceiling for the full-jitter backoff delay.
+        max_backoff_seconds: Maximum ceiling for the full-jitter backoff delay.
+        retry_timeout: Wall-clock budget in seconds across all attempts, including
+            backoff.
     """
 
     max_attempts: int = 50
-    budget_seconds: float = 10.0
-    backoff_base_seconds: float = 0.05
-    backoff_cap_seconds: float = 1.0
+    initial_backoff_seconds: float = 0.05
+    max_backoff_seconds: float = 1.0
+    retry_timeout: float = 10.0
 
     def __post_init__(self) -> None:
         if self.max_attempts <= 0:
             raise ValueError("max_attempts must be greater than 0")
-        if self.budget_seconds <= 0:
-            raise ValueError("budget_seconds must be greater than 0")
-        if self.backoff_base_seconds <= 0:
-            raise ValueError("backoff_base_seconds must be greater than 0")
-        if self.backoff_cap_seconds <= 0:
-            raise ValueError("backoff_cap_seconds must be greater than 0")
+        if self.initial_backoff_seconds <= 0:
+            raise ValueError("initial_backoff_seconds must be greater than 0")
+        if self.max_backoff_seconds <= 0:
+            raise ValueError("max_backoff_seconds must be greater than 0")
+        if self.retry_timeout <= 0:
+            raise ValueError("retry_timeout must be greater than 0")
 
 
 @dataclass

--- a/tests/agents/test_registry_index_contention.py
+++ b/tests/agents/test_registry_index_contention.py
@@ -1,0 +1,251 @@
+#
+# Copyright 2026 The Dapr Authors
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#     http://www.apache.org/licenses/LICENSE-2.0
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+"""
+Concurrency tests for the shared team-registry index.
+
+The team index is a single shared document that every agent in a team mutates on
+register/deregister. When a whole team starts or stops at once (e.g. Ctrl-C on a
+multi-agent run) all writers do a read-modify-write on the same document, so ETag
+conflicts are guaranteed. These tests reproduce that contention and assert that
+every writer converges — no agent is dropped from or stuck in the index.
+"""
+
+import copy
+import threading
+
+import pytest
+
+import dapr_agents.agents.components as components
+from dapr_agents.agents.components import DaprInfra, _REGISTRY_AGENTS_KEY
+from dapr_agents.agents.configs import AgentRegistryConfig
+from dapr_agents.storage.daprstores.stateservice import StateStoreError
+
+
+class FakeEtagStore:
+    """In-memory state store enforcing ETag optimistic concurrency.
+
+    Models a Dapr state store with first-write-wins: a save whose ``etag`` does
+    not match the currently stored etag raises ``StateStoreError``, exactly as the
+    real store does on a conflict. Thread-safe, so it can model many agents
+    mutating the shared team index simultaneously. Values are deep-copied in and
+    out so callers never share mutable references outside the ETag protection.
+    """
+
+    def __init__(self):
+        self._lock = threading.Lock()
+        self._values = {}
+        self._etags = {}
+        self._version = 0
+        self.deleted = []
+
+    def seed(self, key, value):
+        with self._lock:
+            self._version += 1
+            self._values[key] = copy.deepcopy(value)
+            self._etags[key] = str(self._version)
+
+    def load_with_etag(self, *, key, default=None, state_metadata=None):
+        with self._lock:
+            if key not in self._values:
+                return (copy.deepcopy(default), None)
+            return (copy.deepcopy(self._values[key]), self._etags[key])
+
+    def save(self, *, key, value, etag=None, state_metadata=None, state_options=None):
+        with self._lock:
+            current = self._etags.get(key)
+            if current is not None and etag != current:
+                raise StateStoreError(
+                    f"etag mismatch for {key}: stored={current} provided={etag}"
+                )
+            if current is None and etag is not None:
+                raise StateStoreError(f"etag provided for missing key {key}")
+            self._version += 1
+            self._values[key] = copy.deepcopy(value)
+            self._etags[key] = str(self._version)
+
+    def delete(self, *, key, state_metadata=None, etag=None):
+        with self._lock:
+            self.deleted.append(key)
+            self._values.pop(key, None)
+            self._etags.pop(key, None)
+
+
+def _make_infra(name, store):
+    return DaprInfra(
+        name=name,
+        registry=AgentRegistryConfig(store=store, team_name="default"),
+    )
+
+
+@pytest.fixture
+def fast_backoff(monkeypatch):
+    """Shrink backoff so contention tests run quickly while still de-correlating."""
+    monkeypatch.setattr(components, "_INDEX_BACKOFF_BASE_SECONDS", 0.001)
+    monkeypatch.setattr(components, "_INDEX_BACKOFF_CAP_SECONDS", 0.03)
+
+
+def _run_concurrently(targets):
+    errors = []
+
+    def wrap(fn):
+        def inner():
+            try:
+                fn()
+            except Exception as exc:  # pragma: no cover - failures surface via errors
+                errors.append(exc)
+
+        return inner
+
+    threads = [threading.Thread(target=wrap(fn)) for fn in targets]
+    for t in threads:
+        t.start()
+    for t in threads:
+        t.join(timeout=30)
+    assert not any(t.is_alive() for t in threads), "a worker thread hung"
+    return errors
+
+
+@pytest.mark.parametrize("num_agents", [8])
+def test_concurrent_deregister_all_converge(fast_backoff, num_agents):
+    """Every agent deregisters concurrently and the index ends empty."""
+    store = FakeEtagStore()
+    names = [f"agent-{i}" for i in range(num_agents)]
+    infras = [_make_infra(n, store) for n in names]
+
+    index_key = infras[0]._team_registry_index_key("default")
+    store.seed(index_key, {_REGISTRY_AGENTS_KEY: list(names)})
+
+    errors = _run_concurrently([inf.deregister_agentic_system for inf in infras])
+
+    assert not errors, f"deregistration raised under contention: {errors}"
+    final, _ = store.load_with_etag(key=index_key)
+    assert final[_REGISTRY_AGENTS_KEY] == [], (
+        f"every agent should be removed from the index, got {final}"
+    )
+    # Each agent also deletes its own per-agent key (step 1).
+    for n in names:
+        assert f"agents:default:{n}" in store.deleted
+
+
+@pytest.mark.parametrize("num_agents", [8])
+def test_concurrent_index_add_all_converge(fast_backoff, num_agents):
+    """Every agent adds itself to the index concurrently; none is lost."""
+    store = FakeEtagStore()
+    names = [f"agent-{i}" for i in range(num_agents)]
+    infras = [_make_infra(n, store) for n in names]
+
+    index_key = infras[0]._team_registry_index_key("default")
+    store.seed(index_key, {_REGISTRY_AGENTS_KEY: []})
+    partition = infras[0]._registry_partition_key("default")
+
+    def adder(infra):
+        def _add(agents_list):
+            if infra.name in agents_list:
+                return False
+            agents_list.append(infra.name)
+            return True
+
+        def run():
+            assert infra._mutate_team_index(
+                index_key=index_key, partition_meta=partition, mutate=_add
+            )
+
+        return run
+
+    errors = _run_concurrently([adder(inf) for inf in infras])
+
+    assert not errors, f"index add raised under contention: {errors}"
+    final, _ = store.load_with_etag(key=index_key)
+    assert sorted(final[_REGISTRY_AGENTS_KEY]) == sorted(names), (
+        f"all agents should be present exactly once, got {final}"
+    )
+
+
+def test_mutate_team_index_gives_up_when_always_conflicting(monkeypatch):
+    """A permanently-conflicting store fails bounded — it must not hang."""
+    monkeypatch.setattr(components, "_INDEX_MUTATION_MAX_ATTEMPTS", 4)
+    monkeypatch.setattr(components, "_INDEX_MUTATION_BUDGET_SECONDS", 5.0)
+    monkeypatch.setattr(components, "_INDEX_BACKOFF_BASE_SECONDS", 0.001)
+    monkeypatch.setattr(components, "_INDEX_BACKOFF_CAP_SECONDS", 0.005)
+
+    store = FakeEtagStore()
+    index_key = "agents:default:_index"
+    store.seed(index_key, {_REGISTRY_AGENTS_KEY: ["agent-0"]})
+
+    load_calls = {"n": 0}
+    real_load = store.load_with_etag
+
+    def flaky_load(**kw):
+        load_calls["n"] += 1
+        return real_load(**kw)
+
+    # Every save loses the ETag race (simulates a writer that is always last).
+    def always_conflict(**kw):
+        raise StateStoreError("permanent conflict")
+
+    store.load_with_etag = flaky_load
+    store.save = always_conflict
+
+    infra = _make_infra("agent-0", store)
+
+    def _remove(agents_list):
+        if "agent-0" not in agents_list:
+            return False
+        agents_list.remove("agent-0")
+        return True
+
+    ok = infra._mutate_team_index(
+        index_key=index_key,
+        partition_meta={},
+        mutate=_remove,
+    )
+
+    assert ok is False
+    assert load_calls["n"] == 4, "should retry up to the attempt bound, then give up"
+
+
+def test_mutate_team_index_retries_then_succeeds(monkeypatch):
+    """A few transient conflicts are absorbed; the write eventually lands."""
+    monkeypatch.setattr(components, "_INDEX_BACKOFF_BASE_SECONDS", 0.001)
+    monkeypatch.setattr(components, "_INDEX_BACKOFF_CAP_SECONDS", 0.005)
+
+    store = FakeEtagStore()
+    index_key = "agents:default:_index"
+    store.seed(index_key, {_REGISTRY_AGENTS_KEY: ["agent-0"]})
+
+    real_save = store.save
+    fail_budget = {"n": 2}
+
+    def flaky_save(**kw):
+        if fail_budget["n"] > 0:
+            fail_budget["n"] -= 1
+            raise StateStoreError("transient conflict")
+        return real_save(**kw)
+
+    store.save = flaky_save
+    infra = _make_infra("agent-0", store)
+
+    def _remove(agents_list):
+        if "agent-0" not in agents_list:
+            return False
+        agents_list.remove("agent-0")
+        return True
+
+    ok = infra._mutate_team_index(
+        index_key=index_key, partition_meta={}, mutate=_remove
+    )
+
+    assert ok is True
+    final, _ = store.load_with_etag(key=index_key)
+    assert final[_REGISTRY_AGENTS_KEY] == []

--- a/tests/agents/test_registry_index_contention.py
+++ b/tests/agents/test_registry_index_contention.py
@@ -26,9 +26,8 @@ import threading
 
 import pytest
 
-import dapr_agents.agents.components as components
 from dapr_agents.agents.components import DaprInfra, _REGISTRY_AGENTS_KEY
-from dapr_agents.agents.configs import AgentRegistryConfig
+from dapr_agents.agents.configs import AgentRegistryConfig, RegistryIndexRetryConfig
 from dapr_agents.storage.daprstores.stateservice import StateStoreError
 
 
@@ -81,18 +80,22 @@ class FakeEtagStore:
             self._etags.pop(key, None)
 
 
-def _make_infra(name, store):
+def _fast_retry(**overrides):
+    """A retry policy with shrunk backoff so contention tests run quickly."""
+    params = dict(backoff_base_seconds=0.001, backoff_cap_seconds=0.03)
+    params.update(overrides)
+    return RegistryIndexRetryConfig(**params)
+
+
+def _make_infra(name, store, retry=None):
     return DaprInfra(
         name=name,
-        registry=AgentRegistryConfig(store=store, team_name="default"),
+        registry=AgentRegistryConfig(
+            store=store,
+            team_name="default",
+            index_retry=retry or _fast_retry(),
+        ),
     )
-
-
-@pytest.fixture
-def fast_backoff(monkeypatch):
-    """Shrink backoff so contention tests run quickly while still de-correlating."""
-    monkeypatch.setattr(components, "_INDEX_BACKOFF_BASE_SECONDS", 0.001)
-    monkeypatch.setattr(components, "_INDEX_BACKOFF_CAP_SECONDS", 0.03)
 
 
 def _run_concurrently(targets):
@@ -117,7 +120,7 @@ def _run_concurrently(targets):
 
 
 @pytest.mark.parametrize("num_agents", [8])
-def test_concurrent_deregister_all_converge(fast_backoff, num_agents):
+def test_concurrent_deregister_all_converge(num_agents):
     """Every agent deregisters concurrently and the index ends empty."""
     store = FakeEtagStore()
     names = [f"agent-{i}" for i in range(num_agents)]
@@ -139,7 +142,7 @@ def test_concurrent_deregister_all_converge(fast_backoff, num_agents):
 
 
 @pytest.mark.parametrize("num_agents", [8])
-def test_concurrent_index_add_all_converge(fast_backoff, num_agents):
+def test_concurrent_index_add_all_converge(num_agents):
     """Every agent adds itself to the index concurrently; none is lost."""
     store = FakeEtagStore()
     names = [f"agent-{i}" for i in range(num_agents)]
@@ -172,13 +175,8 @@ def test_concurrent_index_add_all_converge(fast_backoff, num_agents):
     )
 
 
-def test_mutate_team_index_gives_up_when_always_conflicting(monkeypatch):
+def test_mutate_team_index_gives_up_when_always_conflicting():
     """A permanently-conflicting store fails bounded — it must not hang."""
-    monkeypatch.setattr(components, "_INDEX_MUTATION_MAX_ATTEMPTS", 4)
-    monkeypatch.setattr(components, "_INDEX_MUTATION_BUDGET_SECONDS", 5.0)
-    monkeypatch.setattr(components, "_INDEX_BACKOFF_BASE_SECONDS", 0.001)
-    monkeypatch.setattr(components, "_INDEX_BACKOFF_CAP_SECONDS", 0.005)
-
     store = FakeEtagStore()
     index_key = "agents:default:_index"
     store.seed(index_key, {_REGISTRY_AGENTS_KEY: ["agent-0"]})
@@ -197,7 +195,16 @@ def test_mutate_team_index_gives_up_when_always_conflicting(monkeypatch):
     store.load_with_etag = flaky_load
     store.save = always_conflict
 
-    infra = _make_infra("agent-0", store)
+    infra = _make_infra(
+        "agent-0",
+        store,
+        retry=_fast_retry(
+            max_attempts=4,
+            budget_seconds=5.0,
+            backoff_base_seconds=0.001,
+            backoff_cap_seconds=0.005,
+        ),
+    )
 
     def _remove(agents_list):
         if "agent-0" not in agents_list:
@@ -215,11 +222,8 @@ def test_mutate_team_index_gives_up_when_always_conflicting(monkeypatch):
     assert load_calls["n"] == 4, "should retry up to the attempt bound, then give up"
 
 
-def test_mutate_team_index_retries_then_succeeds(monkeypatch):
+def test_mutate_team_index_retries_then_succeeds():
     """A few transient conflicts are absorbed; the write eventually lands."""
-    monkeypatch.setattr(components, "_INDEX_BACKOFF_BASE_SECONDS", 0.001)
-    monkeypatch.setattr(components, "_INDEX_BACKOFF_CAP_SECONDS", 0.005)
-
     store = FakeEtagStore()
     index_key = "agents:default:_index"
     store.seed(index_key, {_REGISTRY_AGENTS_KEY: ["agent-0"]})
@@ -234,7 +238,11 @@ def test_mutate_team_index_retries_then_succeeds(monkeypatch):
         return real_save(**kw)
 
     store.save = flaky_save
-    infra = _make_infra("agent-0", store)
+    infra = _make_infra(
+        "agent-0",
+        store,
+        retry=_fast_retry(backoff_base_seconds=0.001, backoff_cap_seconds=0.005),
+    )
 
     def _remove(agents_list):
         if "agent-0" not in agents_list:

--- a/tests/agents/test_registry_index_contention.py
+++ b/tests/agents/test_registry_index_contention.py
@@ -82,7 +82,7 @@ class FakeEtagStore:
 
 def _fast_retry(**overrides):
     """A retry policy with shrunk backoff so contention tests run quickly."""
-    params = dict(backoff_base_seconds=0.001, backoff_cap_seconds=0.03)
+    params = dict(initial_backoff_seconds=0.001, max_backoff_seconds=0.03)
     params.update(overrides)
     return RegistryIndexRetryConfig(**params)
 
@@ -200,9 +200,9 @@ def test_mutate_team_index_gives_up_when_always_conflicting():
         store,
         retry=_fast_retry(
             max_attempts=4,
-            budget_seconds=5.0,
-            backoff_base_seconds=0.001,
-            backoff_cap_seconds=0.005,
+            retry_timeout=5.0,
+            initial_backoff_seconds=0.001,
+            max_backoff_seconds=0.005,
         ),
     )
 
@@ -241,7 +241,7 @@ def test_mutate_team_index_retries_then_succeeds():
     infra = _make_infra(
         "agent-0",
         store,
-        retry=_fast_retry(backoff_base_seconds=0.001, backoff_cap_seconds=0.005),
+        retry=_fast_retry(initial_backoff_seconds=0.001, max_backoff_seconds=0.005),
     )
 
     def _remove(agents_list):


### PR DESCRIPTION
# Description

Include backoff handling to avoid conflict on add/remove of agents to the registry `_index`. This is especially seen during multi-agent shutdown where the 04 example results in 10s timeout to ungracefully exit.

## Issue reference

We strive to have all PR being opened based on an issue, where the problem or feature have been discussed prior to implementation.

Please reference the issue this PR closes: N/A

## Checklist

Please make sure you've completed the relevant tasks for this PR, out of the following list:

* [x] Created/updated tests
* [x] Tested this change against all the quickstarts
* [x] Extended the documentation
    * [x] Created the [dapr/docs](https://github.com/dapr/docs) PR: N/A

**Note:** We expect contributors to open a corresponding documentation PR in the [dapr/docs](https://github.com/dapr/docs/) repository. As the implementer, you are the best person to document your work! Implementation PRs will not be merged until the documentation PR is opened and ready for review.
