### PR TITLE
fix(embedder): normalize single-chunk OpenAI embeddings

### DIFF
--- a/dapr_agents/document/embedder/openai.py
+++ b/dapr_agents/document/embedder/openai.py
@@ -160,7 +160,12 @@ class OpenAIEmbedder(OpenAIEmbeddingClient, EmbedderBase):
         for embeddings, tokens in zip(grouped_embeddings, tokenized_inputs):
             if len(embeddings) == 1:
                 # If only one chunk, use its embedding directly
-                results.append(embeddings[0])
+                embedding = embeddings[0]
+                if self.normalize:
+                    embedding = (
+                        np.array(embedding) / np.linalg.norm(embedding)
+                    ).tolist()
+                results.append(embedding)
             else:
                 # Combine chunk embeddings using weighted averaging
                 weights = [

--- a/tests/document/embedder/test_openai.py
+++ b/tests/document/embedder/test_openai.py
@@ -1,0 +1,65 @@
+#
+# Copyright 2026 The Dapr Authors
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#     http://www.apache.org/licenses/LICENSE-2.0
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+from unittest.mock import MagicMock, patch
+
+import numpy as np
+
+from dapr_agents.document.embedder.openai import OpenAIEmbedder
+
+
+def _embedding_response(vectors):
+    """Build a mock CreateEmbeddingResponse exposing one .embedding per vector."""
+    response = MagicMock()
+    response.data = [MagicMock(embedding=list(v)) for v in vectors]
+    return response
+
+
+class TestOpenAIEmbedder:
+    """Unit tests for OpenAIEmbedder.embed normalization (no network)."""
+
+    def test_single_input_is_normalized_by_default(self, monkeypatch):
+        monkeypatch.setenv("OPENAI_API_KEY", "sk-test")
+        embedder = OpenAIEmbedder()
+        with patch.object(
+            OpenAIEmbedder,
+            "create_embedding",
+            return_value=_embedding_response([[3.0, 4.0]]),
+        ):
+            result = embedder.embed("hello")
+        assert np.isclose(np.linalg.norm(result), 1.0)
+
+    def test_list_input_is_normalized_by_default(self, monkeypatch):
+        monkeypatch.setenv("OPENAI_API_KEY", "sk-test")
+        embedder = OpenAIEmbedder()
+        with patch.object(
+            OpenAIEmbedder,
+            "create_embedding",
+            return_value=_embedding_response([[3.0, 4.0], [6.0, 8.0]]),
+        ):
+            results = embedder.embed(["hello", "world"])
+        assert len(results) == 2
+        for vector in results:
+            assert np.isclose(np.linalg.norm(vector), 1.0)
+
+    def test_normalize_false_returns_raw_vector(self, monkeypatch):
+        monkeypatch.setenv("OPENAI_API_KEY", "sk-test")
+        embedder = OpenAIEmbedder(normalize=False)
+        with patch.object(
+            OpenAIEmbedder,
+            "create_embedding",
+            return_value=_embedding_response([[3.0, 4.0]]),
+        ):
+            result = embedder.embed("hello")
+        assert result == [3.0, 4.0]
+        assert np.isclose(np.linalg.norm(result), 5.0)


### PR DESCRIPTION
# Description

`OpenAIEmbedder.embed` only normalized vectors on the multi-chunk path (via `_process_embeddings`). With the default `normalize=True`, single-chunk inputs (any text under `max_tokens`, i.e. the common case) were returned raw, so `normalize=True` and `normalize=False` behaved the same and cosine-similarity comparisons broke. This mirrors `NVIDIAEmbedder` by normalizing the single-chunk branch too; `normalize=False` still returns raw vectors and the multi-chunk path is unchanged. Adds focused unit tests (`create_embedding` mocked, no network).

## Issue reference

We strive to have all PR being opened based on an issue, where the problem or feature have been discussed prior to implementation.

Please reference the issue this PR closes: #675

## Checklist

Please make sure you've completed the relevant tasks for this PR, out of the following list:

* [x] Created/updated tests
* [ ] Tested this change against all the quickstarts
* [x] Extended the documentation
    * [ ] Created the [dapr/docs](https://github.com/dapr/docs) PR: not required (internal correctness fix, no API / feature / config change; behaviour now matches the existing docstring and `NVIDIAEmbedder`)

## AGENTS.md Notes

- AGENTS.md says a dapr/docs PR is required for API / feature / breaking / config changes. Consider adding an explicit line that pure internal correctness fixes (no public API or config change) do not need one, so contributors are not blocked on a no-op docs PR.
- The "Before commit (REQUIRED)" command block is excellent and worked verbatim.
- The Apache 2.0 test-file header convention is enforced in review but only discoverable by reading existing test files; one line in AGENTS.md pointing at it would help first-time contributors.
