### PR TITLE
fix(examples): separate Drasi egress pubsub

### DIFF
--- a/examples/ext-drasi-change-driven-agents-k8s/README.md
+++ b/examples/ext-drasi-change-driven-agents-k8s/README.md
@@ -30,6 +30,8 @@ This example focuses on an inventory agent that automatically generates purchase
 
 Data lives in a Postgres instance — when a product's stock level dips below its threshold (or reaches zero), it emits a low-level change event that is tracked by two Drasi queries: one for "low" and one for "critical". All of the low-level changes are transparent to downstream consumers, as queries **only** emit change events when their conditions are satisfied. The inventory agent does not have to do any additional processing.
 
+The setup script installs a demo application Redis and creates namespace-local Dapr pub/sub components for the `PostDaprPubSub` reaction and inventory agent. Both components point to this broker, which is separate from Drasi's internal pub/sub infrastructure.
+
 ## Prerequisites
 
 - [Docker](https://docs.docker.com/get-started/get-docker/)

--- a/examples/ext-drasi-change-driven-agents-k8s/drasi/components/inventory-agent-pubsub.yaml
+++ b/examples/ext-drasi-change-driven-agents-k8s/drasi/components/inventory-agent-pubsub.yaml
@@ -14,7 +14,7 @@
 apiVersion: dapr.io/v1alpha1
 kind: Component
 metadata:
-  name: drasi-pubsub
+  name: inventory-agent-pubsub
   namespace: drasi-system
 spec:
   type: pubsub.redis

--- a/examples/ext-drasi-change-driven-agents-k8s/drasi/reactions/inventory-events-publisher.yaml
+++ b/examples/ext-drasi-change-driven-agents-k8s/drasi/reactions/inventory-events-publisher.yaml
@@ -19,7 +19,7 @@ spec:
   queries:
     low-stock-event-query: >
       {
-        "pubsubName": "drasi-pubsub",
+        "pubsubName": "inventory-agent-pubsub",
         "topicName": "drasi-events-low-stock-event-query",
         "format": "Unpacked",
         "skipControlSignals": true
@@ -27,7 +27,7 @@ spec:
     
     critical-stock-event-query: >
       {
-        "pubsubName": "drasi-pubsub",
+        "pubsubName": "inventory-agent-pubsub",
         "topicName": "drasi-events-critical-stock-event-query",
         "format": "Unpacked",
         "skipControlSignals": true


### PR DESCRIPTION
# Description

Rename the Drasi change-driven agents example's application-facing pub/sub component so it does not overwrite Drasi's internal `drasi-pubsub` component. Update the reaction configuration and clarify the broker separation in the example README.

## Issue reference

Closes #729

## Checklist

* [ ] Created/updated tests (manifest and documentation change only)
* [ ] Tested this change against all the quickstarts (not applicable)
* [x] Extended the example documentation
    * [ ] Created the dapr/docs PR (not required; no public API change)