### PR TITLE
fix(types): raise ValueError for invalid FunctionCall arguments

### DIFF
--- a/dapr_agents/types/message.py
+++ b/dapr_agents/types/message.py
@@ -15,7 +15,6 @@ from typing import Any
 from pydantic import (
     BaseModel,
     field_validator,
-    ValidationError,
     model_validator,
     ConfigDict,
 )
@@ -99,13 +98,13 @@ class FunctionCall(BaseModel):
             try:
                 return json.dumps(v)
             except TypeError as e:
-                raise ValidationError(f"Invalid data type in dictionary: {e}")
+                raise ValueError(f"Invalid data type in dictionary: {e}")
         elif isinstance(v, str):
             try:
                 json.loads(v)  # This is to check if it's valid JSON
                 return v
             except json.JSONDecodeError as e:
-                raise ValidationError(f"Invalid JSON format: {e}")
+                raise ValueError(f"Invalid JSON format: {e}")
         else:
             raise TypeError(f"Unsupported type for field: {type(v)}")
 

--- a/tests/types/test_message.py
+++ b/tests/types/test_message.py
@@ -1,0 +1,46 @@
+#
+# Copyright 2026 The Dapr Authors
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#     http://www.apache.org/licenses/LICENSE-2.0
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+import pytest
+from pydantic import ValidationError
+
+from dapr_agents.types.message import FunctionCall
+
+
+def test_function_call_accepts_valid_json_string():
+    call = FunctionCall(name="get_weather", arguments='{"city": "Seattle"}')
+    assert call.arguments == '{"city": "Seattle"}'
+    assert call.arguments_dict == {"city": "Seattle"}
+
+
+def test_function_call_serializes_dict_arguments():
+    call = FunctionCall(name="get_weather", arguments={"city": "Seattle"})
+    assert call.arguments == '{"city": "Seattle"}'
+    assert call.arguments_dict == {"city": "Seattle"}
+
+
+def test_function_call_invalid_json_string_raises_validation_error():
+    with pytest.raises(ValidationError) as exc_info:
+        FunctionCall(name="get_weather", arguments="{not valid json")
+    assert "Invalid JSON format" in str(exc_info.value)
+
+
+def test_function_call_non_serializable_dict_raises_validation_error():
+    with pytest.raises(ValidationError) as exc_info:
+        FunctionCall(name="get_weather", arguments={"key": object()})
+    assert "Invalid data type in dictionary" in str(exc_info.value)
+
+
+def test_function_call_unsupported_type_raises_type_error():
+    with pytest.raises(TypeError):
+        FunctionCall(name="get_weather", arguments=123)


### PR DESCRIPTION
# Description

`FunctionCall.validate_json` raised pydantic's `ValidationError` directly from a
string when the tool-call `arguments` were malformed:

```python
except TypeError as e:
    raise ValidationError(f"Invalid data type in dictionary: {e}")
...
except json.JSONDecodeError as e:
    raise ValidationError(f"Invalid JSON format: {e}")
```

In pydantic v2, `ValidationError` cannot be constructed from a string (it
requires `line_errors`), so the `raise` itself failed with a cryptic
`TypeError: ValidationError.__new__() missing 1 required positional argument: 'line_errors'`,
and the intended human-readable message was discarded.

This change raises plain `ValueError` instead, which is the pydantic-idiomatic
signal inside a `field_validator`: pydantic catches it and wraps it into a clean
`ValidationError` that preserves the message. This matches the validator's own
docstring (`Raises: ValueError`) and every other field validator in
`dapr_agents/types/`. The now-unused `ValidationError` import is removed.

The path is reachable from real input: `FunctionCall` is constructed from
LLM/provider tool-call argument strings (`llm/openai`, `llm/anthropic`,
`llm/dapr`, `llm/huggingface`), so a provider returning malformed JSON triggered
the crash.

Before:

```python
>>> FunctionCall(name="f", arguments="{not valid json")
TypeError: ValidationError.__new__() missing 1 required positional argument: 'line_errors'
```

After:

```python
>>> FunctionCall(name="f", arguments="{not valid json")
pydantic_core._pydantic_core.ValidationError: 1 validation error for FunctionCall
arguments
  Value error, Invalid JSON format: Expecting property name enclosed in double quotes ...
```

Adds `tests/types/test_message.py` covering malformed string args and a
non-serializable dict (now surfacing `ValidationError`, not a bare `TypeError`),
valid `str`/`dict` round-trips, and the unsupported-type contract. Backward
compatible: valid arguments are unaffected; the unsupported-type branch still
raises `TypeError` on purpose.

## Issue reference

We strive to have all PR being opened based on an issue, where the problem or feature have been discussed prior to implementation.

Please reference the issue this PR closes: #678

## Checklist

Please make sure you've completed the relevant tasks for this PR, out of the following list:

* [x] Created/updated tests
* [ ] Tested this change against all the quickstarts
* [x] Extended the documentation
    * [ ] Created the [dapr/docs](https://github.com/dapr/docs) PR: n/a - internal error-type fix, no public API/behaviour change (see note below)

**Note:** We expect contributors to open a corresponding documentation PR in the [dapr/docs](https://github.com/dapr/docs/) repository. As the implementer, you are the best person to document your work! Implementation PRs will not be merged until the documentation PR is opened and ready for review.

This change does not alter any public API, configuration, or documented
behaviour: it fixes an internal exception type so a malformed-argument case
surfaces the validation error the docstring already promises instead of crashing.
No `dapr/docs` content corresponds to it. Flagging for a maintainer to confirm
no docs PR is required; happy to open one if you disagree.

## AGENTS.md Notes

(`AGENTS.md` asks every PR to include this section.)

- The pre-commit gate in `AGENTS.md` ran clean as written
  (`ruff format` -> `flake8 ... --ignore=E501,F401,W503,E203,E704` ->
  `mypy --config-file mypy.ini` -> `pytest tests -m "not integration"`).
- Minor doc nit: `AGENTS.md` says flake8 "ignores: E501, F401, W503, E203", but
  the documented command (and CI) also pass `E704`. Aligning the prose with the
  command would avoid confusion.
- It would help first-time contributors if `AGENTS.md` mentioned the DCO
  sign-off requirement (`git commit -s`) next to the commit-format section, since
  an unsigned commit blocks the PR but that is only discoverable from the DCO
  check.
