### PR TITLE
feat(hooks): extend Deny decision with code and details fields

### DIFF
--- a/dapr_agents/hooks.py
+++ b/dapr_agents/hooks.py
@@ -129,6 +129,14 @@ class Deny(HookDecision):
     """
 
     reason: Optional[str] = None
+    code: Optional[str] = None
+    """Structured error code (e.g., "oauth.invalid_signature"). Plugin authors
+    use this for programmatic error handling; workflow logs include it in
+    audit events. Free-form but conventionally `<plugin>.<reason>`."""
+
+    details: Optional[Dict[str, Any]] = None
+    """Plugin-specific diagnostic context (issuer attempted, expected audience,
+    etc.). NEVER include secrets — these flow into workflow history."""
 
 
 # Generic callable aliases — kept for backwards compatibility with user code that

--- a/dapr_agents/hooks.py
+++ b/dapr_agents/hooks.py
@@ -131,8 +131,8 @@ class Deny(HookDecision):
     reason: Optional[str] = None
     code: Optional[str] = None
     """Structured error code (e.g., "oauth.invalid_signature"). Plugin authors
-    use this for programmatic error handling; workflow logs include it in
-    audit events. Free-form but conventionally `<plugin>.<reason>`."""
+    can use this for programmatic error handling. Note: the agent runtime does not
+    currently surface this value automatically (e.g., in denial messages/events)."""
 
     details: Optional[Dict[str, Any]] = None
     """Plugin-specific diagnostic context (issuer attempted, expected audience,

--- a/tests/test_hooks.py
+++ b/tests/test_hooks.py
@@ -1,0 +1,54 @@
+#
+# Copyright 2026 The Dapr Authors
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#     http://www.apache.org/licenses/LICENSE-2.0
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+from dapr_agents.hooks import Deny
+
+
+def test_deny_backwards_compat_reason_only():
+    d = Deny(reason="blocked")
+    assert d.reason == "blocked"
+    assert d.code is None
+    assert d.details is None
+
+
+def test_deny_with_code_and_details():
+    d = Deny(
+        reason="JWT failed",
+        code="oauth.invalid_signature",
+        details={"issuer_attempted": "https://acme.us.auth0.com/"},
+    )
+    assert d.code == "oauth.invalid_signature"
+    assert d.details["issuer_attempted"] == "https://acme.us.auth0.com/"
+
+
+def test_deny_defaults_to_all_none():
+    d = Deny()
+    assert d.reason is None
+    assert d.code is None
+    assert d.details is None
+
+
+def test_deny_code_accepts_empty_string():
+    d = Deny(reason="blocked", code="")
+    assert d.code == ""
+
+
+def test_deny_details_accepts_arbitrary_nested_dict():
+    d = Deny(details={"nested": {"deep": [1, 2, 3]}})
+    assert d.details["nested"]["deep"] == [1, 2, 3]
+
+
+def test_deny_equality():
+    a = Deny(reason="x", code="y", details={"k": 1})
+    b = Deny(reason="x", code="y", details={"k": 1})
+    assert a == b


### PR DESCRIPTION
# Description

## What

Adds two optional fields to the `Deny` HookDecision dataclass in`dapr_agents/hooks.py`:

- `code: Optional[str]` — structured error code (e.g., "oauth.invalid_signature")
- `details: Optional[Dict[str, Any]]` — plugin-specific diagnostic context

## Why

Need to support users who build their own hooks to return structured denial reasons.

## Backwards compat

Both new fields default to None. Existing `Deny(reason="x")` callers unaffected.

## Issue reference

We strive to have all PR being opened based on an issue, where the problem or feature have been discussed prior to implementation.

Please reference the issue this PR closes: #_[issue number]_

## Checklist

Please make sure you've completed the relevant tasks for this PR, out of the following list:

* [ ] Created/updated tests
* [ ] Tested this change against all the quickstarts
* [ ] Extended the documentation
    * [ ] Created the [dapr/docs](https://github.com/dapr/docs) PR: <insert PR link here>

**Note:** We expect contributors to open a corresponding documentation PR in the [dapr/docs](https://github.com/dapr/docs/) repository. As the implementer, you are the best person to document your work! Implementation PRs will not be merged until the documentation PR is opened and ready for review.
