### PR TITLE
feat(llm): add iFlytek Spark chat client

### DIFF
--- a/dapr_agents/llm/__init__.py
+++ b/dapr_agents/llm/__init__.py
@@ -16,6 +16,7 @@ from .dapr import DaprChatClient
 from .litellm.chat import LiteLLMChatClient
 from .elevenlabs import ElevenLabsSpeechClient
 from .huggingface.chat import HFHubChatClient
+from .iflytek.chat import IFlytekChatClient
 from .mistral.chat import MistralChatClient
 from .nvidia.chat import NVIDIAChatClient
 from .nvidia.embeddings import NVIDIAEmbeddingClient
@@ -28,6 +29,7 @@ __all__ = [
     "OpenAIAudioClient",
     "OpenAIEmbeddingClient",
     "HFHubChatClient",
+    "IFlytekChatClient",
     "MistralChatClient",
     "NVIDIAChatClient",
     "NVIDIAEmbeddingClient",

--- a/dapr_agents/llm/iflytek/__init__.py
+++ b/dapr_agents/llm/iflytek/__init__.py
@@ -1,0 +1,16 @@
+#
+# Copyright 2026 The Dapr Authors
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#     http://www.apache.org/licenses/LICENSE-2.0
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+from .chat import IFlytekChatClient
+
+__all__ = ["IFlytekChatClient"]

--- a/dapr_agents/llm/iflytek/chat.py
+++ b/dapr_agents/llm/iflytek/chat.py
@@ -1,0 +1,217 @@
+#
+# Copyright 2026 The Dapr Authors
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#     http://www.apache.org/licenses/LICENSE-2.0
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+import logging
+from pathlib import Path
+from typing import (
+    Any,
+    ClassVar,
+    Dict,
+    Iterable,
+    Iterator,
+    List,
+    Literal,
+    Optional,
+    Type,
+    Union,
+)
+
+from pydantic import BaseModel, Field
+
+from dapr_agents.llm.chat import ChatClientBase
+from dapr_agents.llm.iflytek.client import IFlytekClientBase
+from dapr_agents.llm.utils import RequestHandler, ResponseHandler
+from dapr_agents.prompt.base import PromptTemplateBase
+from dapr_agents.prompt.prompty import Prompty
+from dapr_agents.tool import AgentTool
+from dapr_agents.types.message import (
+    BaseMessage,
+    LLMChatCandidateChunk,
+    LLMChatResponse,
+)
+
+logger = logging.getLogger(__name__)
+
+
+class IFlytekChatClient(IFlytekClientBase, ChatClientBase):
+    """
+    Chat client for iFlytek Spark chat models, combining iFlytek client management
+    with Prompty-specific prompt templates and unified request/response handling.
+
+    iFlytek Spark exposes an OpenAI-compatible chat-completions API, so requests and
+    responses are handled through the shared OpenAI-compatible path.
+
+    Inherits:
+      - IFlytekClientBase: manages API key, base_url, etc. for iFlytek Spark endpoints.
+      - ChatClientBase: provides chat-specific abstractions.
+
+    Attributes:
+        model: the model name to use (e.g. "generalv3.5", "4.0Ultra", "lite").
+        max_tokens: maximum number of tokens to generate per call.
+    """
+
+    model: str = Field(
+        default="generalv3.5",
+        description="Model name to use. Defaults to 'generalv3.5'.",
+    )
+    max_tokens: Optional[int] = Field(
+        default=1024,
+        description=(
+            "Maximum number of tokens to generate in a single call. "
+            "Must be ≥1; defaults to 1024."
+        ),
+    )
+    prompty: Optional[Prompty] = Field(
+        default=None, description="Optional Prompty instance for templating."
+    )
+    prompt_template: Optional[PromptTemplateBase] = Field(
+        default=None, description="Optional prompt-template to format inputs."
+    )
+
+    # iFlytek Spark supports function_call structured output via its OpenAI-compatible API
+    SUPPORTED_STRUCTURED_MODES: ClassVar[set[str]] = {"function_call"}
+
+    def model_post_init(self, __context: Any) -> None:
+        """
+        After Pydantic init, configure the client for 'chat' API.
+        """
+        self._api = "chat"
+        super().model_post_init(__context)
+
+    @classmethod
+    def from_prompty(cls, prompty_source: Union[str, Path]) -> "IFlytekChatClient":
+        """
+        Build an IFlytekChatClient from a Prompty spec (file path or inline YAML/JSON).
+
+        Args:
+            prompty_source: Path or inline content of a Prompty specification.
+
+        Returns:
+            Configured IFlytekChatClient instance.
+        """
+        prompty_instance = Prompty.load(prompty_source)
+        prompt_template = Prompty.to_prompt_template(prompty_instance)
+        cfg = prompty_instance.model.configuration
+
+        return cls.model_validate(
+            {
+                "model": cfg.name,
+                "api_key": cfg.api_key,
+                "base_url": cfg.base_url,
+                "prompty": prompty_instance,
+                "prompt_template": prompt_template,
+            }
+        )
+
+    def generate(
+        self,
+        messages: Union[
+            str,
+            Dict[str, Any],
+            BaseMessage,
+            Iterable[Union[Dict[str, Any], BaseMessage]],
+        ] = None,
+        *,
+        input_data: Optional[Dict[str, Any]] = None,
+        model: Optional[str] = None,
+        tools: Optional[List[Union[AgentTool, Dict[str, Any]]]] = None,
+        response_format: Optional[Type[BaseModel]] = None,
+        max_tokens: Optional[int] = None,
+        structured_mode: Literal["function_call"] = "function_call",
+        stream: bool = False,
+        **kwargs: Any,
+    ) -> Union[
+        Iterator[LLMChatCandidateChunk],  # streaming
+        LLMChatResponse,  # non‑stream + no format
+        BaseModel,  # non‑stream + single structured format
+        List[BaseModel],  # non‑stream + list structured format
+    ]:
+        """
+        Issue a chat completion to iFlytek Spark.
+
+        - If `stream=True`, returns an iterator of `LLMChatCandidateChunk` via
+          ResponseHandler.
+        - Otherwise returns either:
+            • a raw `LLMChatResponse`, or
+            • validated Pydantic model(s) per `response_format`.
+
+        Args:
+            messages:        Pre-built messages or None to use `input_data`.
+            input_data:      Variables for the Prompty template.
+            model:           Override default model name.
+            tools:           List of AgentTool or dict specs.
+            response_format: Pydantic model (or list thereof) for structured output.
+            max_tokens:      Override default max_tokens.
+            structured_mode: Must be "function_call" (only supported mode).
+            stream:          If True, return an iterator of `LLMChatCandidateChunk`.
+            **kwargs:        Other LLM params (temperature, etc.).
+
+        Raises:
+            ValueError: for invalid structured_mode or missing inputs.
+        """
+        # 1) Validate structured_mode
+        if structured_mode not in self.SUPPORTED_STRUCTURED_MODES:
+            raise ValueError(
+                f"structured_mode must be one of {self.SUPPORTED_STRUCTURED_MODES}"
+            )
+
+        # 2) If input_data is provided, format messages via Prompty
+        if input_data:
+            if not self.prompt_template:
+                raise ValueError("input_data provided but no prompt_template is set.")
+            logger.info("Formatting messages via prompt_template.")
+            messages = self.prompt_template.format_prompt(**input_data)
+
+        if not messages:
+            raise ValueError("Either 'messages' or 'input_data' must be provided.")
+
+        # 3) Normalize messages + merge client/prompty defaults
+        params: Dict[str, Any] = {
+            "messages": RequestHandler.normalize_chat_messages(messages)
+        }
+        if self.prompty:
+            params = {**self.prompty.model.parameters.model_dump(), **params, **kwargs}
+        else:
+            params.update(kwargs)
+
+        # 4) Add the stream parameter explicitly to params
+        params["stream"] = stream
+
+        # 5) Override model & max_tokens if provided
+        params["model"] = model or self.model
+        params["max_tokens"] = max_tokens or self.max_tokens
+
+        # 6) Inject tools / response_format / structured_mode
+        params = RequestHandler.process_params(
+            params,
+            llm_provider=self.provider,
+            tools=tools,
+            response_format=response_format,
+            structured_mode=structured_mode,
+        )
+
+        # 7) Call iFlytek Spark API + dispatch to ResponseHandler
+        try:
+            logger.info("Calling iFlytek Spark ChatCompletion API.")
+            logger.debug(f"Parameters: {params}")
+            resp = self.client.chat.completions.create(**params)
+            return ResponseHandler.process_response(
+                response=resp,
+                llm_provider=self.provider,
+                response_format=response_format,
+                structured_mode=structured_mode,
+                stream=stream,
+            )
+        except Exception:
+            logger.error("iFlytek Spark ChatCompletion error", exc_info=True)
+            raise

--- a/dapr_agents/llm/iflytek/chat.py
+++ b/dapr_agents/llm/iflytek/chat.py
@@ -66,6 +66,7 @@ class IFlytekChatClient(IFlytekClientBase, ChatClientBase):
     )
     max_tokens: Optional[int] = Field(
         default=1024,
+        ge=1,
         description=(
             "Maximum number of tokens to generate in a single call. "
             "Must be ≥1; defaults to 1024."

--- a/dapr_agents/llm/iflytek/client.py
+++ b/dapr_agents/llm/iflytek/client.py
@@ -1,0 +1,113 @@
+#
+# Copyright 2026 The Dapr Authors
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#     http://www.apache.org/licenses/LICENSE-2.0
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+from dapr_agents.types.llm import IFlytekClientConfig
+from dapr_agents.llm.base import LLMClientBase
+from typing import Any, Optional
+from pydantic import Field
+from openai import OpenAI
+import os
+import logging
+
+logger = logging.getLogger(__name__)
+
+
+class IFlytekClientBase(LLMClientBase):
+    """
+    Base class for managing iFlytek Spark LLM clients.
+
+    iFlytek Spark exposes an OpenAI-compatible chat-completions endpoint, so the
+    OpenAI SDK is reused for transport, mirroring the other OpenAI-compatible
+    providers (e.g. NVIDIA). Handles client initialization, configuration, and
+    shared logic specific to the iFlytek Spark API.
+    """
+
+    api_key: Optional[str] = Field(
+        default=None,
+        description=(
+            "API key (the HTTP API password from the iFlytek open-platform console) "
+            "for authenticating with the iFlytek Spark API. If not provided, it will "
+            "be sourced from the 'IFLYTEK_API_KEY' environment variable."
+        ),
+    )
+    base_url: Optional[str] = Field(
+        default="https://spark-api-open.xf-yun.com/v1",
+        description="Base URL for the iFlytek Spark OpenAI-compatible API endpoints.",
+    )
+
+    def model_post_init(self, __context: Any) -> None:
+        """
+        Initializes private attributes and performs any post-validation setup.
+
+        This includes setting up provider-specific attributes such as configuration
+        and client instances.
+
+        Args:
+            __context (Any): Additional context for post-initialization (not used here).
+        """
+        self._provider = "iflytek"
+
+        # Use environment variable if `api_key` is not explicitly provided
+        if self.api_key is None:
+            self.api_key = os.environ.get("IFLYTEK_API_KEY")
+
+        if self.api_key is None:
+            raise ValueError(
+                "API key is required. Set it explicitly or in the 'IFLYTEK_API_KEY' environment variable."
+            )
+
+        # Set up the private config and client attributes
+        self._config: IFlytekClientConfig = self.get_config()
+        self._client: OpenAI = self.get_client()
+        return super().model_post_init(__context)
+
+    def get_config(self) -> IFlytekClientConfig:
+        """
+        Returns the configuration object for the iFlytek Spark LLM API client.
+
+        Returns:
+            IFlytekClientConfig: Configuration object containing API credentials and endpoint details.
+        """
+        return IFlytekClientConfig(api_key=self.api_key, base_url=self.base_url)
+
+    def get_client(self) -> OpenAI:
+        """
+        Initializes and returns the iFlytek Spark LLM API client.
+
+        Returns:
+            OpenAI: The initialized iFlytek Spark API client instance.
+        """
+        config = self.config
+
+        logger.info("Initializing iFlytek Spark API client...")
+        return OpenAI(api_key=config.api_key, base_url=config.base_url)
+
+    @property
+    def config(self) -> IFlytekClientConfig:
+        """
+        Provides access to the iFlytek Spark API client configuration.
+
+        Returns:
+            IFlytekClientConfig: Configuration object for the iFlytek Spark API client.
+        """
+        return self._config
+
+    @property
+    def client(self) -> OpenAI:
+        """
+        Provides access to the iFlytek Spark API client instance.
+
+        Returns:
+            OpenAI: The iFlytek Spark API client instance.
+        """
+        return self._client

--- a/dapr_agents/llm/utils/response.py
+++ b/dapr_agents/llm/utils/response.py
@@ -91,7 +91,7 @@ class ResponseHandler:
         else:
             # ─── Non‑streaming ─────────────────────────────────────────────────────
             # 1) Normalize full response → LLMChatResponse
-            if provider in ("openai", "nvidia", "litellm"):
+            if provider in ("openai", "nvidia", "litellm", "iflytek"):
                 from dapr_agents.llm.openai.utils import process_openai_chat_response
 
                 llm_resp: LLMChatResponse = process_openai_chat_response(response)

--- a/dapr_agents/llm/utils/stream.py
+++ b/dapr_agents/llm/utils/stream.py
@@ -51,7 +51,7 @@ class StreamHandler:
             LLMChatCandidateChunk: fully-typed chunks, partial and final.
         """
 
-        if llm_provider in ("openai", "nvidia", "litellm"):
+        if llm_provider in ("openai", "nvidia", "litellm", "iflytek"):
             from dapr_agents.llm.openai.utils import process_openai_stream
 
             yield from process_openai_stream(

--- a/dapr_agents/llm/utils/structure.py
+++ b/dapr_agents/llm/utils/structure.py
@@ -312,7 +312,14 @@ class StructureHandler:
         """
         try:
             logger.debug(f"Processing structured response for mode: {structured_mode}")
-            if llm_provider in ("openai", "nvidia", "huggingface", "dapr", "litellm"):
+            if llm_provider in (
+                "openai",
+                "nvidia",
+                "huggingface",
+                "dapr",
+                "litellm",
+                "iflytek",
+            ):
                 if structured_mode == "function_call":
                     tool_calls = getattr(message, "tool_calls", None)
                     if tool_calls:

--- a/dapr_agents/observability/instrumentor.py
+++ b/dapr_agents/observability/instrumentor.py
@@ -336,7 +336,7 @@ class DaprAgentsInstrumentor(BaseInstrumentor):
         chat_client_classes = []
 
         # Check each LLM provider module for ChatClient classes
-        for provider in ["openai", "nvidia", "huggingface", "dapr"]:
+        for provider in ["openai", "nvidia", "huggingface", "dapr", "iflytek"]:
             try:
                 module = __import__(f"dapr_agents.llm.{provider}.chat", fromlist=[""])
 

--- a/dapr_agents/observability/utils.py
+++ b/dapr_agents/observability/utils.py
@@ -334,6 +334,8 @@ def resolve_provider_name(instance: Any) -> str:
         return "openai"
     if "nvidia" in module:
         return "nvidia"
+    if "iflytek" in module:
+        return "iflytek"
     if "huggingface" in module:
         return "huggingface"
     return "unknown"

--- a/dapr_agents/tool/utils/function_calling.py
+++ b/dapr_agents/tool/utils/function_calling.py
@@ -223,8 +223,8 @@ def to_function_call_definition(
     """
     Generates a dictionary representing a function call specification, supporting various API formats.
 
-    - For format_type in ("openai", "nvidia", "huggingface"), produces an OpenAI-style
-      tool definition (type="function", function={…}).
+    - For format_type in ("openai", "nvidia", "huggingface", "dapr", "litellm", "iflytek"), produces
+      an OpenAI-style tool definition (type="function", function={…}).
     - For "claude", produces a Claude-style {name, description, input_schema}.
     - (Gemini omitted here—call to_gemini_function_call_definition if you need it.)
 
@@ -235,7 +235,8 @@ def to_function_call_definition(
         description (str): A brief description of what the function does.
         args_schema (BaseModel): The Pydantic model describing the function's parameters.
         format_type (str, optional): Which API flavor to target:
-            - "openai", "nvidia", or "huggingface" all share the same OpenAI-style schema.
+            - "openai", "nvidia", "huggingface", "dapr", "litellm", and "iflytek" all share the same
+              OpenAI-style schema.
             - "claude" uses Anthropic's format.
           Defaults to "openai".
         use_deprecated (bool): If True and format_type is OpenAI,
@@ -294,7 +295,14 @@ def validate_and_format_tool(
     fmt = tool_format.lower()
 
     try:
-        if fmt in ("openai", "azure_openai", "nvidia", "huggingface", "litellm", "iflytek"):
+        if fmt in (
+            "openai",
+            "azure_openai",
+            "nvidia",
+            "huggingface",
+            "litellm",
+            "iflytek",
+        ):
             validated = (
                 OAIFunctionDefinition(**tool)
                 if use_deprecated

--- a/dapr_agents/tool/utils/function_calling.py
+++ b/dapr_agents/tool/utils/function_calling.py
@@ -250,7 +250,7 @@ def to_function_call_definition(
     fmt = format_type.lower()
 
     # OpenAI‑style wrapper schema:
-    if fmt in ("openai", "nvidia", "huggingface", "dapr", "litellm"):
+    if fmt in ("openai", "nvidia", "huggingface", "dapr", "litellm", "iflytek"):
         return to_openai_function_call_definition(
             name, description, args_schema, use_deprecated
         )
@@ -294,7 +294,7 @@ def validate_and_format_tool(
     fmt = tool_format.lower()
 
     try:
-        if fmt in ("openai", "azure_openai", "nvidia", "huggingface", "litellm"):
+        if fmt in ("openai", "azure_openai", "nvidia", "huggingface", "litellm", "iflytek"):
             validated = (
                 OAIFunctionDefinition(**tool)
                 if use_deprecated

--- a/dapr_agents/types/llm.py
+++ b/dapr_agents/types/llm.py
@@ -38,6 +38,16 @@ class NVIDIAClientConfig(BaseModel):
     )
 
 
+class IFlytekClientConfig(BaseModel):
+    base_url: Optional[str] = Field(
+        "https://spark-api-open.xf-yun.com/v1",
+        description="Base URL for the iFlytek Spark OpenAI-compatible API",
+    )
+    api_key: Optional[str] = Field(
+        None, description="API key to authenticate the iFlytek Spark API"
+    )
+
+
 class MistralClientConfig(BaseModel):
     endpoint: Optional[str] = Field(None, description="Base URL for the Mistral API")
     api_key: Optional[str] = Field(
@@ -247,6 +257,15 @@ class NVIDIAModelConfig(NVIDIAClientConfig):
     )
 
 
+class IFlytekModelConfig(IFlytekClientConfig):
+    type: Literal["iflytek"] = Field(
+        "iflytek", description="Type of the model, must always be 'iflytek'"
+    )
+    name: str = Field(
+        default="", description="Name of the model available through iFlytek Spark"
+    )
+
+
 class OpenAIParamsBase(BaseModel):
     """
     Common request settings for OpenAI services.
@@ -410,6 +429,25 @@ class NVIDIAChatCompletionParams(OpenAIParamsBase):
     )
 
 
+class IFlytekChatCompletionParams(OpenAIParamsBase):
+    """
+    Specific settings for the iFlytek Spark Chat Completion endpoint.
+
+    iFlytek Spark exposes an OpenAI-compatible Chat Completion API, so these
+    parameters mirror the OpenAI-style request settings.
+    """
+
+    n: Optional[int] = Field(
+        1, ge=1, description="Number of chat completion choices to generate"
+    )
+    tools: Optional[List[Dict[str, Any]]] = Field(
+        None, description="List of tools the model may call"
+    )
+    tool_choice: Optional[Union[str, Dict[str, Any]]] = Field(
+        None, description="Controls which tool is called"
+    )
+
+
 class PromptyModelConfig(BaseModel):
     api: Literal["chat", "completion"] = Field(
         "chat", description="The API to use, either 'chat' or 'completion'"
@@ -419,6 +457,7 @@ class PromptyModelConfig(BaseModel):
         AzureOpenAIModelConfig,
         HFHubModelConfig,
         NVIDIAModelConfig,
+        IFlytekModelConfig,
         MistralModelConfig,
         AnthropicModelConfig,
     ] = Field(..., description="Model configuration settings")
@@ -427,6 +466,7 @@ class PromptyModelConfig(BaseModel):
         OpenAIChatCompletionParams,
         HFHubChatCompletionParams,
         NVIDIAChatCompletionParams,
+        IFlytekChatCompletionParams,
         MistralChatCompletionParams,
         AnthropicChatCompletionParams,
     ] = Field(..., description="Parameters for the model request")
@@ -453,6 +493,8 @@ class PromptyModelConfig(BaseModel):
                 configuration = HFHubModelConfig(**configuration)
             elif configuration.get("type") == "nvidia":
                 configuration = NVIDIAModelConfig(**configuration)
+            elif configuration.get("type") == "iflytek":
+                configuration = IFlytekModelConfig(**configuration)
             elif configuration.get("type") == "mistral":
                 configuration = MistralModelConfig(**configuration)
             elif configuration.get("type") == "anthropic":
@@ -463,6 +505,7 @@ class PromptyModelConfig(BaseModel):
             | AzureOpenAIModelConfig
             | HFHubModelConfig
             | NVIDIAModelConfig
+            | IFlytekModelConfig
             | MistralModelConfig
             | AnthropicModelConfig,
             configuration,
@@ -478,6 +521,8 @@ class PromptyModelConfig(BaseModel):
                 parameters = HFHubChatCompletionParams(**parameters)
             elif configuration and isinstance(configuration, NVIDIAModelConfig):
                 parameters = NVIDIAChatCompletionParams(**parameters)
+            elif configuration and isinstance(configuration, IFlytekModelConfig):
+                parameters = IFlytekChatCompletionParams(**parameters)
             elif configuration and isinstance(configuration, MistralModelConfig):
                 parameters = MistralChatCompletionParams(**parameters)
             elif configuration and isinstance(configuration, AnthropicModelConfig):
@@ -487,6 +532,7 @@ class PromptyModelConfig(BaseModel):
             OpenAIChatCompletionParams
             | HFHubChatCompletionParams
             | NVIDIAChatCompletionParams
+            | IFlytekChatCompletionParams
             | MistralChatCompletionParams
             | AnthropicChatCompletionParams,
             parameters,

--- a/dapr_agents/types/llm.py
+++ b/dapr_agents/types/llm.py
@@ -441,7 +441,7 @@ class IFlytekChatCompletionParams(OpenAIParamsBase):
         1, ge=1, description="Number of chat completion choices to generate"
     )
     tools: Optional[List[Dict[str, Any]]] = Field(
-        None, description="List of tools the model may call"
+        None, max_length=64, description="List of tools the model may call"
     )
     tool_choice: Optional[Union[str, Dict[str, Any]]] = Field(
         None, description="Controls which tool is called"

--- a/tests/llm/test_iflytek.py
+++ b/tests/llm/test_iflytek.py
@@ -1,0 +1,99 @@
+#
+# Copyright 2026 The Dapr Authors
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#     http://www.apache.org/licenses/LICENSE-2.0
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+import os
+from unittest.mock import patch, MagicMock
+
+import pytest
+
+from dapr_agents.llm.iflytek.chat import IFlytekChatClient
+
+
+def test_iflytek_client_initialization():
+    """Test default model, base URL, provider and API key env fallback."""
+    with patch.dict(os.environ, {"IFLYTEK_API_KEY": "env-key"}, clear=False):
+        client = IFlytekChatClient()
+    assert client.model == "generalv3.5"
+    assert client.base_url == "https://spark-api-open.xf-yun.com/v1"
+    assert client.provider == "iflytek"
+    assert client.api == "chat"
+    assert client.api_key == "env-key"
+
+
+def test_iflytek_requires_api_key():
+    """Test that a missing API key raises a clear error."""
+    with patch.dict(os.environ, {}, clear=True):
+        with pytest.raises(ValueError, match="API key is required"):
+            IFlytekChatClient()
+
+
+@patch("dapr_agents.llm.iflytek.client.OpenAI")
+def test_iflytek_generate(mock_openai_class):
+    """Test basic text generation using a mocked OpenAI-compatible client."""
+    from openai.types.chat import ChatCompletion, ChatCompletionMessage
+    from openai.types.chat.chat_completion import Choice
+
+    mock_instance = MagicMock()
+    mock_openai_class.return_value = mock_instance
+
+    completion = ChatCompletion(
+        id="test-iflytek-id",
+        object="chat.completion",
+        created=0,
+        model="generalv3.5",
+        choices=[
+            Choice(
+                index=0,
+                finish_reason="stop",
+                message=ChatCompletionMessage(
+                    role="assistant", content="Hello from Spark"
+                ),
+            )
+        ],
+    )
+    mock_instance.chat.completions.create.return_value = completion
+
+    client = IFlytekChatClient(api_key="fake-key")
+    response = client.generate("Say hello")
+
+    assert response.get_message().content == "Hello from Spark"
+    mock_instance.chat.completions.create.assert_called_once()
+
+
+def test_iflytek_from_prompty():
+    """Test initializing IFlytekChatClient from a Prompty template."""
+    prompty_content = """---
+name: iFlytek Test
+model:
+  api: chat
+  configuration:
+    type: iflytek
+    name: 4.0Ultra
+    base_url: https://spark-api-open.xf-yun.com/v1
+    api_key: dummy_key
+  parameters:
+    temperature: 0.5
+    max_tokens: 100
+---
+system:
+You are a helpful assistant.
+"""
+    client = IFlytekChatClient.from_prompty(prompty_content)
+
+    assert client.model == "4.0Ultra"
+    assert client.api_key == "dummy_key"
+    assert client.base_url == "https://spark-api-open.xf-yun.com/v1"
+
+    assert client.prompty is not None
+    assert client.prompty.model.parameters.temperature == 0.5
+    assert client.prompty.model.parameters.max_tokens == 100


### PR DESCRIPTION
## Description

Adds an **iFlytek Spark** chat client provider.

iFlytek Spark exposes an OpenAI-compatible chat-completions endpoint
(`https://spark-api-open.xf-yun.com/v1`), so the new client reuses the OpenAI
SDK for transport and the shared OpenAI-compatible request / response /
streaming / structured-output / tool-formatting paths — mirroring the existing
`nvidia` provider rather than adding a bespoke client.

### What's included
- New `dapr_agents/llm/iflytek` package: `IFlytekClientBase` and `IFlytekChatClient`
- `IFlytekClientConfig`, `IFlytekModelConfig`, and `IFlytekChatCompletionParams`
  types, plus Prompty configuration/parameters wiring (`type: iflytek`)
- `iflytek` registered alongside `openai`/`nvidia` in the OpenAI-compatible
  branches of the response, stream, structured-output, tool-formatting and
  observability helpers
- `IFlytekChatClient` exported from `dapr_agents.llm`
- Unit tests covering initialization, generation (mocked), missing-key error,
  and `from_prompty`

### Usage
```python
from dapr_agents.llm import IFlytekChatClient

# IFLYTEK_API_KEY = the HTTP API password from the iFlytek open-platform console
llm = IFlytekChatClient(model="generalv3.5")
resp = llm.generate("Hello")
```

### Testing
- `pytest tests/llm` → all pass (incl. new `tests/llm/test_iflytek.py`)
- `pytest tests/tool` → all pass (no regression from the shared tool-format change)
- `ruff check` / `ruff format --check` clean

## Issue reference
N/A — additive new provider; no behavior change to existing providers.
