### PR TITLE
fix(prompt): correct extract_variables return type to List[str]

### DIFF
--- a/dapr_agents/prompt/utils/string.py
+++ b/dapr_agents/prompt/utils/string.py
@@ -19,7 +19,7 @@ from dapr_agents.prompt.utils.fstring import (
     render_fstring_template,
     extract_fstring_variables,
 )
-from typing import Any, Dict
+from typing import Any, List
 
 DEFAULT_FORMATTER_MAPPING = {
     "f-string": render_fstring_template,
@@ -57,7 +57,7 @@ class StringPromptHelper:
         return formatter(content, **kwargs)
 
     @staticmethod
-    def extract_variables(template: str, template_format: str) -> Dict[str, Any]:
+    def extract_variables(template: str, template_format: str) -> List[str]:
         """
         Extract variables from the template content based on the template format.
 
@@ -66,7 +66,7 @@ class StringPromptHelper:
             template_format (str): Template format ('f-string' or 'jinja2').
 
         Returns:
-            Dict[str, Any]: A dictionary of extracted variables.
+            List[str]: A list of extracted variable names.
         """
         extractor = DEFAULT_VARIABLE_EXTRACTOR_MAPPING.get(template_format)
         if not extractor:

--- a/tests/prompt/utils/test_string.py
+++ b/tests/prompt/utils/test_string.py
@@ -1,0 +1,56 @@
+#
+# Copyright 2026 The Dapr Authors
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#     http://www.apache.org/licenses/LICENSE-2.0
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+"""Unit tests for StringPromptHelper.extract_variables()."""
+
+from typing import List, get_type_hints
+
+import pytest
+
+from dapr_agents.prompt.utils.string import StringPromptHelper
+
+
+class TestStringPromptHelperExtractVariables:
+    """Tests for StringPromptHelper.extract_variables() return value and type."""
+
+    def test_extract_variables_fstring_returns_list_of_names(self):
+        """f-string templates return a list of variable names, not a dict."""
+        result = StringPromptHelper.extract_variables(
+            "Hello {name}, you are a {role}.", "f-string"
+        )
+        assert isinstance(result, list)
+        assert sorted(result) == ["name", "role"]
+
+    def test_extract_variables_jinja2_returns_list_of_names(self):
+        """jinja2 templates return a list of variable names, not a dict."""
+        result = StringPromptHelper.extract_variables(
+            "Hello {{ name }}, you are a {{ role }}.", "jinja2"
+        )
+        assert isinstance(result, list)
+        assert sorted(result) == ["name", "role"]
+
+    def test_extract_variables_no_variables_returns_empty_list(self):
+        """A template without placeholders returns an empty list."""
+        assert (
+            StringPromptHelper.extract_variables("no variables here", "f-string") == []
+        )
+
+    def test_extract_variables_unsupported_format_raises(self):
+        """An unknown template format raises ValueError."""
+        with pytest.raises(ValueError):
+            StringPromptHelper.extract_variables("{name}", "unsupported")
+
+    def test_extract_variables_return_annotation_is_list(self):
+        """The return annotation matches the List[str] the callers rely on."""
+        hints = get_type_hints(StringPromptHelper.extract_variables)
+        assert hints["return"] == List[str]


### PR DESCRIPTION
# Description

`StringPromptHelper.extract_variables` was annotated as returning `Dict[str, Any]`, but it delegates to f-string and Jinja extractors that both return `List[str]`. Its callers also use the result as a list of input variable names.

This corrects the annotation and docstring, updates the typing import, and adds tests covering both template formats, empty templates, unsupported formats, and the return annotation. Runtime behavior is unchanged.

## Issue reference

No issue. This is a small, self-contained type-contract correction.

## Checklist

* [x] Created/updated tests
* [ ] Tested this change against all the quickstarts
* [ ] Extended the documentation
    * [ ] Created the [dapr/docs](https://github.com/dapr/docs) PR: N/A

No documentation PR is needed because this corrects an internal annotation and docstring without changing runtime behavior.

## AGENTS.md Notes

- The documented pre-commit checks ran successfully.
- Mentioning that `dapr_agents.prompt.*` is excluded from mypy checks would clarify why runtime contract tests remain useful there.
