### PR TITLE
fix(prompt): handle unset ${VAR} in PromptyHelper.normalize

### DIFF
--- a/dapr_agents/prompt/utils/prompty.py
+++ b/dapr_agents/prompt/utils/prompty.py
@@ -200,7 +200,7 @@ class PromptyHelper:
                     return PromptyHelper.process_file(variable[1], parent)
                 else:
                     v = PromptyHelper.process_env(variable[0], False)
-                    if len(v) == 0:
+                    if not v:
                         if len(variable) > 1:
                             return variable[1]
                         elif env_error:

--- a/tests/prompt/test_prompty.py
+++ b/tests/prompt/test_prompty.py
@@ -1,0 +1,46 @@
+#
+# Copyright 2026 The Dapr Authors
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#     http://www.apache.org/licenses/LICENSE-2.0
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+"""Unit tests for PromptyHelper.normalize() environment variable resolution."""
+
+from dapr_agents.prompt.utils.prompty import PromptyHelper
+
+
+class TestPromptyHelperNormalize:
+    """Tests for PromptyHelper.normalize() with ${VAR} env references."""
+
+    def test_legacy_default_used_when_var_unset(self, monkeypatch):
+        """${VAR:default} returns the default when the env var is unset."""
+        monkeypatch.delenv("DA_NORMALIZE_MISSING", raising=False)
+        assert PromptyHelper.normalize("${DA_NORMALIZE_MISSING:fallback}") == "fallback"
+
+    def test_unset_var_without_default_returns_none(self, monkeypatch):
+        """${VAR} with no default returns None when env_error is False."""
+        monkeypatch.delenv("DA_NORMALIZE_MISSING", raising=False)
+        assert (
+            PromptyHelper.normalize("${DA_NORMALIZE_MISSING}", env_error=False) is None
+        )
+
+    def test_set_var_round_trips(self, monkeypatch):
+        """${VAR} returns the env value when the variable is set."""
+        monkeypatch.setenv("DA_NORMALIZE_SET", "xyz")
+        assert PromptyHelper.normalize("${DA_NORMALIZE_SET}") == "xyz"
+
+    def test_env_prefixed_default_still_works(self, monkeypatch):
+        """${env:NAME:default} still falls back to the default when unset."""
+        monkeypatch.delenv("DA_NORMALIZE_MISSING", raising=False)
+        assert PromptyHelper.normalize("${env:DA_NORMALIZE_MISSING:def}") == "def"
+
+    def test_plain_string_unchanged(self):
+        """A plain string is returned unchanged."""
+        assert PromptyHelper.normalize("hello") == "hello"


### PR DESCRIPTION
# Description

`PromptyHelper.normalize()` called `len()` on the result of `process_env()` for legacy bare `${VAR}` references. `process_env(var, False)` returns `None` when the variable is unset, so `len(None)` raised `TypeError: object of type 'NoneType' has no len()` before the `${VAR:default}` fallback could fire. That crashes `Prompty.load` / `from_prompty` for every chat client when a spec uses a bare `${API_KEY}` style ref for an unset var.

Guarded with `if not v:`, mirroring the sibling `resolve_env` (L135), so the documented default is used and an unset var without a default returns `None` (or raises the clear "not found" error when `env_error` is set). The `${env:NAME:default}` and `${file:...}` arms are untouched. Added `tests/prompt/test_prompty.py` covering unset-with-default, unset-without-default, set round-trip, env-prefixed default, and plain strings.

## Issue reference

We strive to have all PR being opened based on an issue, where the problem or feature have been discussed prior to implementation.

Please reference the issue this PR closes: Closes #673

## Checklist

Please make sure you've completed the relevant tasks for this PR, out of the following list:

* [x] Created/updated tests
* [ ] Tested this change against all the quickstarts
* [ ] Extended the documentation
    * [ ] Created the [dapr/docs](https://github.com/dapr/docs) PR: <insert PR link here>

**Note:** We expect contributors to open a corresponding documentation PR in the [dapr/docs](https://github.com/dapr/docs/) repository. As the implementer, you are the best person to document your work! Implementation PRs will not be merged until the documentation PR is opened and ready for review.
