### PR TITLE
fix(prompt): correct extract_input_variables return type to List[str]

### DIFF
--- a/dapr_agents/prompt/prompty.py
+++ b/dapr_agents/prompt/prompty.py
@@ -21,7 +21,7 @@ from dapr_agents.prompt.base import PromptTemplateBase
 from dapr_agents.prompt.chat import ChatPromptTemplate
 from dapr_agents.prompt.string import StringPromptTemplate
 from dapr_agents.prompt.utils.prompty import PromptyHelper
-from typing import Dict, Any, Union, Optional, Literal, List, Tuple
+from typing import Dict, Any, Union, Optional, Literal, List
 from pathlib import Path
 import logging
 
@@ -35,19 +35,16 @@ class Prompty(PromptyDefinition):
 
     def extract_input_variables(
         self, template_format: Literal["f-string", "jinja2"] = "jinja2"
-    ) -> Tuple[List[str], List[str]]:
+    ) -> List[str]:
         """
         Extract all input variables from the Prompty instance, including placeholders from content,
-        predefined inputs, and sample inputs. This method returns both regular input variables and
-        more complex placeholders that may require additional processing.
+        predefined inputs, and sample inputs.
 
         Args:
             template_format (Literal["f-string", "jinja2"]): Template format for content parsing. Default is 'jinja2'.
 
         Returns:
-            Tuple[List[str], List[str]]:
-                - A list of regular input variables.
-                - A list of placeholders that may require extra processing (e.g., loops or attributes).
+            List[str]: A deduplicated list of input variable names.
         """
         # Extract undeclared variables and placeholders from the content
         undeclared_variables = PromptyHelper.extract_placeholders_from_content(

--- a/tests/prompt/test_prompty.py
+++ b/tests/prompt/test_prompty.py
@@ -11,7 +11,7 @@
 # limitations under the License.
 #
 
-"""Unit tests for PromptyHelper.normalize() environment variable resolution."""
+"""Unit tests for Prompty and PromptyHelper prompt utilities."""
 
 from dapr_agents.prompt.prompty import Prompty
 from dapr_agents.prompt.utils.prompty import PromptyHelper

--- a/tests/prompt/test_prompty.py
+++ b/tests/prompt/test_prompty.py
@@ -13,6 +13,7 @@
 
 """Unit tests for PromptyHelper.normalize() environment variable resolution."""
 
+from dapr_agents.prompt.prompty import Prompty
 from dapr_agents.prompt.utils.prompty import PromptyHelper
 
 
@@ -44,3 +45,55 @@ class TestPromptyHelperNormalize:
     def test_plain_string_unchanged(self):
         """A plain string is returned unchanged."""
         assert PromptyHelper.normalize("hello") == "hello"
+
+
+class TestPromptyExtractInputVariables:
+    """Tests for Prompty.extract_input_variables() return contract."""
+
+    PROMPTY_CONTENT = """---
+name: Extract Vars Test
+model:
+  api: chat
+  configuration:
+    type: openai
+    name: gpt-4o
+  parameters:
+    max_tokens: 128
+    temperature: 0.2
+inputs:
+  question:
+    type: string
+sample:
+  "topic": "history"
+---
+system:
+You are a helpful assistant.
+
+user:
+{{question}} about {{subject}}
+"""
+
+    def test_returns_flat_list_of_strings(self):
+        """extract_input_variables returns a single flat list of variable names.
+
+        Regression test: the method used to be annotated
+        ``-> Tuple[List[str], List[str]]`` while it only ever returns one list,
+        so callers (e.g. to_prompt_template) treat the result as ``List[str]``.
+        """
+        prompty = Prompty.load(self.PROMPTY_CONTENT)
+
+        result = prompty.extract_input_variables("jinja2")
+
+        assert isinstance(result, list)
+        assert all(isinstance(name, str) for name in result)
+        # Content placeholders (question, subject), declared inputs (question),
+        # and sample keys (topic), deduplicated into one flat list.
+        assert sorted(result) == ["question", "subject", "topic"]
+
+    def test_result_feeds_prompt_template_input_variables(self):
+        """The returned list is used directly as the template input variables."""
+        prompty = Prompty.load(self.PROMPTY_CONTENT)
+
+        template = prompty.to_prompt_template("jinja2")
+
+        assert sorted(template.input_variables) == ["question", "subject", "topic"]


### PR DESCRIPTION
# Description

`Prompty.extract_input_variables` was annotated as returning `Tuple[List[str], List[str]]`, and its docstring described two lists. The implementation has one return statement that produces a flat, deduplicated `List[str]`. Its caller already treats the result as that list.

This aligns the annotation and docstring with the existing behavior, removes the unused `Tuple` import, and adds regression tests for the return contract and prompt-template input variables. Runtime behavior is unchanged.

## Issue reference

No issue. This is a small, self-contained type-contract correction.

## Checklist

* [x] Created/updated tests
* [ ] Tested this change against all the quickstarts
* [ ] Extended the documentation
    * [ ] Created the [dapr/docs](https://github.com/dapr/docs) PR: N/A

No documentation PR is needed because this corrects an internal annotation and docstring without changing runtime behavior.

## AGENTS.md Notes

- The documented pre-commit checks ran successfully.
- Mentioning that `dapr_agents.prompt.*` is excluded from mypy checks would clarify why runtime contract tests remain useful there.
