### PR TITLE
feat(plugins): add lifecycle dispatcher for plugin extensions

### DIFF
--- a/dapr_agents/lifecycle.py
+++ b/dapr_agents/lifecycle.py
@@ -1,0 +1,105 @@
+"""
+Lifecycle dispatch extension point for DurableAgent.
+
+This module exposes a minimal Protocol that DurableAgent calls into at
+known lifecycle events (BEFORE_AGENT_INVOKE, BEFORE_TOOL_CALL, etc.).
+Implementations of this Protocol can intercept those events to add
+authentication, OBO, HITL approver authorization, observability, and
+other cross-cutting concerns without modifying DurableAgent itself.
+
+Design notes:
+    - dapr_agents.lifecycle stays OSS-clean: no proprietary or
+      plugin-specific imports. Any implementation can plug in.
+    - DecisionDict is a serializable subset of dapr_agents.hooks
+      decisions. Implementations that want richer return types can
+      still subclass; this type is the minimum protocol contract.
+    - This module is intentionally tiny. Heavy plugin logic lives
+      outside dapr-agents.
+"""
+
+from typing import Any, Dict, Literal, Optional, Protocol, TypedDict, runtime_checkable
+
+
+class DecisionDict(TypedDict, total=False):
+    """
+    Serializable subset of HookDecision returned from LifecycleDispatcher.dispatch.
+
+    The `type` field is required. Other fields are populated conditionally
+    based on the decision type:
+        - "proceed": no other fields
+        - "skip": optional `result`
+        - "mutate": `payload` dict
+        - "require_approval": optional `timeout_seconds`, `instructions`,
+          `reason`, `required_approver_scopes`, `allowed_approver_subjects`,
+          `approver_audience`
+        - "deny": optional `reason`, `code`, `details`
+    """
+
+    type: Literal["proceed", "skip", "mutate", "require_approval", "deny"]
+    result: Any
+    payload: Dict[str, Any]
+    reason: Optional[str]
+    code: Optional[str]
+    details: Optional[Dict[str, Any]]
+    timeout_seconds: Optional[int]
+    instructions: Optional[str]
+    required_approver_scopes: list
+    allowed_approver_subjects: Optional[list]
+    approver_audience: Optional[str]
+
+
+@runtime_checkable
+class LifecycleDispatcher(Protocol):
+    """
+    Protocol implemented by anything that wants to intercept DurableAgent
+    lifecycle events.
+
+    DurableAgent calls dispatch() at known lifecycle points. Returning None
+    or {"type": "proceed"} means "run the step normally." Returning a
+    DecisionDict with type "skip" | "mutate" | "require_approval" | "deny"
+    alters the workflow per the existing hook semantics in
+    dapr_agents.hooks.
+
+    attach() is called once during DurableAgent construction so the
+    dispatcher can initialize any per-agent state (open clients, register
+    sub-handlers, etc.). detach() is called during cleanup. Implementations
+    are free to no-op either method.
+    """
+
+    def attach(self, agent: Any) -> None:
+        """
+        Called by DurableAgent during initialization. The agent reference is
+        passed in case the dispatcher needs to read agent config or register
+        callbacks. Implementations should not retain the reference longer
+        than necessary; detach() should release any held state.
+        """
+        ...
+
+    def detach(self) -> None:
+        """
+        Called by DurableAgent during cleanup. Implementations release any
+        per-agent resources here.
+        """
+        ...
+
+    def dispatch(
+        self,
+        event_name: str,
+        context: Dict[str, Any],
+    ) -> Optional[DecisionDict]:
+        """
+        Called by DurableAgent at a known lifecycle event.
+
+        Args:
+            event_name: One of "BEFORE_AGENT_INVOKE", "BEFORE_TOOL_CALL",
+                "BEFORE_LLM_CALL", "BEFORE_APPROVAL_DECISION",
+                "AFTER_TOOL_CALL", "AFTER_LLM_CALL", "AFTER_AGENT_INVOKE",
+                or future events added by extension.
+            context: Event-specific context dict. Shape depends on
+                event_name; documented in DurableAgent's dispatch sites.
+
+        Returns:
+            A DecisionDict to alter workflow behavior, or None for "proceed."
+            Returning {"type": "proceed"} is equivalent to None.
+        """
+        ...

--- a/dapr_agents/lifecycle.py
+++ b/dapr_agents/lifecycle.py
@@ -1,3 +1,16 @@
+#
+# Copyright 2026 The Dapr Authors
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#     http://www.apache.org/licenses/LICENSE-2.0
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
 """
 Lifecycle dispatch extension point for DurableAgent.
 
@@ -17,7 +30,7 @@ Design notes:
       outside dapr-agents.
 """
 
-from typing import Any, Dict, Literal, Optional, Protocol, TypedDict, runtime_checkable
+from typing import Any, Dict, Literal, Optional, Protocol, Required, TypedDict, runtime_checkable
 
 
 class DecisionDict(TypedDict, total=False):
@@ -35,7 +48,7 @@ class DecisionDict(TypedDict, total=False):
         - "deny": optional `reason`, `code`, `details`
     """
 
-    type: Literal["proceed", "skip", "mutate", "require_approval", "deny"]
+    type: Required[Literal["proceed", "skip", "mutate", "require_approval", "deny"]]
     result: Any
     payload: Dict[str, Any]
     reason: Optional[str]

--- a/dapr_agents/lifecycle.py
+++ b/dapr_agents/lifecycle.py
@@ -23,29 +23,47 @@ other cross-cutting concerns without modifying DurableAgent itself.
 Design notes:
     - dapr_agents.lifecycle stays OSS-clean: no proprietary or
       plugin-specific imports. Any implementation can plug in.
-    - DecisionDict is a serializable subset of dapr_agents.hooks
-      decisions. Implementations that want richer return types can
-      still subclass; this type is the minimum protocol contract.
+    - DecisionDict mirrors the serializable fields of dapr_agents.hooks
+      decisions, plus a few forward-looking approver-authorization fields
+      that dispatcher implementations may populate (see below).
+      Implementations that want richer return types can still subclass;
+      this type is the minimum protocol contract.
     - This module is intentionally tiny. Heavy plugin logic lives
       outside dapr-agents.
 """
 
-from typing import Any, Dict, Literal, Optional, Protocol, Required, TypedDict, runtime_checkable
+from typing import (
+    Any,
+    Dict,
+    Literal,
+    Optional,
+    Protocol,
+    runtime_checkable,
+)
+
+from typing_extensions import Required, TypedDict
 
 
 class DecisionDict(TypedDict, total=False):
     """
-    Serializable subset of HookDecision returned from LifecycleDispatcher.dispatch.
+    Serializable decision returned from LifecycleDispatcher.dispatch.
 
-    The `type` field is required. Other fields are populated conditionally
-    based on the decision type:
+    Fields up to and including `details` mirror the serializable fields of
+    the dapr_agents.hooks decisions. The `type` field is required. Other
+    fields are populated conditionally based on the decision type:
         - "proceed": no other fields
         - "skip": optional `result`
         - "mutate": `payload` dict
         - "require_approval": optional `timeout_seconds`, `instructions`,
-          `reason`, `required_approver_scopes`, `allowed_approver_subjects`,
-          `approver_audience`
+          `reason`
         - "deny": optional `reason`, `code`, `details`
+
+    The `required_approver_scopes`, `allowed_approver_subjects`, and
+    `approver_audience` fields are extension fields for dispatcher
+    implementations that perform approver authorization. They are not part
+    of the current dapr_agents.hooks decisions or approval event schema, so
+    the core agent runtime does not interpret them; a dispatcher that emits
+    them is responsible for acting on them.
     """
 
     type: Required[Literal["proceed", "skip", "mutate", "require_approval", "deny"]]

--- a/dapr_agents/lifecycle.py
+++ b/dapr_agents/lifecycle.py
@@ -74,7 +74,7 @@ class DecisionDict(TypedDict, total=False):
     details: Optional[Dict[str, Any]]
     timeout_seconds: Optional[int]
     instructions: Optional[str]
-    required_approver_scopes: list
+    required_approver_scopes: Optional[list]
     allowed_approver_subjects: Optional[list]
     approver_audience: Optional[str]
 

--- a/tests/test_lifecycle.py
+++ b/tests/test_lifecycle.py
@@ -1,0 +1,113 @@
+#
+# Copyright 2026 The Dapr Authors
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#     http://www.apache.org/licenses/LICENSE-2.0
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+import pytest
+from dapr_agents.lifecycle import LifecycleDispatcher, DecisionDict
+
+
+def test_protocol_accepts_minimal_implementation():
+    """A minimal class that implements the 3 methods satisfies the Protocol."""
+
+    class FakeDispatcher:
+        def attach(self, agent):
+            pass
+
+        def detach(self):
+            pass
+
+        def dispatch(self, event_name, context):
+            return None
+
+    d = FakeDispatcher()
+    assert isinstance(d, LifecycleDispatcher)
+
+
+def test_protocol_rejects_incomplete_implementation():
+    """A class missing one of the 3 methods does NOT satisfy the Protocol
+    under runtime_checkable."""
+
+    class IncompleteDispatcher:
+        def attach(self, agent):
+            pass
+
+        # missing detach and dispatch
+
+    d = IncompleteDispatcher()
+    assert not isinstance(d, LifecycleDispatcher)
+
+
+def test_protocol_dispatch_returns_optional_decision():
+    """dispatch() can return None or a DecisionDict."""
+
+    class Dispatcher:
+        def attach(self, agent):
+            pass
+
+        def detach(self):
+            pass
+
+        def dispatch(self, event_name, context):
+            if event_name == "deny_me":
+                return {"type": "deny", "code": "test.denied"}
+            return None
+
+    d = Dispatcher()
+    assert d.dispatch("anything", {}) is None
+    result = d.dispatch("deny_me", {})
+    assert result["type"] == "deny"
+    assert result["code"] == "test.denied"
+
+
+# ----- DecisionDict shape -----
+
+
+def test_decision_dict_proceed():
+    decision: DecisionDict = {"type": "proceed"}
+    assert decision["type"] == "proceed"
+
+
+def test_decision_dict_deny_with_code_details():
+    decision: DecisionDict = {
+        "type": "deny",
+        "code": "oauth.invalid_signature",
+        "details": {"issuer": "https://example.com/"},
+    }
+    assert decision["code"] == "oauth.invalid_signature"
+
+
+def test_decision_dict_require_approval():
+    decision: DecisionDict = {
+        "type": "require_approval",
+        "required_approver_scopes": ["approver.delete"],
+        "approver_audience": "agent-svc",
+    }
+    assert decision["required_approver_scopes"] == ["approver.delete"]
+
+
+# ----- No forbidden imports -----
+
+
+def test_lifecycle_module_has_no_external_deps():
+    """The lifecycle module must stay OSS-clean — only stdlib imports."""
+    import dapr_agents.lifecycle as lifecycle_mod
+    import inspect
+
+    source = inspect.getsource(lifecycle_mod)
+    # No proprietary or plugin-specific imports
+    for forbidden in ("diagrid", "catalyst", "cloudgrid"):
+        assert forbidden not in source.lower(), (
+            f"dapr_agents.lifecycle must not import from {forbidden}"
+        )
+    # No dapr_agents.hooks imports (Protocol stays decoupled)
+    assert "from dapr_agents.hooks" not in source
+    assert "import dapr_agents.hooks" not in source


### PR DESCRIPTION
# Description

## What

New file `dapr_agents/lifecycle.py` defining:
- `LifecycleDispatcher` Protocol (3 methods: attach, detach, dispatch)
- `DecisionDict` TypedDict (serializable subset of HookDecision)

Marked `@runtime_checkable` so consumers can use `isinstance(x, LifecycleDispatcher)` to validate implementations.

## Why

dapr-agents needs a single, clean extension point that any lifecycle-aware library or custom user implementation can implement to intercept DurableAgent's lifecycle events without modifying dapr-agents itself.

dapr-agents stays minimal; concrete plugin infrastructure lives in downstream libraries. A follow-up adds the `lifecycle_dispatcher` kwarg to DurableAgent and wires the actual dispatch sites.


## Issue reference

We strive to have all PR being opened based on an issue, where the problem or feature have been discussed prior to implementation.

Please reference the issue this PR closes: #_[issue number]_

## Checklist

Please make sure you've completed the relevant tasks for this PR, out of the following list:

* [ ] Created/updated tests
* [ ] Tested this change against all the quickstarts
* [ ] Extended the documentation
    * [ ] Created the [dapr/docs](https://github.com/dapr/docs) PR: <insert PR link here>

**Note:** We expect contributors to open a corresponding documentation PR in the [dapr/docs](https://github.com/dapr/docs/) repository. As the implementer, you are the best person to document your work! Implementation PRs will not be merged until the documentation PR is opened and ready for review.
