### PR TITLE
feat: add approver token to event for hitl

### DIFF
--- a/dapr_agents/agents/durable.py
+++ b/dapr_agents/agents/durable.py
@@ -3169,6 +3169,7 @@ class DurableAgent(AgentBase):
         approval_request_id: str,
         approved: bool,
         reason: Optional[str] = None,
+        approver_token: Optional[str] = None,
     ) -> None:
         """
         Send a human approval decision back to a workflow that is waiting for it.
@@ -3182,6 +3183,10 @@ class DurableAgent(AgentBase):
             approval_request_id: Unique request ID from the ApprovalRequiredEvent.
             approved: True to allow the tool to run, False to block it.
             reason: Optional human-provided explanation for the decision.
+            approver_token: Optional raw JWT from the approving user, required when
+                the originating approval declared approver scopes or subjects. Passed
+                through opaquely — the downstream HITL plugin verifies it before
+                honoring approved=True. Treated as sensitive and never logged here.
 
         Raises:
             Exception: If the Dapr workflow client cannot deliver the event.
@@ -3191,6 +3196,7 @@ class DurableAgent(AgentBase):
             approval_request_id=approval_request_id,
             approved=approved,
             reason=reason,
+            approver_token=approver_token,
         )
 
         wf_client = self._wf_client

--- a/dapr_agents/agents/durable.py
+++ b/dapr_agents/agents/durable.py
@@ -3183,10 +3183,11 @@ class DurableAgent(AgentBase):
             approval_request_id: Unique request ID from the ApprovalRequiredEvent.
             approved: True to allow the tool to run, False to block it.
             reason: Optional human-provided explanation for the decision.
-            approver_token: Optional raw JWT from the approving user, required when
-                the originating approval declared approver scopes or subjects. Passed
-                through opaquely — the downstream HITL plugin verifies it before
-                honoring approved=True. Treated as sensitive and never logged here.
+            approver_token: Optional raw JWT from the approving user, which may be
+                required by downstream HITL plugins when the originating approval
+                declared approver scopes or subjects. Passed through opaquely — the
+                plugin verifies it before honoring approved=True. Treated as
+                sensitive and never logged here.
 
         Raises:
             Exception: If the Dapr workflow client cannot deliver the event.

--- a/dapr_agents/agents/schemas.py
+++ b/dapr_agents/agents/schemas.py
@@ -110,10 +110,12 @@ class ApprovalResponseEvent(BaseModel):
     approver_token: Optional[str] = Field(
         default=None,
         description=(
-            "Raw JWT submitted by the approver via the approval UI, CLI, or chat bot. "
-            "Verified by the downstream HITL plugin against the requirements declared "
-            "on the original ApprovalRequiredEvent. MUST be scrubbed from any signed "
-            "workflow history — only the verified-claims subset (subject, scopes) propagates."
+            "Sensitive: raw JWT submitted by the approver via the approval UI, CLI, "
+            "or chat bot. dapr-agents carries it through the event payload as-is and "
+            "does not validate or persist it. The downstream HITL plugin verifies it "
+            "against the requirements declared on the original ApprovalRequiredEvent, "
+            "and is responsible for scrubbing it so only the verified-claims subset "
+            "(subject, scopes) propagates into any retained workflow history."
         ),
     )
     approver_subject: Optional[str] = Field(

--- a/dapr_agents/agents/schemas.py
+++ b/dapr_agents/agents/schemas.py
@@ -107,6 +107,23 @@ class ApprovalResponseEvent(BaseModel):
     decided_at: datetime = Field(
         default_factory=utcnow, description="When the decision was made"
     )
+    approver_token: Optional[str] = Field(
+        default=None,
+        description=(
+            "Raw JWT submitted by the approver via the approval UI, CLI, or chat bot. "
+            "Verified by the downstream HITL plugin against the requirements declared "
+            "on the original ApprovalRequiredEvent. MUST be scrubbed from any signed "
+            "workflow history — only the verified-claims subset (subject, scopes) propagates."
+        ),
+    )
+    approver_subject: Optional[str] = Field(
+        default=None,
+        description=(
+            "Approver's verified `sub` claim. Populated by the HITL plugin after "
+            "verifying approver_token; not trusted on input from the raw event payload. "
+            "Carrying it here lets observers see who approved without re-verifying."
+        ),
+    )
 
 
 class BroadcastMessage(BaseMessage):

--- a/dapr_agents/lifecycle.py
+++ b/dapr_agents/lifecycle.py
@@ -41,6 +41,9 @@ from typing import (
     runtime_checkable,
 )
 
+# Required, and the TypedDict that honors it, live in typing_extensions until
+# Python 3.11; on the project's 3.10 floor the stdlib typing.TypedDict ignores
+# the Required marker at runtime, so both must come from typing_extensions.
 from typing_extensions import Required, TypedDict
 
 
@@ -74,8 +77,8 @@ class DecisionDict(TypedDict, total=False):
     details: Optional[Dict[str, Any]]
     timeout_seconds: Optional[int]
     instructions: Optional[str]
-    required_approver_scopes: list
-    allowed_approver_subjects: Optional[list]
+    required_approver_scopes: list[str]
+    allowed_approver_subjects: Optional[list[str]]
     approver_audience: Optional[str]
 
 

--- a/dapr_agents/lifecycle.py
+++ b/dapr_agents/lifecycle.py
@@ -77,7 +77,7 @@ class DecisionDict(TypedDict, total=False):
     details: Optional[Dict[str, Any]]
     timeout_seconds: Optional[int]
     instructions: Optional[str]
-    required_approver_scopes: list[str]
+    required_approver_scopes: Optional[list[str]]
     allowed_approver_subjects: Optional[list[str]]
     approver_audience: Optional[str]
 

--- a/tests/agents/durableagent/test_hitl.py
+++ b/tests/agents/durableagent/test_hitl.py
@@ -174,6 +174,35 @@ class TestApprovalResponseEvent:
         assert restored.approved == resp.approved
         assert restored.reason == resp.reason
 
+    def test_approver_fields_default_to_none(self):
+        resp = ApprovalResponseEvent(
+            approval_request_id="req-1",
+            approved=True,
+        )
+        assert resp.approver_token is None
+        assert resp.approver_subject is None
+
+    def test_approver_fields_populated(self):
+        resp = ApprovalResponseEvent(
+            approval_request_id="req-1",
+            approved=True,
+            approver_token="eyJhbG...",
+            approver_subject="bob@acme.com",
+        )
+        assert resp.approver_token == "eyJhbG..."
+        assert resp.approver_subject == "bob@acme.com"
+
+    def test_approver_fields_roundtrip_serialization(self):
+        resp = ApprovalResponseEvent(
+            approval_request_id="req-1",
+            approved=True,
+            approver_token="eyJhbG...",
+            approver_subject="bob@acme.com",
+        )
+        restored = ApprovalResponseEvent.model_validate(resp.model_dump(mode="json"))
+        assert restored.approver_token == "eyJhbG..."
+        assert restored.approver_subject == "bob@acme.com"
+
 
 class TestAgentApprovalConfig:
     def test_default_pubsub_is_none(self):

--- a/tests/agents/durableagent/test_raise_approval_event.py
+++ b/tests/agents/durableagent/test_raise_approval_event.py
@@ -1,0 +1,114 @@
+#
+# Copyright 2026 The Dapr Authors
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#     http://www.apache.org/licenses/LICENSE-2.0
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+"""Tests for the optional approver_token kwarg on DurableAgent.raise_approval_event.
+
+The kwarg is a pure pass-through: it flows into the published ApprovalResponseEvent
+so the downstream HITL plugin can verify the approver's JWT. dapr-agents does not
+validate, persist, or log the raw token.
+"""
+
+from types import SimpleNamespace
+from unittest.mock import MagicMock
+
+import dapr.ext.workflow as wf
+
+from dapr_agents.agents.durable import DurableAgent
+
+
+def _agent_waiting_for_approval():
+    """Minimal stand-in exposing only what raise_approval_event touches on ``self``.
+
+    The workflow is reported RUNNING so the method gets past its terminal-state guard.
+    """
+    wf_client = MagicMock()
+    wf_client.get_workflow_state.return_value = SimpleNamespace(
+        runtime_status=wf.WorkflowStatus.RUNNING
+    )
+    return SimpleNamespace(
+        _wf_client=wf_client,
+        _pending_approvals={"appr-1": {"instance_id": "wf-1"}},
+        _persist_pending_approvals=MagicMock(),
+    )
+
+
+def _raised_event_data(agent):
+    """Return the event payload passed to raise_workflow_event."""
+    return agent._wf_client.raise_workflow_event.call_args.kwargs["data"]
+
+
+def test_raise_approval_event_backwards_compat():
+    """Existing callers without approver_token still work; token defaults to None."""
+    agent = _agent_waiting_for_approval()
+
+    DurableAgent.raise_approval_event(
+        agent,
+        instance_id="wf-1",
+        approval_request_id="appr-1",
+        approved=True,
+    )
+
+    data = _raised_event_data(agent)
+    assert data["approved"] is True
+    assert data.get("approver_token") is None
+
+
+def test_raise_approval_event_with_approver_token():
+    """approver_token kwarg flows into the published ApprovalResponseEvent."""
+    agent = _agent_waiting_for_approval()
+
+    DurableAgent.raise_approval_event(
+        agent,
+        instance_id="wf-1",
+        approval_request_id="appr-1",
+        approved=True,
+        approver_token="eyJhbGciOi...",
+    )
+
+    data = _raised_event_data(agent)
+    assert data["approver_token"] == "eyJhbGciOi..."
+
+
+def test_raise_approval_event_with_reason_and_token():
+    """Both reason and approver_token populate correctly on a denial."""
+    agent = _agent_waiting_for_approval()
+
+    DurableAgent.raise_approval_event(
+        agent,
+        instance_id="wf-1",
+        approval_request_id="appr-1",
+        approved=False,
+        reason="not authorized in this environment",
+        approver_token="eyJhbGciOi...",
+    )
+
+    data = _raised_event_data(agent)
+    assert data["approved"] is False
+    assert data["reason"].startswith("not authorized")
+    assert data["approver_token"] == "eyJhbGciOi..."
+
+
+def test_raise_approval_event_does_not_log_token(caplog):
+    """The raw token must never appear in log output, even on success."""
+    agent = _agent_waiting_for_approval()
+
+    with caplog.at_level("DEBUG"):
+        DurableAgent.raise_approval_event(
+            agent,
+            instance_id="wf-1",
+            approval_request_id="appr-1",
+            approved=True,
+            approver_token="super-secret-jwt",
+        )
+
+    assert "super-secret-jwt" not in caplog.text


### PR DESCRIPTION
# Description

I accidentally branched off my branch for this PR here https://github.com/dapr/dapr-agents/pull/669 so please review/merge that one first so the diff is clean 🙏 

## What

Adds `approver_token: Optional[str] = None` kwarg to `DurableAgent.raise_approval_event` in`dapr_agents/agents/durable.py`. The kwarg is passed through to the published `ApprovalResponseEvent`.

## Why

External approval services (Slack bot, dashboard, CLI) need a way to attach the approver's JWT to their decision so the downstream HITL plugin can verify it against the originating RequireApproval's requirements. This means we are just a pure pass through for this.

## Issue reference

We strive to have all PR being opened based on an issue, where the problem or feature have been discussed prior to implementation.

Please reference the issue this PR closes: #_[issue number]_

## Checklist

Please make sure you've completed the relevant tasks for this PR, out of the following list:

* [ ] Created/updated tests
* [ ] Tested this change against all the quickstarts
* [ ] Extended the documentation
    * [ ] Created the [dapr/docs](https://github.com/dapr/docs) PR: <insert PR link here>

**Note:** We expect contributors to open a corresponding documentation PR in the [dapr/docs](https://github.com/dapr/docs/) repository. As the implementer, you are the best person to document your work! Implementation PRs will not be merged until the documentation PR is opened and ready for review.
