### PR TITLE
feat: add caller headers to trigger action

### DIFF
--- a/dapr_agents/agents/schemas.py
+++ b/dapr_agents/agents/schemas.py
@@ -139,15 +139,18 @@ class TriggerAction(BaseModel):
     )
     caller_headers: Optional[Dict[str, str]] = Field(
         default=None,
+        exclude=True,
         description=(
             "HTTP headers from the inbound request that triggered the agent. "
             "Used by lifecycle plugins on BEFORE_AGENT_INVOKE "
             "to extract the bearer token and other caller context. "
             "Populated by the agent's HTTP/serve layer when the trigger arrives via "
             "HTTP; left None for in-process or replay invocations. "
-            "Plugins MUST scrub sensitive values (e.g., Authorization) before any "
-            "downstream activity dispatch — raw bearers should never enter signed "
-            "workflow history."
+            "Transient and in-memory only: excluded from serialization (exclude=True) "
+            "so raw headers such as Authorization are never emitted by model_dump(), "
+            "never published over pub/sub, and never persisted to signed workflow "
+            "history or logs. Plugins read it from the live object on "
+            "BEFORE_AGENT_INVOKE."
         ),
     )
 

--- a/dapr_agents/agents/schemas.py
+++ b/dapr_agents/agents/schemas.py
@@ -137,6 +137,19 @@ class TriggerAction(BaseModel):
     workflow_instance_id: Optional[str] = Field(
         default=None, description="Dapr workflow instance id from source if available"
     )
+    caller_headers: Optional[Dict[str, str]] = Field(
+        default=None,
+        description=(
+            "HTTP headers from the inbound request that triggered the agent. "
+            "Used by lifecycle plugins on BEFORE_AGENT_INVOKE "
+            "to extract the bearer token and other caller context. "
+            "Populated by the agent's HTTP/serve layer when the trigger arrives via "
+            "HTTP; left None for in-process or replay invocations. "
+            "Plugins MUST scrub sensitive values (e.g., Authorization) before any "
+            "downstream activity dispatch — raw bearers should never enter signed "
+            "workflow history."
+        ),
+    )
 
 
 class AgentWorkflowMessage(MessageContent):

--- a/tests/agents/test_schemas.py
+++ b/tests/agents/test_schemas.py
@@ -1,0 +1,57 @@
+#
+# Copyright 2026 The Dapr Authors
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#     http://www.apache.org/licenses/LICENSE-2.0
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+from dapr_agents.agents.schemas import TriggerAction
+
+
+def test_trigger_action_backwards_compat():
+    t = TriggerAction(task="say hello")
+    assert t.task == "say hello"
+    assert t.workflow_instance_id is None
+    assert t.caller_headers is None
+
+
+def test_trigger_action_with_caller_headers():
+    headers = {
+        "Authorization": "Bearer eyJhbG...",
+        "X-Request-Id": "req-c4d2e1f0",
+        "traceparent": "00-4bf92f3577b34da6-a3ce929d0e0e4736-01",
+    }
+    t = TriggerAction(task="x", caller_headers=headers)
+    assert t.caller_headers["Authorization"].startswith("Bearer ")
+    assert t.caller_headers["X-Request-Id"] == "req-c4d2e1f0"
+
+
+def test_trigger_action_serialization_roundtrip():
+    t = TriggerAction(
+        task="x",
+        workflow_instance_id="wf-1",
+        caller_headers={"Authorization": "Bearer x"},
+    )
+    payload = t.model_dump()
+    t2 = TriggerAction.model_validate(payload)
+    assert t2.task == "x"
+    assert t2.workflow_instance_id == "wf-1"
+    assert t2.caller_headers == {"Authorization": "Bearer x"}
+
+
+def test_trigger_action_omitted_headers_serializes_as_none():
+    t = TriggerAction(task="x")
+    payload = t.model_dump()
+    assert payload.get("caller_headers") is None
+
+
+def test_trigger_action_empty_headers_dict():
+    # Empty dict allowed; semantically equivalent to None for plugin behavior
+    t = TriggerAction(task="x", caller_headers={})
+    assert t.caller_headers == {}

--- a/tests/agents/test_schemas.py
+++ b/tests/agents/test_schemas.py
@@ -32,23 +32,30 @@ def test_trigger_action_with_caller_headers():
     assert t.caller_headers["X-Request-Id"] == "req-c4d2e1f0"
 
 
-def test_trigger_action_serialization_roundtrip():
+def test_trigger_action_caller_headers_excluded_from_serialization():
+    # caller_headers is transient (exclude=True): it must never be emitted by
+    # model_dump(), so raw headers like Authorization cannot leak into pub/sub
+    # payloads, signed workflow history, or logs.
     t = TriggerAction(
         task="x",
         workflow_instance_id="wf-1",
         caller_headers={"Authorization": "Bearer x"},
     )
     payload = t.model_dump()
+    assert "caller_headers" not in payload
+    assert payload == {"task": "x", "workflow_instance_id": "wf-1"}
+
+    # Round-tripping the serialized payload drops the transient headers.
     t2 = TriggerAction.model_validate(payload)
     assert t2.task == "x"
     assert t2.workflow_instance_id == "wf-1"
-    assert t2.caller_headers == {"Authorization": "Bearer x"}
+    assert t2.caller_headers is None
 
 
-def test_trigger_action_omitted_headers_serializes_as_none():
+def test_trigger_action_caller_headers_excluded_even_when_omitted():
     t = TriggerAction(task="x")
     payload = t.model_dump()
-    assert payload.get("caller_headers") is None
+    assert "caller_headers" not in payload
 
 
 def test_trigger_action_empty_headers_dict():


### PR DESCRIPTION
# Description

If users are making their own custom hooks then they will likely want to be able to propagate authorization headers into the trigger action. This could also be used to propagate traceparent and request ids for correlation. This is just adding the field and a future PR will enhance this to be used.

## Issue reference

We strive to have all PR being opened based on an issue, where the problem or feature have been discussed prior to implementation.

Please reference the issue this PR closes: #_[issue number]_

## Checklist

Please make sure you've completed the relevant tasks for this PR, out of the following list:

* [ ] Created/updated tests
* [ ] Tested this change against all the quickstarts
* [ ] Extended the documentation
    * [ ] Created the [dapr/docs](https://github.com/dapr/docs) PR: <insert PR link here>

**Note:** We expect contributors to open a corresponding documentation PR in the [dapr/docs](https://github.com/dapr/docs/) repository. As the implementer, you are the best person to document your work! Implementation PRs will not be merged until the documentation PR is opened and ready for review.
