### PR TITLE
fix(workflow): retry actor deactivation while waiting

### DIFF
--- a/dapr_agents/workflow/runners/base.py
+++ b/dapr_agents/workflow/runners/base.py
@@ -567,11 +567,34 @@ class WorkflowRunner(SignalMixin):
         """
 
         def _wait() -> Optional[WorkflowState]:
-            return self._wf_client.wait_for_workflow_completion(
-                instance_id,
-                fetch_payloads=fetch_payloads,
-                timeout_in_seconds=timeout_in_seconds,
-            )
+            # Dapr may deactivate an idle workflow actor while a streaming
+            # completion RPC is in flight. The workflow is still valid; retry
+            # the wait so the client can reconnect to the reactivated actor.
+            max_retries = 3
+            retry_delay = 0.1
+            for attempt in range(max_retries + 1):
+                try:
+                    return self._wf_client.wait_for_workflow_completion(
+                        instance_id,
+                        fetch_payloads=fetch_payloads,
+                        timeout_in_seconds=timeout_in_seconds,
+                    )
+                except Exception as exc:
+                    if (
+                        "actor is closed" not in str(exc).lower()
+                        or attempt == max_retries
+                    ):
+                        raise
+                    logger.warning(
+                        "[%s] Workflow actor deactivated while waiting for %s; "
+                        "retrying (%d/%d)",
+                        self._name,
+                        instance_id,
+                        attempt + 1,
+                        max_retries,
+                    )
+                    time.sleep(retry_delay)
+                    retry_delay *= 2
 
         return await asyncio.to_thread(_wait)
 

--- a/tests/workflow/test_workflow_runner.py
+++ b/tests/workflow/test_workflow_runner.py
@@ -15,6 +15,7 @@
 
 from __future__ import annotations
 
+import asyncio
 import time
 from concurrent.futures import ThreadPoolExecutor, as_completed
 from unittest.mock import MagicMock, patch
@@ -145,3 +146,20 @@ def test_run_workflow_retry_on_transient_grpc_error():
 
     assert result == "id-retry-success"
     assert client.schedule_new_workflow.call_count == 2
+
+
+def test_wait_retries_when_workflow_actor_is_deactivated():
+    """A transient actor deactivation must not fail an otherwise valid wait."""
+    client = MagicMock()
+    final_state = MagicMock(runtime_status="COMPLETED")
+    client.wait_for_workflow_completion.side_effect = [
+        RuntimeError("actor is closed, cannot handle deactivated"),
+        final_state,
+    ]
+    runner = _make_runner(client)
+
+    with patch("dapr_agents.workflow.runners.base.time.sleep"):
+        result = asyncio.run(runner._await_state("instance-123", 30, True))
+
+    assert result is final_state
+    assert client.wait_for_workflow_completion.call_count == 2


### PR DESCRIPTION
## Summary\n\n- retry bounded ctor is closed deactivation errors while waiting for workflow completion\n- preserve all unrelated errors and existing timeout behavior\n- add regression coverage for a deactivation followed by successful completion\n\nFixes #520\n\n## Verification\n\n- python -m pytest tests/workflow/test_workflow_runner.py -q (5 passed)\n- uff check reports only the test file's pre-existing unused pytest import\n- git diff --check (pass)