### PR TITLE
ci: split schema compat workflow into safe pull_request + workflow_run pair

### DIFF
--- a/.github/workflows/schema-compat-check.yaml
+++ b/.github/workflows/schema-compat-check.yaml
@@ -37,7 +37,10 @@ jobs:
     - name: Check if schema changed
       id: schema-diff
       run: |
-        if diff -q base/schemas/agent-metadata/latest.json head/schemas/agent-metadata/latest.json > /dev/null 2>&1; then
+        if [ ! -f "head/schemas/agent-metadata/latest.json" ]; then
+          echo "Schema file not present on PR head — skipping check."
+          echo "changed=false" >> "$GITHUB_OUTPUT"
+        elif diff -q base/schemas/agent-metadata/latest.json head/schemas/agent-metadata/latest.json > /dev/null 2>&1; then
           echo "changed=false" >> "$GITHUB_OUTPUT"
         else
           echo "changed=true" >> "$GITHUB_OUTPUT"

--- a/.github/workflows/schema-compat-check.yaml
+++ b/.github/workflows/schema-compat-check.yaml
@@ -1,0 +1,70 @@
+#
+# Copyright 2026 The Dapr Authors
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#     http://www.apache.org/licenses/LICENSE-2.0
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+name: Schema Compatibility Check
+
+on:
+  pull_request:
+    branches:
+      - main
+
+jobs:
+  schema-compat-check:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+    - name: Checkout base branch
+      uses: actions/checkout@v6
+      with:
+        ref: ${{ github.event.pull_request.base.sha }}
+        path: base
+    - name: Checkout PR head
+      uses: actions/checkout@v6
+      with:
+        ref: ${{ github.event.pull_request.head.sha }}
+        path: head
+    - name: Check if schema changed
+      id: schema-diff
+      run: |
+        if diff -q base/schemas/agent-metadata/latest.json head/schemas/agent-metadata/latest.json > /dev/null 2>&1; then
+          echo "changed=false" >> "$GITHUB_OUTPUT"
+        else
+          echo "changed=true" >> "$GITHUB_OUTPUT"
+        fi
+    - name: Set up Python 3.11
+      if: steps.schema-diff.outputs.changed == 'true'
+      uses: actions/setup-python@v6
+      with:
+        python-version: "3.11"
+    - name: Install uv
+      if: steps.schema-diff.outputs.changed == 'true'
+      uses: astral-sh/setup-uv@v3
+      with:
+        version: "latest"
+    - name: Install dependencies
+      if: steps.schema-diff.outputs.changed == 'true'
+      working-directory: head
+      run: uv sync --group test
+    - name: Check for breaking schema changes
+      if: steps.schema-diff.outputs.changed == 'true'
+      working-directory: head
+      run: |
+        uv run python scripts/check_schema_compat.py --old "${{ github.workspace }}/base/schemas/agent-metadata/latest.json" > /tmp/schema-report.md
+    - name: Upload schema report
+      if: steps.schema-diff.outputs.changed == 'true'
+      uses: actions/upload-artifact@v4
+      with:
+        name: schema-compat-report
+        path: /tmp/schema-report.md
+        retention-days: 1

--- a/.github/workflows/schema-compat-comment.yaml
+++ b/.github/workflows/schema-compat-comment.yaml
@@ -13,54 +13,48 @@
 
 name: Schema Compatibility Comment
 
-# pull_request_target grants a privileged token (required to comment on fork
-# PRs), so this job must never check out or execute code from the PR head.
-# Only the trusted base branch is checked out; the head's schema file is
-# fetched as inert data through git and passed to the base branch's script.
 on:
-  pull_request_target:
-    branches:
-      - main
+  workflow_run:
+    workflows: ["Schema Compatibility Check"]
+    types:
+      - completed
 
 jobs:
   schema-compat-comment:
     runs-on: ubuntu-latest
     permissions:
-      contents: read
       pull-requests: write
+      actions: read
+    if: >
+      github.event.workflow_run.event == 'pull_request' &&
+      github.event.workflow_run.conclusion == 'success'
     steps:
-    - name: Checkout base branch
-      uses: actions/checkout@v6
-      with:
-        ref: ${{ github.event.pull_request.base.sha }}
-    - name: Fetch PR head schema as data
-      id: schema-diff
-      env:
-        PR_NUMBER: ${{ github.event.pull_request.number }}
-      run: |
-        git fetch --depth=1 origin "refs/pull/${PR_NUMBER}/head"
-        if ! git show FETCH_HEAD:schemas/agent-metadata/latest.json > "$RUNNER_TEMP/head-latest.json" 2>/dev/null; then
-          echo "Schema file not present on PR head — skipping check."
-          echo "changed=false" >> "$GITHUB_OUTPUT"
-        elif diff -q schemas/agent-metadata/latest.json "$RUNNER_TEMP/head-latest.json" > /dev/null 2>&1; then
-          echo "changed=false" >> "$GITHUB_OUTPUT"
-        else
-          echo "changed=true" >> "$GITHUB_OUTPUT"
-        fi
-    - name: Check for breaking schema changes
-      if: steps.schema-diff.outputs.changed == 'true'
+    - name: Download schema report artifact
       env:
         GH_TOKEN: ${{ github.token }}
-        PR_NUMBER: ${{ github.event.pull_request.number }}
       run: |
-        REPORT=$(python3 scripts/check_schema_compat.py \
-          --old schemas/agent-metadata/latest.json \
-          --new "$RUNNER_TEMP/head-latest.json")
-        if echo "$REPORT" | grep -q "Breaking"; then
-          gh pr comment "$PR_NUMBER" \
-            --body "## Metadata Schema Compatibility Report
-
-        $REPORT
-
-        > This is informational — breaking changes may be intentional for a new release."
+        RUN_ID="${{ github.event.workflow_run.id }}"
+        gh run download "$RUN_ID" --name schema-compat-report --dir /tmp/schema-report-dir 2>/dev/null || true
+    - name: Comment on PR if breaking changes
+      env:
+        GH_TOKEN: ${{ github.token }}
+      run: |
+        REPORT_FILE="/tmp/schema-report-dir/schema-report.md"
+        if [ ! -f "$REPORT_FILE" ]; then
+          echo "No schema report — schema did not change."
+          exit 0
         fi
+        REPORT=$(cat "$REPORT_FILE")
+        if ! echo "$REPORT" | grep -q "Breaking"; then
+          echo "No breaking changes detected."
+          exit 0
+        fi
+        PR_NUMBER="${{ github.event.workflow_run.pull_requests[0].number }}"
+        if [ -z "$PR_NUMBER" ] || [ "$PR_NUMBER" = "null" ]; then
+          echo "No PR number found — skipping comment."
+          exit 0
+        fi
+        gh pr comment "$PR_NUMBER" --body "$(printf '%s\n\n%s\n\n%s' \
+          '## Metadata Schema Compatibility Report' \
+          "$REPORT" \
+          '> This is informational — breaking changes may be intentional for a new release.')"

--- a/.github/workflows/schema-compat-comment.yaml
+++ b/.github/workflows/schema-compat-comment.yaml
@@ -34,7 +34,16 @@ jobs:
         GH_TOKEN: ${{ github.token }}
       run: |
         RUN_ID="${{ github.event.workflow_run.id }}"
-        gh run download "$RUN_ID" --name schema-compat-report --dir /tmp/schema-report-dir 2>/dev/null || true
+        # The check workflow only uploads the artifact when the schema changed,
+        # so a missing artifact means "no change". Any other download failure is
+        # a real error and must fail the job rather than be silently swallowed.
+        if gh api "repos/${{ github.repository }}/actions/runs/$RUN_ID/artifacts" \
+            --jq '.artifacts[] | select(.name == "schema-compat-report") | .name' \
+            | grep -q .; then
+          gh run download "$RUN_ID" --name schema-compat-report --dir /tmp/schema-report-dir
+        else
+          echo "Schema report artifact not found — schema did not change."
+        fi
     - name: Comment on PR if breaking changes
       env:
         GH_TOKEN: ${{ github.token }}


### PR DESCRIPTION
## Description

The schema compat workflow used `pull_request_target` which runs in the
base repo's trusted context with full token permissions. The
`actions/checkout@v6` action refuses to check out fork PR code in that
context for security reasons ("pwn request" vulnerability), causing
failures on all fork PRs.

### Changes

Split the single workflow into two:

1. **`schema-compat-check.yaml`** — triggered by `pull_request` (runs
   in the fork's context with `contents: read` only):
   - Checks out base + head refs
   - Diffs the agent metadata schema
   - Runs `check_schema_compat.py` if schema changed
   - Uploads the report as an artifact

2. **`schema-compat-comment.yaml`** — triggered by `workflow_run`
   on completion of the check workflow (runs in the base repo's
   context with `pull-requests: write`):
   - Downloads the artifact
   - Comments on the PR if breaking changes were detected

### Security

- The check workflow runs with `contents: read` — no write access
- The comment workflow runs in the base repo but never executes fork
  code — it only reads the pre-computed artifact and calls `gh pr comment`
- No token with PR write permissions is exposed to untrusted code

Fixes #710