### PR TITLE
fix(workflow): rewire changed pubsub route specs

### DIFF
--- a/dapr_agents/workflow/runners/agent.py
+++ b/dapr_agents/workflow/runners/agent.py
@@ -87,6 +87,7 @@ class AgentRunner(WorkflowRunner):
         #   _activation_closers  — teardown closers per agent, drained on shutdown
         self._activated_agent_ids: set[int] = set()
         self._activation_closers: Dict[int, List[Callable[[], None]]] = {}
+        self._pubsub_specs: list[PubSubRouteSpec] = []
 
     @staticmethod
     async def _ensure_mcp_connected(agent: DurableAgent) -> None:
@@ -429,11 +430,18 @@ class AgentRunner(WorkflowRunner):
 
         specs = self._build_pubsub_specs(agent, config)
         if not specs:
+            if self._wired_pubsub:
+                self.unwire_pubsub()
+            self._pubsub_specs = []
             return
 
         self._ensure_dapr_client()
-        if self._wired_pubsub or self._dapr_client is None:
+        if self._dapr_client is None:
             return
+        if self._wired_pubsub:
+            if specs == self._pubsub_specs:
+                return
+            self.unwire_pubsub()
 
         try:
             deduper = TTLDedupeBackend()
@@ -458,6 +466,7 @@ class AgentRunner(WorkflowRunner):
             client_factory=self._client_factory,
         )
         self._pubsub_closers.extend(closers)
+        self._pubsub_specs = specs
         self._wired_pubsub = True
 
     def _wire_http_routes(

--- a/tests/workflow/test_agent_runner_pubsub.py
+++ b/tests/workflow/test_agent_runner_pubsub.py
@@ -17,7 +17,7 @@ def _wire(runner, agent):
 
 
 def test_rewires_pubsub_routes_when_specs_change():
-    runner = AgentRunner(wf_client=MagicMock(), dapr_client=MagicMock())
+    runner = AgentRunner(wf_client=MagicMock(), client_factory=lambda: MagicMock())
     agent = MagicMock(pubsub=object())
     first_handler = MagicMock()
     second_handler = MagicMock()
@@ -41,7 +41,7 @@ def test_rewires_pubsub_routes_when_specs_change():
 
 
 def test_does_not_reregister_identical_pubsub_specs():
-    runner = AgentRunner(wf_client=MagicMock(), dapr_client=MagicMock())
+    runner = AgentRunner(wf_client=MagicMock(), client_factory=lambda: MagicMock())
     agent = MagicMock(pubsub=object())
     handler = MagicMock()
     specs = [PubSubRouteSpec("pubsub", "topic", handler)]

--- a/tests/workflow/test_agent_runner_pubsub.py
+++ b/tests/workflow/test_agent_runner_pubsub.py
@@ -1,0 +1,59 @@
+from unittest.mock import MagicMock, patch
+
+from dapr_agents.types.workflow import PubSubRouteSpec
+from dapr_agents.workflow.runners.agent import AgentRunner
+
+
+def _wire(runner, agent):
+    runner._wire_pubsub_routes(
+        agent=agent,
+        delivery_mode="sync",
+        queue_maxsize=1024,
+        await_result=False,
+        await_timeout=None,
+        fetch_payloads=True,
+        log_outcome=False,
+    )
+
+
+def test_rewires_pubsub_routes_when_specs_change():
+    runner = AgentRunner(wf_client=MagicMock(), dapr_client=MagicMock())
+    agent = MagicMock(pubsub=object())
+    first_handler = MagicMock()
+    second_handler = MagicMock()
+    first = [PubSubRouteSpec("pubsub", "first", first_handler)]
+    second = [PubSubRouteSpec("pubsub", "second", second_handler)]
+    runner._build_pubsub_specs = MagicMock(side_effect=[first, second])
+    first_close = MagicMock()
+    second_close = MagicMock()
+
+    with patch(
+        "dapr_agents.workflow.runners.agent.register_message_routes",
+        side_effect=[[first_close], [second_close]],
+    ) as register:
+        _wire(runner, agent)
+        _wire(runner, agent)
+
+    first_close.assert_called_once_with()
+    assert register.call_count == 2
+    assert runner._pubsub_specs == second
+    assert runner._pubsub_closers == [second_close]
+
+
+def test_does_not_reregister_identical_pubsub_specs():
+    runner = AgentRunner(wf_client=MagicMock(), dapr_client=MagicMock())
+    agent = MagicMock(pubsub=object())
+    handler = MagicMock()
+    specs = [PubSubRouteSpec("pubsub", "topic", handler)]
+    runner._build_pubsub_specs = MagicMock(side_effect=[specs, specs.copy()])
+    close = MagicMock()
+
+    with patch(
+        "dapr_agents.workflow.runners.agent.register_message_routes",
+        return_value=[close],
+    ) as register:
+        _wire(runner, agent)
+        _wire(runner, agent)
+
+    register.assert_called_once()
+    close.assert_not_called()


### PR DESCRIPTION
## Summary\n\n- rewire AgentRunner pub/sub routes when the computed route specs change\n- tear down stale closers before registering replacement routes\n- clear stale wiring when the spec set becomes empty\n- add regression tests for changed and identical specs\n\nFixes #707\n\n## Verification\n\n- python -m pytest tests/workflow/test_agent_runner_pubsub.py tests/workflow/test_activation_hooks.py -q (26 passed)\n- git diff --check (pass)