### PR TITLE
fix: skip broadcast handlers if no broadcast topic is configured

### DIFF
--- a/dapr_agents/workflow/runners/agent.py
+++ b/dapr_agents/workflow/runners/agent.py
@@ -364,9 +364,16 @@ class AgentRunner(WorkflowRunner):
                 config.broadcast_topic if is_broadcast else config.agent_topic
             )
             if not topic:
-                kind = "broadcast" if is_broadcast else "direct"
+                if is_broadcast:
+                    # Skip broadcast handlers if the agent has no broadcast topic configured,
+                    # as no registered broadcast workflow exists to handle messages.
+                    logger.debug(
+                        f"[{self._name}] Agent {getattr(agent, 'name', agent)} has no broadcast topic; "
+                        f"skipping broadcast handler {handler.__name__}."
+                    )
+                    continue
                 raise ValueError(
-                    f"AgentPubSubConfig missing topic for {kind} handler {handler.__name__}"
+                    f"AgentPubSubConfig missing agent topic for handler {handler.__name__}"
                 )
 
             schemas = meta.get("message_schemas") or []


### PR DESCRIPTION
# Description

Subscriptions are not wired when `AgentPubSubConfig.broadcast_topic` is omitted, matching the workflow registration behavior.

/cc @CasperGN

## Issue reference

Please reference the issue this PR closes: #691

## Checklist

Please make sure you've completed the relevant tasks for this PR, out of the following list:

* [ ] Created/updated tests
* [ ] Tested this change against all the quickstarts
* [ ] Extended the documentation
    * [ ] Created the [dapr/docs](https://github.com/dapr/docs) PR: <insert PR link here>

**Note:** We expect contributors to open a corresponding documentation PR in the [dapr/docs](https://github.com/dapr/docs/) repository. As the implementer, you are the best person to document your work! Implementation PRs will not be merged until the documentation PR is opened and ready for review.
