### PR TITLE
feat(schema): add approver authz felds to events

### DIFF
--- a/dapr_agents/agents/schemas.py
+++ b/dapr_agents/agents/schemas.py
@@ -73,6 +73,28 @@ class ApprovalRequiredEvent(BaseModel):
     timeout_seconds: int = Field(
         description="Seconds before the workflow auto-denies if no human responds"
     )
+    required_approver_scopes: List[str] = Field(
+        default_factory=list,
+        description=(
+            "Scopes the approver's JWT must carry. Empty list = any verified "
+            "approver. Approval UIs / approver-finding code can filter by these. "
+            "Enforced by the downstream HITL plugin."
+        ),
+    )
+    allowed_approver_subjects: List[str] = Field(
+        default_factory=list,
+        description=(
+            "Optional allowlist of approver `sub` claim values. Empty list = "
+            "any subject that meets required_approver_scopes."
+        ),
+    )
+    approver_audience: Optional[str] = Field(
+        default=None,
+        description=(
+            "Expected `aud` claim on the approver's JWT. None = falls back to "
+            "the agent's own identity."
+        ),
+    )
 
     @model_validator(mode="before")
     @classmethod
@@ -106,6 +128,24 @@ class ApprovalResponseEvent(BaseModel):
     )
     decided_at: datetime = Field(
         default_factory=utcnow, description="When the decision was made"
+    )
+    approver_token: Optional[str] = Field(
+        default=None,
+        description=(
+            "Raw JWT submitted by the approver via the approval UI / CLI / chat bot. "
+            "Verified by the downstream HITL plugin against the requirements declared "
+            "on the original ApprovalRequiredEvent. "
+            "MUST be scrubbed from any signed workflow history — only the "
+            "verified-claims subset (subject, scopes) propagates."
+        ),
+    )
+    approver_subject: Optional[str] = Field(
+        default=None,
+        description=(
+            "Approver's verified `sub` claim. Populated by the HITL plugin AFTER "
+            "verifying approver_token; not trusted on input from raw event payload. "
+            "Carrying it here lets observers see who approved without re-verifying."
+        ),
     )
 
 

--- a/dapr_agents/agents/schemas.py
+++ b/dapr_agents/agents/schemas.py
@@ -131,6 +131,7 @@ class ApprovalResponseEvent(BaseModel):
     )
     approver_token: Optional[str] = Field(
         default=None,
+        repr=False,
         description=(
             "Raw JWT submitted by the approver via the approval UI / CLI / chat bot. "
             "Verified by the downstream HITL plugin against the requirements declared "

--- a/tests/agents/test_schemas.py
+++ b/tests/agents/test_schemas.py
@@ -98,6 +98,18 @@ def test_approval_response_event_with_approver_fields():
     assert r.approver_subject == "bob@acme.com"
 
 
+def test_approval_response_event_token_excluded_from_repr():
+    # approver_token is a sensitive raw JWT and must not leak via repr / logs,
+    # but it must still serialize for delivery.
+    r = ApprovalResponseEvent(
+        approval_request_id="appr-1",
+        approved=True,
+        approver_token="eyJhbG...",
+    )
+    assert "eyJhbG..." not in repr(r)
+    assert r.model_dump(mode="json")["approver_token"] == "eyJhbG..."
+
+
 def test_approval_response_event_serialization_roundtrip():
     r = ApprovalResponseEvent(
         approval_request_id="appr-1",

--- a/tests/agents/test_schemas.py
+++ b/tests/agents/test_schemas.py
@@ -1,0 +1,111 @@
+#
+# Copyright 2026 The Dapr Authors
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#     http://www.apache.org/licenses/LICENSE-2.0
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+from dapr_agents.agents.schemas import ApprovalRequiredEvent, ApprovalResponseEvent
+
+
+# ----- ApprovalRequiredEvent -----
+
+
+def test_approval_required_event_backwards_compat():
+    e = ApprovalRequiredEvent(
+        approval_request_id="appr-1",
+        instance_id="wf-1",
+        step_name="my_tool",
+        tool_call_id="tc-1",
+        tool_arguments={"x": 1},
+        timeout_seconds=600,
+    )
+    assert e.required_approver_scopes == []
+    assert e.allowed_approver_subjects == []
+    assert e.approver_audience is None
+
+
+def test_approval_required_event_with_authz():
+    e = ApprovalRequiredEvent(
+        approval_request_id="appr-1",
+        instance_id="wf-1",
+        step_name="my_tool",
+        tool_call_id="tc-1",
+        tool_arguments={},
+        timeout_seconds=600,
+        required_approver_scopes=["approver.delete-customer"],
+        allowed_approver_subjects=["bob@acme.com"],
+        approver_audience="agent-svc",
+    )
+    assert "approver.delete-customer" in e.required_approver_scopes
+    assert e.allowed_approver_subjects == ["bob@acme.com"]
+    assert e.approver_audience == "agent-svc"
+
+
+def test_approval_required_event_serialization_roundtrip():
+    e = ApprovalRequiredEvent(
+        approval_request_id="appr-1",
+        instance_id="wf-1",
+        step_name="my_tool",
+        tool_call_id="tc-1",
+        tool_arguments={"x": 1},
+        timeout_seconds=600,
+        required_approver_scopes=["approver.foo"],
+    )
+    payload = e.model_dump(mode="json")
+    e2 = ApprovalRequiredEvent.model_validate(payload)
+    assert e2.required_approver_scopes == ["approver.foo"]
+
+
+def test_approval_required_event_backward_compat_tool_name():
+    # The existing model_validator should still convert "tool_name" to "step_name".
+    e = ApprovalRequiredEvent(
+        approval_request_id="appr-1",
+        instance_id="wf-1",
+        tool_name="legacy_name",
+        tool_call_id="tc-1",
+        tool_arguments={},
+        timeout_seconds=600,
+    )
+    assert e.step_name == "legacy_name"
+    assert e.tool_name == "legacy_name"
+
+
+# ----- ApprovalResponseEvent -----
+
+
+def test_approval_response_event_backwards_compat():
+    r = ApprovalResponseEvent(approval_request_id="appr-1", approved=True)
+    assert r.approved is True
+    assert r.approver_token is None
+    assert r.approver_subject is None
+
+
+def test_approval_response_event_with_approver_fields():
+    r = ApprovalResponseEvent(
+        approval_request_id="appr-1",
+        approved=True,
+        approver_token="eyJhbG...",
+        approver_subject="bob@acme.com",
+    )
+    assert r.approver_token == "eyJhbG..."
+    assert r.approver_subject == "bob@acme.com"
+
+
+def test_approval_response_event_serialization_roundtrip():
+    r = ApprovalResponseEvent(
+        approval_request_id="appr-1",
+        approved=True,
+        approver_token="eyJhbG...",
+        approver_subject="bob@acme.com",
+    )
+    payload = r.model_dump(mode="json")
+    r2 = ApprovalResponseEvent.model_validate(payload)
+    assert r2.approver_token == "eyJhbG..."
+    assert r2.approver_subject == "bob@acme.com"


### PR DESCRIPTION
# Description

## What

Adds approver authz fields to the approval events:

`ApprovalRequiredEvent`:
- `required_approver_scopes: List[str]`
- `allowed_approver_subjects: List[str]`
- `approver_audience: Optional[str]`

`ApprovalResponseEvent`:
- `approver_token: Optional[str]` — raw JWT from the approver
- `approver_subject: Optional[str]` — verified subject (populated by HITL plugin)

## Why

Allow for custom plugins to propagate fields into the events through the pub/sub system.
Any custom LifecycleDispatcher impl reads `approver_token` from the response event, verifies it against the requirements declared on the request event, and populates `approver_subject` with the verified identity.

## Issue reference

We strive to have all PR being opened based on an issue, where the problem or feature have been discussed prior to implementation.

Please reference the issue this PR closes: #_[issue number]_

## Checklist

Please make sure you've completed the relevant tasks for this PR, out of the following list:

* [ ] Created/updated tests
* [ ] Tested this change against all the quickstarts
* [ ] Extended the documentation
    * [ ] Created the [dapr/docs](https://github.com/dapr/docs) PR: <insert PR link here>

**Note:** We expect contributors to open a corresponding documentation PR in the [dapr/docs](https://github.com/dapr/docs/) repository. As the implementer, you are the best person to document your work! Implementation PRs will not be merged until the documentation PR is opened and ready for review.
