### PR TITLE
fix(ci): separate schema checks from privileged comments

### DIFF
--- a/.github/workflows/schema-compat-check.yaml
+++ b/.github/workflows/schema-compat-check.yaml
@@ -1,0 +1,54 @@
+#
+# Copyright 2026 The Dapr Authors
+# Licensed under the Apache License, Version 2.0 (the "License");
+#
+# This workflow runs in the unprivileged pull_request context. Its output is
+# treated as data by the privileged workflow that posts comments.
+#
+
+name: Schema Compatibility Check
+
+on:
+  pull_request:
+    branches:
+      - main
+
+permissions:
+  contents: read
+
+jobs:
+  schema-compat-check:
+    runs-on: ubuntu-latest
+    steps:
+    - name: Checkout base branch
+      uses: actions/checkout@v6
+      with:
+        ref: ${{ github.event.pull_request.base.sha }}
+        path: base
+    - name: Checkout pull request
+      uses: actions/checkout@v6
+      with:
+        ref: ${{ github.event.pull_request.head.sha }}
+        path: head
+    - name: Check if schema changed
+      id: schema-diff
+      run: |
+        if diff -q base/schemas/agent-metadata/latest.json head/schemas/agent-metadata/latest.json > /dev/null 2>&1; then
+          echo "changed=false" >> "$GITHUB_OUTPUT"
+        else
+          echo "changed=true" >> "$GITHUB_OUTPUT"
+        fi
+    - name: Check for breaking schema changes
+      if: steps.schema-diff.outputs.changed == 'true'
+      run: |
+        python head/scripts/check_schema_compat.py \
+          --old "$GITHUB_WORKSPACE/base/schemas/agent-metadata/latest.json" \
+          > report.md
+    - name: Write no-change report
+      if: steps.schema-diff.outputs.changed != 'true'
+      run: echo "No metadata schema changes detected." > report.md
+    - name: Upload compatibility report
+      uses: actions/upload-artifact@v4
+      with:
+        name: schema-compat-report
+        path: report.md

--- a/.github/workflows/schema-compat-comment.yaml
+++ b/.github/workflows/schema-compat-comment.yaml
@@ -1,73 +1,40 @@
 #
 # Copyright 2026 The Dapr Authors
 # Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#     http://www.apache.org/licenses/LICENSE-2.0
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
+#
+# This privileged workflow consumes an artifact produced by the unprivileged
+# pull_request workflow. It never checks out or executes fork code.
 #
 
 name: Schema Compatibility Comment
 
 on:
-  pull_request_target:
-    branches:
-      - main
+  workflow_run:
+    workflows: [Schema Compatibility Check]
+    types: [completed]
 
 jobs:
   schema-compat-comment:
+    if: github.event.workflow_run.conclusion == 'success'
     runs-on: ubuntu-latest
     permissions:
+      actions: read
       pull-requests: write
     steps:
-    - name: Checkout base branch
-      uses: actions/checkout@v6
+    - name: Download compatibility report
+      uses: actions/download-artifact@v4
       with:
-        ref: ${{ github.event.pull_request.base.sha }}
-        path: base
-    - name: Checkout PR head
-      uses: actions/checkout@v6
-      with:
-        ref: ${{ github.event.pull_request.head.sha }}
-        path: head
-    - name: Check if schema changed
-      id: schema-diff
-      run: |
-        if diff -q base/schemas/agent-metadata/latest.json head/schemas/agent-metadata/latest.json > /dev/null 2>&1; then
-          echo "changed=false" >> "$GITHUB_OUTPUT"
-        else
-          echo "changed=true" >> "$GITHUB_OUTPUT"
-        fi
-    - name: Set up Python 3.11
-      if: steps.schema-diff.outputs.changed == 'true'
-      uses: actions/setup-python@v6
-      with:
-        python-version: "3.11"
-    - name: Install uv
-      if: steps.schema-diff.outputs.changed == 'true'
-      uses: astral-sh/setup-uv@v3
-      with:
-        version: "latest"
-    - name: Install dependencies
-      if: steps.schema-diff.outputs.changed == 'true'
-      working-directory: head
-      run: uv sync --group test
-    - name: Check for breaking schema changes
-      if: steps.schema-diff.outputs.changed == 'true'
-      working-directory: head
+        name: schema-compat-report
+        path: report
+        run-id: ${{ github.event.workflow_run.id }}
+        github-token: ${{ github.token }}
+    - name: Comment on pull request
       env:
         GH_TOKEN: ${{ github.token }}
+        REPORT_PATH: report/report.md
       run: |
-        REPORT=$(uv run python scripts/check_schema_compat.py --old "${{ github.workspace }}/base/schemas/agent-metadata/latest.json")
-        if echo "$REPORT" | grep -q "Breaking"; then
-          gh pr comment ${{ github.event.pull_request.number }} \
-            --body "## Metadata Schema Compatibility Report
-
-        $REPORT
-
-        > This is informational — breaking changes may be intentional for a new release."
+        if grep -q "Breaking" "$REPORT_PATH"; then
+          gh pr comment "${{ github.event.workflow_run.pull_requests[0].number }}" \
+            --repo "${{ github.repository }}" \
+            --body "$(cat "$REPORT_PATH")"
         fi


### PR DESCRIPTION
## Summary\n\n- move schema diff and compatibility execution to an unprivileged pull_request workflow\n- upload the report as an artifact\n- let the privileged workflow_run workflow download the report and comment without checking out fork code\n- remove the pull_request_target fork checkout that currently blocks new PRs\n\nFixes #710\n\n## Verification\n\n- workflow YAML parsed successfully with PyYAML\n- python scripts/check_schema_compat.py --old schemas/agent-metadata/latest.json completed successfully\n- git diff --check (pass)