### PR TITLE
fix(workflow): gracefully handle 'actor is closed' gRPC error in workflow monitor

### DIFF
--- a/dapr_agents/workflow/runners/base.py
+++ b/dapr_agents/workflow/runners/base.py
@@ -597,10 +597,23 @@ class WorkflowRunner(SignalMixin):
                 instance_id, timeout_in_seconds, fetch_payloads
             )
             self._log_state(instance_id, state)
-        except Exception:
-            logger.exception(
-                f"[{self._name}] {instance_id}: error while monitoring workflow outcome",
-            )
+        except Exception as exc:
+            import grpc
+
+            if (
+                isinstance(exc, grpc._channel._InactiveRpcError)
+                and "actor is closed" in exc.details()
+            ):
+                logger.warning(
+                    "[%s] %s: workflow monitor interrupted because the actor was deactivated "
+                    "(expected during scale-to-zero). Outcome will be checked on next poll.",
+                    self._name,
+                    instance_id,
+                )
+            else:
+                logger.exception(
+                    f"[{self._name}] {instance_id}: error while monitoring workflow outcome",
+                )
 
     def _log_state(self, instance_id: str, state: Optional[WorkflowState]) -> None:
         """


### PR DESCRIPTION
## Description

The `_await_and_log_state` background task can encounter a gRPC
`_InactiveRpcError` with details *"actor is closed, cannot handle
deactivated"* when the workflow actor is deactivated (scale-to-zero)
while the fire-and-forget monitor is still polling for completion.

This is a transient, non-fatal condition — the workflow itself
continues executing successfully. Previously it was logged as a
full exception traceback at `ERROR` level, which alarmed operators
unnecessarily.

### Changes

- Catch `_InactiveRpcError` with "actor is closed" in
  `_await_and_log_state` and log at `WARNING` with a clear
  explanation instead of `ERROR`.
- Other exceptions continue to be logged at `ERROR` as before.

### Before

```
ERROR:dapr_agents.workflow.runners.base:[agent-runner] 231e...: error while monitoring workflow outcome
Traceback (most recent call last):
  ...
grpc._channel._InactiveRpcError: ... "actor is closed, cannot handle deactivated"
```

### After

```
WARNING:dapr_agents.workflow.runners.base:[agent-runner] 231e...: workflow monitor interrupted because the actor was deactivated (expected during scale-to-zero). Outcome will be checked on next poll.
```

Fixes #520