### PR TITLE
chore: clean up drasi trigger and change driven agents example

### DIFF
--- a/examples/ext-drasi-change-driven-agents-k8s/inventory-agent/app/app.py
+++ b/examples/ext-drasi-change-driven-agents-k8s/inventory-agent/app/app.py
@@ -33,20 +33,21 @@ logger = logging.getLogger(__name__)
 def make_task(event: DrasiChangeEvent, ctx: Any) -> TriggerAction:
     return TriggerAction(
         task=(
-            f"You are an inventory agent that creates purchase orders, calculating the order quantity dynamically.\n"
-            f"Create a purchase order for this '{event.payload.source.queryId}' event.\n"
-            f"Use the following data: {event.payload.after.model_dump_json()}.\n\n"
-            "Respond with exactly the following format, and nothing else:\n\n"
-            "Product ID: <productId>\n"
-            "Product Name: <productName>\n"
-            "Product Description: <productDescription>\n"
-            "Order Quantity: <quantity>\n\n"
-            "Rules:\n"
-            "- Output exactly these 4 lines, in this exact order.\n"
-            "- Do not add, remove, rename, or reorder any fields.\n"
-            "- Do not include any explanation, preamble, or extra text.\n"
-            "- Do not wrap the output in code blocks or markdown formatting.\n"
-            "- Replace each <placeholder> with the actual value only — do not include the angle brackets."
+            f"You are an inventory agent that creates purchase orders in response to stock events, "
+            "calculating the order quantity dynamically.\n\n"
+            f"## Event Data\n"
+            f"{event.payload.after.model_dump_json() if event.payload.after else 'N/A'}\n\n"
+            f"## Response Format\n"
+            "Product ID: <productId from Event Data>\n"
+            "Product Name: <productName from Event Data>\n"
+            "Product Description: <productDescription from Event Data>\n"
+            "Order Quantity: <quantity to be calculated>\n\n"
+            "## Rules\n"
+            "- Respond EXACTLY in the given response format, and nothing else.\n"
+            "- Do NOT add, remove, rename, or reorder any fields.\n"
+            "- Do NOT include any explanation, preamble, or extra text.\n"
+            "- Do NOT wrap the output in code blocks (no ``` fences) or markdown formatting.\n"
+            "- Replace each <placeholder> with the actual value only — do NOT include the angle brackets."
         )
     )
 

--- a/ext/dapr-agents-ext-drasi/dapr_agents/ext/drasi/activations.py
+++ b/ext/dapr-agents-ext-drasi/dapr_agents/ext/drasi/activations.py
@@ -43,7 +43,7 @@ _DRASI_TRIGGER_DEFAULT_TASK = (
     "Return the exact JSON payload below, unmodified. "
     "Output ONLY a JSON object; no explanation, no markdown, no extra text:\n\n"
 )
-_DRASI_TRIGGER_DEFAULT_TOPIC_PREFIX = "drasi-events"
+_DRASI_TRIGGER_DEFAULT_TOPIC_PREFIX = "drasi-events-"
 
 
 @dataclass(frozen=True)
@@ -318,9 +318,9 @@ def drasi_trigger(
         operations: Optional Drasi operation(s) to filter change events by.
             Accepts `DrasiOperation` or equivalent string literals:
 
-            - `DrasiOperation.i` / `"i"` - Insert
-            - `DrasiOperation.u` / `"u"` - Update
-            - `DrasiOperation.d` / `"d"` - Delete
+            - `DrasiOperation.i` / `"i"` - A record was added to the result set tracked by the Drasi query.
+            - `DrasiOperation.u` / `"u"` - A record was updated in the result set tracked by the Drasi query.
+            - `DrasiOperation.d` / `"d"` - A record was deleted from the result set tracked by the Drasi query.
 
             Events that are filtered out will not trigger the agent. Defaults to `None` (all operations are allowed).
         change_model: Optional model to use to validate the change data in Drasi change events.
@@ -338,7 +338,7 @@ def drasi_trigger(
         resolved_pubsub = pubsub or (
             ctx.agent.pubsub.pubsub_name if ctx.agent.pubsub else None
         )
-        resolved_topic = topic or f"{_DRASI_TRIGGER_DEFAULT_TOPIC_PREFIX}-{query_id}"
+        resolved_topic = topic or f"{_DRASI_TRIGGER_DEFAULT_TOPIC_PREFIX}{query_id}"
 
         if task_mapper is None:
             logger.warning(

--- a/ext/dapr-agents-ext-drasi/tests/test_drasi_trigger.py
+++ b/ext/dapr-agents-ext-drasi/tests/test_drasi_trigger.py
@@ -840,7 +840,7 @@ async def test_drasi_trigger_defaults_to_derived_topic(setup_deps):
     agent_pubsub_name = "testpubsub"
     agent_topic = "testtopic"
     drasi_pubsub_name = "goalspubsub"
-    drasi_topic = f"{_DRASI_TRIGGER_DEFAULT_TOPIC_PREFIX}-{query_id}"
+    drasi_topic = f"{_DRASI_TRIGGER_DEFAULT_TOPIC_PREFIX}{query_id}"
     events = [
         _make_cloudevent(
             data={


### PR DESCRIPTION
# Description

- Make the `ext-drasi-change-driven-agents-k8s` inventory agent event task more robust
- Add more detailed description for each operation in `drasi_trigger` docstring (to align with Dapr docs)
- Default `drasi_trigger` topic prefix to include hyphen

## Issue reference

We strive to have all PR being opened based on an issue, where the problem or feature have been discussed prior to implementation.

Please reference the issue this PR closes: #_[issue number]_

## Checklist

Please make sure you've completed the relevant tasks for this PR, out of the following list:

* [ ] Created/updated tests
* [ ] Tested this change against all the quickstarts
* [ ] Extended the documentation
    * [ ] Created the [dapr/docs](https://github.com/dapr/docs) PR: <insert PR link here>

**Note:** We expect contributors to open a corresponding documentation PR in the [dapr/docs](https://github.com/dapr/docs/) repository. As the implementer, you are the best person to document your work! Implementation PRs will not be merged until the documentation PR is opened and ready for review.
