### PR TITLE
fix: make litellm lazy import to fix builds

### DIFF
--- a/dapr_agents/__init__.py
+++ b/dapr_agents/__init__.py
@@ -12,6 +12,8 @@
 #
 
 from importlib.metadata import version, PackageNotFoundError
+from typing import TYPE_CHECKING, Any
+
 from dapr_agents.agents.durable import DurableAgent
 from dapr_agents.agents.configs import (
     AgentApprovalConfig,
@@ -52,7 +54,6 @@ from dapr_agents.hooks import (
 from dapr_agents.executors import DockerCodeExecutor, LocalCodeExecutor
 from dapr_agents.llm.anthropic import AnthropicChatClient
 from dapr_agents.llm.dapr import DaprChatClient
-from dapr_agents.llm.litellm import LiteLLMChatClient
 from dapr_agents.llm.elevenlabs import ElevenLabsSpeechClient
 from dapr_agents.llm.huggingface import HFHubChatClient
 from dapr_agents.llm.nvidia import NVIDIAChatClient, NVIDIAEmbeddingClient
@@ -117,6 +118,23 @@ __all__ = [
     "RegistryMetadata",
     "LLMMetadata",
 ]
+
+if TYPE_CHECKING:
+    from dapr_agents.llm.litellm import LiteLLMChatClient
+
+
+def __getattr__(name: str) -> Any:
+    # LiteLLM is a heavy optional dependency (~190 MB RSS, ~2100 modules on
+    # import). Load it lazily so merely importing dapr_agents does not pay that
+    # cost in every agent process. Eager import here previously multiplied
+    # memory use across multi-agent workflows and starved co-located model
+    # servers on constrained CI runners.
+    if name == "LiteLLMChatClient":
+        from dapr_agents.llm.litellm import LiteLLMChatClient
+
+        return LiteLLMChatClient
+    raise AttributeError(f"module {__name__!r} has no attribute {name!r}")
+
 
 try:
     __version__ = version("dapr-agents")

--- a/dapr_agents/llm/__init__.py
+++ b/dapr_agents/llm/__init__.py
@@ -11,9 +11,10 @@
 # limitations under the License.
 #
 
+from typing import TYPE_CHECKING, Any
+
 from .anthropic.chat import AnthropicChatClient
 from .dapr import DaprChatClient
-from .litellm.chat import LiteLLMChatClient
 from .elevenlabs import ElevenLabsSpeechClient
 from .huggingface.chat import HFHubChatClient
 from .iflytek.chat import IFlytekChatClient
@@ -38,3 +39,17 @@ __all__ = [
     "AnthropicChatClient",
     "LiteLLMChatClient",
 ]
+
+if TYPE_CHECKING:
+    from .litellm.chat import LiteLLMChatClient
+
+
+def __getattr__(name: str) -> Any:
+    # LiteLLM is a heavy optional dependency (~190 MB RSS, ~2100 modules on
+    # import). Load it lazily so merely importing dapr_agents.llm — e.g. to use
+    # DaprChatClient — does not pay that cost or require litellm to be installed.
+    if name == "LiteLLMChatClient":
+        from .litellm.chat import LiteLLMChatClient
+
+        return LiteLLMChatClient
+    raise AttributeError(f"module {__name__!r} has no attribute {name!r}")


### PR DESCRIPTION
# Description

All PRs to main are failing rn due to LiteLLM PR that was recently merged. The PR build ran fine, but under memory load, this pkg eats up ~200MB, whereas the other llm clients are ~50MB for the next biggest and then close to 1MB for the rest. This one needs to be lazily imported to not break clients, but then also to not cause test failures where we pay the full import cost across every agent process in our tests which in our memory constrained CI runners causes issues. If you look at other PRs failing rn this is the cause, and this PR should be the fix :) 

## Issue reference

We strive to have all PR being opened based on an issue, where the problem or feature have been discussed prior to implementation.

Please reference the issue this PR closes: #_[issue number]_

## Checklist

Please make sure you've completed the relevant tasks for this PR, out of the following list:

* [ ] Created/updated tests
* [ ] Tested this change against all the quickstarts
* [ ] Extended the documentation
    * [ ] Created the [dapr/docs](https://github.com/dapr/docs) PR: <insert PR link here>

**Note:** We expect contributors to open a corresponding documentation PR in the [dapr/docs](https://github.com/dapr/docs/) repository. As the implementer, you are the best person to document your work! Implementation PRs will not be merged until the documentation PR is opened and ready for review.
