### PR TITLE
fix: register newly added pub/sub routes on repeated wire calls

### DIFF
--- a/dapr_agents/workflow/runners/agent.py
+++ b/dapr_agents/workflow/runners/agent.py
@@ -165,6 +165,11 @@ class AgentRunner(WorkflowRunner):
             client_factory=client_factory,
         )
         self._default_http_paths: set[str] = set()
+        # (pubsub_name, topic) pairs already registered via _wire_pubsub_routes,
+        # so a later call with additional specs (e.g. a broadcast topic added
+        # after the first wiring) still registers what's new instead of being
+        # skipped entirely by the instance-wide `_wired_pubsub` guard.
+        self._wired_pubsub_topics: set[tuple[str, str]] = set()
 
         # In-memory store of managed agents - used for handling shutdown
         self._managed_agents: List[DurableAgent] = []
@@ -802,7 +807,15 @@ class AgentRunner(WorkflowRunner):
             return
 
         self._ensure_dapr_client()
-        if self._wired_pubsub or self._dapr_client is None:
+        if self._dapr_client is None:
+            return
+
+        new_specs = [
+            spec
+            for spec in specs
+            if (spec.pubsub_name, spec.topic) not in self._wired_pubsub_topics
+        ]
+        if not new_specs:
             return
 
         try:
@@ -815,7 +828,7 @@ class AgentRunner(WorkflowRunner):
             deduper = None
 
         closers = register_message_routes(
-            routes=specs,
+            routes=new_specs,
             dapr_client=self._dapr_client,
             delivery_mode=delivery_mode,
             queue_maxsize=queue_maxsize,
@@ -828,7 +841,15 @@ class AgentRunner(WorkflowRunner):
             client_factory=self._client_factory,
         )
         self._pubsub_closers.extend(closers)
+        self._wired_pubsub_topics.update(
+            (spec.pubsub_name, spec.topic) for spec in new_specs
+        )
         self._wired_pubsub = True
+
+    def unwire_pubsub(self) -> None:
+        """Unsubscribe all pub/sub handlers and forget which topics were wired."""
+        super().unwire_pubsub()
+        self._wired_pubsub_topics.clear()
 
     def _wire_http_routes(
         self,

--- a/tests/workflow/test_agent_runner_pubsub.py
+++ b/tests/workflow/test_agent_runner_pubsub.py
@@ -1,0 +1,124 @@
+#
+# Copyright 2026 The Dapr Authors
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#     http://www.apache.org/licenses/LICENSE-2.0
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+"""Regression tests for AgentRunner pub/sub re-wiring (issue #707).
+
+A later call to `_wire_pubsub_routes` with a broader pubsub config (e.g. a
+broadcast topic added after the first wiring) must register the new specs
+instead of being skipped entirely by the instance-wide `_wired_pubsub` guard.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock, patch
+
+from pydantic import BaseModel
+
+from dapr_agents.agents.configs import AgentPubSubConfig
+from dapr_agents.workflow.decorators.decorators import message_router
+from dapr_agents.workflow.runners.agent import AgentRunner
+
+_WIRE_KWARGS = dict(
+    delivery_mode="sync",
+    queue_maxsize=10,
+    await_result=False,
+    await_timeout=None,
+    fetch_payloads=True,
+    log_outcome=False,
+)
+
+
+class _Message(BaseModel):
+    text: str
+
+
+class _FakeAgent:
+    """Minimal stand-in for a DurableAgent with pub/sub handlers."""
+
+    name = "fake-agent"
+
+    @message_router(message_model=_Message)
+    def handle_direct(self, message: _Message) -> None: ...
+
+    @message_router(message_model=_Message, broadcast=True)
+    def handle_broadcast(self, message: _Message) -> None: ...
+
+
+def _make_runner() -> AgentRunner:
+    with patch(
+        "dapr_agents.workflow.runners.base.DaprWorkflowClient",
+        return_value=MagicMock(),
+    ):
+        return AgentRunner(
+            name="test-runner",
+            wf_client=MagicMock(),
+            client_factory=lambda: MagicMock(),
+        )
+
+
+def test_second_wire_call_registers_newly_added_broadcast_topic():
+    agent = _FakeAgent()
+    agent.pubsub = AgentPubSubConfig(pubsub_name="pubsub", agent_topic="direct-topic")
+    runner = _make_runner()
+
+    with patch(
+        "dapr_agents.workflow.runners.agent.register_message_routes",
+        return_value=[],
+    ) as mock_register:
+        runner._wire_pubsub_routes(agent=agent, **_WIRE_KWARGS)
+        assert mock_register.call_count == 1
+        first_topics = {s.topic for s in mock_register.call_args.kwargs["routes"]}
+        assert first_topics == {"direct-topic"}
+
+        # Broadcast topic configured after the agent was already wired once.
+        agent.pubsub = AgentPubSubConfig(
+            pubsub_name="pubsub",
+            agent_topic="direct-topic",
+            broadcast_topic="broadcast-topic",
+        )
+        runner._wire_pubsub_routes(agent=agent, **_WIRE_KWARGS)
+
+    assert mock_register.call_count == 2
+    second_topics = {s.topic for s in mock_register.call_args.kwargs["routes"]}
+    assert second_topics == {"broadcast-topic"}
+
+
+def test_second_wire_call_with_no_new_topics_is_a_noop():
+    agent = _FakeAgent()
+    agent.pubsub = AgentPubSubConfig(pubsub_name="pubsub", agent_topic="direct-topic")
+    runner = _make_runner()
+
+    with patch(
+        "dapr_agents.workflow.runners.agent.register_message_routes",
+        return_value=[],
+    ) as mock_register:
+        runner._wire_pubsub_routes(agent=agent, **_WIRE_KWARGS)
+        runner._wire_pubsub_routes(agent=agent, **_WIRE_KWARGS)
+
+    assert mock_register.call_count == 1
+
+
+def test_unwire_pubsub_clears_wired_topics():
+    agent = _FakeAgent()
+    agent.pubsub = AgentPubSubConfig(pubsub_name="pubsub", agent_topic="direct-topic")
+    runner = _make_runner()
+
+    with patch(
+        "dapr_agents.workflow.runners.agent.register_message_routes",
+        return_value=[],
+    ) as mock_register:
+        runner._wire_pubsub_routes(agent=agent, **_WIRE_KWARGS)
+        runner.unwire_pubsub()
+        runner._wire_pubsub_routes(agent=agent, **_WIRE_KWARGS)
+
+    assert mock_register.call_count == 2


### PR DESCRIPTION
# Description

AgentRunner._wire_pubsub_routes only registered pub/sub routes on the first call for a given runner instance. The guard `self._wired_pubsub` was set to True after the first successful registration and never reset, so a later call to register_routes or subscribe with a broader pubsub config for example a broadcast_topic added after the agent was already wired once was silently skipped in full. The sidecar subscription metadata kept only the original topics and messages sent to the newly configured topic were accepted by Dapr but never delivered to the agent, with no error or log line explaining why.

This PR tracks which (pubsub_name, topic) pairs have already been registered on the runner instance and only registers the specs that are new on each call, instead of skipping registration entirely once anything has been wired. unwire_pubsub now also forgets the previously wired topics so a rewire after teardown still works as it did before this change.

## Issue reference

Please reference the issue this PR closes: #707

## Checklist

Please make sure you've completed the relevant tasks for this PR, out of the following list:

* [x] Created/updated tests
* [ ] Tested against all quickstarts
* [ ] Extended the documentation

Notes:
- Tests: added tests/workflow/test_agent_runner_pubsub.py with a regression test that fails against the pre-fix code (verified locally) and passes with the fix, plus a no-op case and an unwire/rewire case.
- Quickstarts: not run in this environment since it requires a live Dapr sidecar; the fix is covered by the new unit tests instead.
- Documentation: this is an internal bug fix with no change to any public API or configuration surface, so no dapr.io documentation update is needed for it.
