### PR TITLE
fix(anthropic): normalize string tool_choice into Anthropic's required object shape

### DIFF
--- a/dapr_agents/llm/anthropic/chat.py
+++ b/dapr_agents/llm/anthropic/chat.py
@@ -24,6 +24,7 @@ from dapr_agents.llm.anthropic.client import PROVIDER, AnthropicClientBase
 from dapr_agents.llm.anthropic.utils import (
     STRUCTURED_INJECTORS,
     assert_json_output_supported,
+    normalize_tool_choice,
     split_messages,
 )
 from dapr_agents.llm.chat import ChatClientBase
@@ -156,6 +157,8 @@ class AnthropicChatClient(AnthropicClientBase, ChatClientBase):
             params["system"] = system
         if tools_formatted:
             params["tools"] = tools_formatted
+        if "tool_choice" in params:
+            params["tool_choice"] = normalize_tool_choice(params["tool_choice"])
         if response_format is not None:
             if structured_mode == "json":
                 assert_json_output_supported(self.client, params["model"])

--- a/dapr_agents/llm/anthropic/utils.py
+++ b/dapr_agents/llm/anthropic/utils.py
@@ -272,6 +272,23 @@ def resolve_target_model(
     return target_format, target_model
 
 
+def normalize_tool_choice(tool_choice: Any) -> Any:
+    """Translate dapr-agents' internal `tool_choice` representation into the
+    object shape Anthropic's Messages API requires.
+
+    dapr-agents' agent execution config (and the OpenAI-style providers)
+    represent `tool_choice` as a bare string (`"auto"`, `"any"`, `"none"`),
+    but Anthropic always requires an object: `{"type": "auto"}`,
+    `{"type": "any"}`, `{"type": "none"}`, or `{"type": "tool", "name": ...}`.
+    Dict values (e.g. from structured-output injection or a caller forcing a
+    specific tool) are already in Anthropic's shape and are passed through
+    unchanged.
+    """
+    if isinstance(tool_choice, str):
+        return {"type": tool_choice}
+    return tool_choice
+
+
 def inject_function_call_request(
     params: dict[str, Any], response_format: type[BaseModel]
 ) -> None:

--- a/tests/llm/test_anthropic.py
+++ b/tests/llm/test_anthropic.py
@@ -343,6 +343,73 @@ def test_anthropic_generate_formats_tools_for_claude(mock_anthropic_class):
 
 
 # ---------------------------------------------------------------------------
+# tool_choice normalization
+# ---------------------------------------------------------------------------
+
+_WEATHER_TOOL = {
+    "name": "get_weather",
+    "description": "Return the current weather.",
+    "input_schema": {
+        "type": "object",
+        "properties": {"city": {"type": "string"}},
+        "required": ["city"],
+    },
+}
+
+
+@pytest.mark.parametrize(
+    "internal_value,expected",
+    [
+        ("auto", {"type": "auto"}),
+        ("any", {"type": "any"}),
+        ("none", {"type": "none"}),
+    ],
+)
+@patch("dapr_agents.llm.anthropic.client.Anthropic")
+def test_anthropic_generate_normalizes_string_tool_choice(
+    mock_anthropic_class, internal_value, expected
+):
+    """dapr-agents' internal bare-string `tool_choice` (as produced by the
+    agent execution config, e.g. `"auto"`) must be translated into the
+    object shape the Anthropic Messages API requires
+    (`{"type": "auto"}`, etc.); a bare string is rejected by the API with
+    `tool_choice: Input should be an object`.
+    """
+    sdk = MagicMock()
+    sdk.messages.create.return_value = _fake_anthropic_response("ok")
+    mock_anthropic_class.return_value = sdk
+
+    client = AnthropicChatClient(api_key="fake-key")
+    client.generate(
+        "what is the weather?",
+        tools=[_WEATHER_TOOL],
+        tool_choice=internal_value,
+    )
+
+    kwargs = sdk.messages.create.call_args.kwargs
+    assert kwargs["tool_choice"] == expected
+
+
+@patch("dapr_agents.llm.anthropic.client.Anthropic")
+def test_anthropic_generate_passes_through_object_tool_choice(mock_anthropic_class):
+    """A caller-supplied object-shaped `tool_choice` (e.g. forcing a specific
+    tool) is left untouched."""
+    sdk = MagicMock()
+    sdk.messages.create.return_value = _fake_anthropic_response("ok")
+    mock_anthropic_class.return_value = sdk
+
+    client = AnthropicChatClient(api_key="fake-key")
+    client.generate(
+        "what is the weather?",
+        tools=[_WEATHER_TOOL],
+        tool_choice={"type": "tool", "name": "get_weather"},
+    )
+
+    kwargs = sdk.messages.create.call_args.kwargs
+    assert kwargs["tool_choice"] == {"type": "tool", "name": "get_weather"}
+
+
+# ---------------------------------------------------------------------------
 # Streaming
 # ---------------------------------------------------------------------------
 


### PR DESCRIPTION
## Bug

Every `DurableAgent` turn with tools registered and `llm=AnthropicChatClient(...)` (or `DaprChatClient` pointed at a `conversation.anthropic` component) fails with:

```
Error code: 400 - {'type': 'error', 'error': {'type': 'invalid_request_error', 'message': 'tool_choice: Input should be an object'}}
```

## Root cause

The agent execution config represents `tool_choice` as a bare string (`"auto"`, `"any"`, `"none"`, default `"auto"`). `AnthropicChatClient.generate()` forwards this string unmodified into `anthropic.Anthropic().messages.create()`. Anthropic's Messages API requires `tool_choice` to always be an object (`{"type": "auto"}`, `{"type": "any"}`, `{"type": "none"}`, `{"type": "tool", "name": ...}`) — a bare string is rejected.

The structured-output path (`inject_function_call_request` in `dapr_agents/llm/anthropic/utils.py`) already builds the correct object shape for its own case, but the plain agent tool-calling path had no equivalent conversion.

Verified two ways: through `DaprChatClient`/`conversation.anthropic` (Dapr's Go runtime), and by calling `AnthropicChatClient` directly in Python, bypassing the Dapr runtime entirely. Both produced the identical error from Anthropic's API, confirming the bug is in this package, not the Go runtime.

## Fix

Added `normalize_tool_choice()` to `dapr_agents/llm/anthropic/utils.py`: wraps a bare string into `{"type": <value>}`, passes an already-object `tool_choice` through unchanged. Wired into `AnthropicChatClient.generate()` before the request params are finalized.

## Test plan

- Added regression tests in `tests/llm/test_anthropic.py` that mock the Anthropic SDK client and assert the outgoing `tool_choice` kwarg shape for string (`auto`/`any`/`none`) and dict inputs — no live API key required.
- `uv run pytest tests/llm/test_anthropic.py -q` → 34 passed (30 pre-existing + 4 new).
- `uv run pytest tests -m "not integration" -q` → 1124 passed, 15 skipped, 0 failed.
- Additionally reproduced and verified the fix against a real multi-agent Dapr workflow on Kubernetes (Dapr control plane + workflow orchestration + pub/sub), where every worker agent failed at this exact error before the fix and completed successfully after it.

## Known follow-up (not in scope here)

`AgentExecutionConfig`'s advisory `tool_choice` values include `"required"` (OpenAI-style), used by the separate Dapr-runtime path. If `AnthropicChatClient` were ever called directly with `tool_choice="required"`, this fix would produce `{"type": "required"}`, which Anthropic doesn't accept (it expects `"any"`). Nothing in this package's own code path sets `"required"` when calling `AnthropicChatClient` directly today, so it's unaffected by this bug, but worth a follow-up if that changes.

## Relationship to #733

#733 (open, also touches `dapr_agents/llm/anthropic/chat.py` and `utils.py`) does **not** address this bug — its diff has no `tool_choice` changes; it's about streaming, structured-output normalization, tool-name aliases, and multimodal image inputs.

It does, however, edit the same region of `AnthropicChatClient.generate()` (the `tools_formatted`/`params` construction block, roughly lines 139-168) that this PR's `normalize_tool_choice()` call site sits in. Whichever of these two PRs merges second will very likely need a rebase to resolve the overlap. Flagging so maintainers can sequence the merges deliberately rather than hit a surprise conflict.
