### PR TITLE
fix(memory): record createdAt in UTC instead of mislabeled local time

### DIFF
--- a/dapr_agents/memory/daprstatestore.py
+++ b/dapr_agents/memory/daprstatestore.py
@@ -13,7 +13,7 @@
 
 import json
 import logging
-from datetime import datetime
+from datetime import datetime, timezone
 from typing import Any, Dict, List, Optional, Union
 
 from pydantic import Field
@@ -87,7 +87,7 @@ class ConversationDaprStateMemory(MemoryBase):
         message = self._convert_to_dict(message)
         message.update(
             {
-                "createdAt": datetime.now().isoformat() + "Z",
+                "createdAt": datetime.now(timezone.utc).isoformat(),
             }
         )
 

--- a/tests/memory/test_daprstatestore.py
+++ b/tests/memory/test_daprstatestore.py
@@ -1,0 +1,63 @@
+#
+# Copyright 2026 The Dapr Authors
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#     http://www.apache.org/licenses/LICENSE-2.0
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+"""Unit tests for ConversationDaprStateMemory."""
+
+import json
+from datetime import datetime, timedelta, timezone
+from unittest.mock import MagicMock
+
+from dapr_agents.memory.daprstatestore import ConversationDaprStateMemory
+
+
+def _make_memory() -> ConversationDaprStateMemory:
+    """Build a memory instance whose Dapr store is a mock that captures writes."""
+    memory = ConversationDaprStateMemory(agent_name="test-agent")
+    store = MagicMock()
+    store.get_state.return_value = MagicMock(data=None, etag=None)
+    memory.dapr_store = store
+    return memory
+
+
+def test_add_message_records_created_at_in_utc(monkeypatch):
+    """createdAt must be a timezone-aware UTC timestamp, not local time mislabeled
+    as UTC.
+
+    Regression for a bug where ``datetime.now().isoformat() + "Z"`` stamped the
+    host's naive LOCAL time and hard-appended ``Z``, so on any non-UTC host the
+    persisted instant was wrong by the host's UTC offset while claiming to be UTC.
+    """
+    # A local wall clock 4 hours ahead of UTC (e.g. a non-UTC deployment).
+    true_utc = datetime(2026, 1, 2, 3, 4, 5, 678901, tzinfo=timezone.utc)
+    naive_local = (true_utc + timedelta(hours=4)).replace(tzinfo=None)
+
+    class FakeDateTime(datetime):
+        @classmethod
+        def now(cls, tz=None):
+            # Mirror the stdlib: no tz -> naive local time; tz -> that timezone.
+            return naive_local if tz is None else true_utc.astimezone(tz)
+
+    monkeypatch.setattr("dapr_agents.memory.daprstatestore.datetime", FakeDateTime)
+
+    memory = _make_memory()
+    memory.add_message({"role": "user", "content": "hello"}, "wf-1")
+
+    saved_value = memory.dapr_store.save_state.call_args.args[1]
+    stored = json.loads(saved_value)[0]
+    parsed = datetime.fromisoformat(stored["createdAt"])
+
+    # Must be timezone-aware and equal to the true UTC instant.
+    assert parsed.tzinfo is not None
+    assert parsed == true_utc
+    # And must NOT be the naive local wall clock mislabeled as UTC.
+    assert parsed != naive_local.replace(tzinfo=timezone.utc)


### PR DESCRIPTION


`ConversationDaprStateMemory.add_message` stamps every persisted message with a
`createdAt` timestamp:

```python
message.update({"createdAt": datetime.now().isoformat() + "Z"})
```

`datetime.now()` (called with no timezone argument) returns a **naive** datetime
in the host's **local** time. Hard-appending the literal `"Z"` then asserts, per
ISO 8601, that this instant is UTC. So on any host that is not set to UTC, the
stored `createdAt` is wrong by the host's UTC offset while claiming to be UTC,
and the error shifts with daylight saving time.

Example on a host in `America/New_York` (UTC-4 in summer): the code records
`2026-07-03T02:39:22.427252Z`, but the true instant is
`2026-07-03T06:39:22.427263+00:00`, a 4-hour error mislabeled as UTC.

This is the only occurrence of the `isoformat() + "Z"` pattern in the codebase.
The fix uses a timezone-aware UTC timestamp, matching the sibling
`ConversationVectorMemory`, which already writes
`datetime.now(timezone.utc).isoformat()`:

```python
message.update({"createdAt": datetime.now(timezone.utc).isoformat()})
```

`createdAt` is now a correct, timezone-aware UTC ISO-8601 string (`...+00:00`)
regardless of the host timezone.

A regression test (`tests/memory/test_daprstatestore.py`) forces a non-UTC local
clock (4 hours ahead of UTC), calls `add_message`, captures the value written to
the Dapr state store, parses `createdAt`, and asserts it is timezone-aware and
equals the true UTC instant (and is not the naive local wall clock mislabeled as
UTC). It fails on the old code and passes on the fix.

## Issue reference

Please reference the issue this PR closes: #_[issue number]_

## Checklist

* [x] Created/updated tests
* [ ] Tested this change against all the quickstarts
* [ ] Extended the documentation
    * [ ] Created the dapr/docs PR: _not required; internal-only bug fix (no
      public API / feature / config / documented-behavior change)._

## AGENTS.md Notes

- The `AGENTS.md` "Before commit (REQUIRED)" gate (`ruff format` -> `flake8` ->
  `mypy --config-file mypy.ini` -> `pytest tests -m "not integration"`) was clear
  and matched CI exactly; all steps passed locally. Nothing needed to be guessed.
- Suggestion: the "Test Structure" section lists `agents/`, `llm/`, `workflow/`
  as the unit-test dirs; `memory/` (which this PR adds a test under) exists in
  `tests/` too. Listing it, or noting the list is illustrative, would remove a
  small ambiguity for contributors touching `dapr_agents/memory/`.
