### PR TITLE
fix(ext-drasi): fix packaging

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -106,3 +106,31 @@ jobs:
     - name: Run tests
       run: |
         uv run pytest tests ext -m "not integration"
+
+  package:
+    needs: lint
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v6
+      with:
+        fetch-depth: 0
+    - name: Set up Python 3.11
+      uses: actions/setup-python@v6
+      with:
+        python-version: "3.11"
+    - name: Install uv
+      uses: astral-sh/setup-uv@v3
+      with:
+        version: "latest"
+    - name: Install dependencies
+      run: uv sync --frozen --group test
+    - name: Build packages
+      run: |
+        uv build --wheel --out-dir dist/core
+        uv build --package dapr-agents-ext-drasi --wheel --out-dir dist/drasi
+    - name: Verify Drasi extension wheel
+      run: |
+        uv pip install --target .wheel-test --no-deps dist/core/*.whl dist/drasi/*.whl
+        cd /tmp
+        PYTHONPATH="$GITHUB_WORKSPACE/.wheel-test" "$GITHUB_WORKSPACE/.venv/bin/python" \
+          -c "from dapr_agents.ext.drasi import DrasiChangeEvent, DrasiOperation, drasi_trigger"

--- a/ext/dapr-agents-ext-drasi/pyproject.toml
+++ b/ext/dapr-agents-ext-drasi/pyproject.toml
@@ -11,6 +11,10 @@
 # limitations under the License.
 #
 
+[build-system]
+requires = ["setuptools>=61.0"]
+build-backend = "setuptools.build_meta"
+
 [project]
 name = "dapr-agents-ext-drasi"
 version = "0.1.0"  # TODO: switch to dynamic versioning
@@ -23,7 +27,7 @@ authors = [
     {name = "Dapr Authors", email = "dapr@dapr.io"}
 ]
 dependencies = [
-    "dapr-agents<2.0.0",
+    "dapr-agents>=1.0.6,<2.0.0",
 ]
 classifiers = [
     "Development Status :: 2 - Pre-Alpha",
@@ -55,7 +59,7 @@ Documentation = "https://github.com/dapr/docs"
 Source = "https://github.com/dapr/dapr-agents"
 
 [tool.setuptools.packages.find]
-include = ["dapr_agents.ext.drasi"]
+include = ["dapr_agents.ext.drasi", "dapr_agents.ext.drasi.*"]
 exclude = ["tests"]
 
 [tool.setuptools.package-data]


### PR DESCRIPTION
## Summary

- Include all Drasi extension subpackages in the wheel
- Require `dapr-agents>=1.0.6,<2.0.0`
- Add an explicit setuptools build backend
- Verify the built extension wheel imports correctly in CI

Fixes dapr/dapr-agents#741