### PR TITLE
feat: add agent metadata to hook context

### DIFF
--- a/dapr_agents/agents/durable.py
+++ b/dapr_agents/agents/durable.py
@@ -726,15 +726,12 @@ class DurableAgent(AgentBase):
                                     )
                                 except json.JSONDecodeError:
                                     hook_payload = {}
-                                hook_metadata = {
-                                    "source_agent": self.name,
-                                }
                                 hook_ctx = ToolHookContext(
                                     step_name=fn_name_check,
                                     source=getattr(tool_obj_check, "source", "local"),
                                     payload=hook_payload,
                                     tool_call_id=tc["id"],
-                                    metadata=hook_metadata,
+                                    agent=self,
                                 )
                                 decision = None
                                 for hook in self._hooks.before_tool_call:
@@ -2332,14 +2329,11 @@ class DurableAgent(AgentBase):
         # message so replays use the recorded output rather than re-running the
         # hook. First non-Proceed decision wins, mirroring before_tool_call.
         before_llm_decision: Optional[HookDecision] = None
-        hook_metadata = {
-            "source_agent": self.name,
-        }
         if self._hooks and self._hooks.before_llm_call:
             hook_payload: Dict[str, Any] = dict(generate_kwargs)
             if "messages" in hook_payload:
                 hook_payload["messages"] = list(hook_payload["messages"])
-            before_ctx = LLMHookContext(payload=hook_payload, metadata=hook_metadata)
+            before_ctx = LLMHookContext(payload=hook_payload, agent=self)
             for hook in self._hooks.before_llm_call:
                 result = hook(before_ctx)
                 if result is not None and not isinstance(result, Proceed):
@@ -2481,14 +2475,11 @@ class DurableAgent(AgentBase):
         # on the after-path since the LLM has already produced output. Hooks
         # receive a shallow copy so in-place mutation cannot bypass the Mutate
         # contract.
-        hook_metadata = {
-            "source_agent": self.name,
-        }
         if self._hooks and self._hooks.after_llm_call:
             after_payload: Dict[str, Any] = dict(generate_kwargs)
             if "messages" in after_payload:
                 after_payload["messages"] = list(after_payload["messages"])
-            after_ctx = LLMHookContext(payload=after_payload, metadata=hook_metadata)
+            after_ctx = LLMHookContext(payload=after_payload, agent=self)
             for hook in self._hooks.after_llm_call:
                 result = hook(after_ctx, dict(assistant_message))
                 if isinstance(result, Mutate) and result.payload is not None:

--- a/dapr_agents/agents/durable.py
+++ b/dapr_agents/agents/durable.py
@@ -726,11 +726,15 @@ class DurableAgent(AgentBase):
                                     )
                                 except json.JSONDecodeError:
                                     hook_payload = {}
+                                hook_metadata = {
+                                    "source_agent": self.name,
+                                }
                                 hook_ctx = ToolHookContext(
                                     step_name=fn_name_check,
                                     source=getattr(tool_obj_check, "source", "local"),
                                     payload=hook_payload,
                                     tool_call_id=tc["id"],
+                                    metadata=hook_metadata,
                                 )
                                 decision = None
                                 for hook in self._hooks.before_tool_call:
@@ -2328,11 +2332,14 @@ class DurableAgent(AgentBase):
         # message so replays use the recorded output rather than re-running the
         # hook. First non-Proceed decision wins, mirroring before_tool_call.
         before_llm_decision: Optional[HookDecision] = None
+        hook_metadata = {
+            "source_agent": self.name,
+        }
         if self._hooks and self._hooks.before_llm_call:
             hook_payload: Dict[str, Any] = dict(generate_kwargs)
             if "messages" in hook_payload:
                 hook_payload["messages"] = list(hook_payload["messages"])
-            before_ctx = LLMHookContext(payload=hook_payload)
+            before_ctx = LLMHookContext(payload=hook_payload, metadata=hook_metadata)
             for hook in self._hooks.before_llm_call:
                 result = hook(before_ctx)
                 if result is not None and not isinstance(result, Proceed):
@@ -2474,11 +2481,14 @@ class DurableAgent(AgentBase):
         # on the after-path since the LLM has already produced output. Hooks
         # receive a shallow copy so in-place mutation cannot bypass the Mutate
         # contract.
+        hook_metadata = {
+            "source_agent": self.name,
+        }
         if self._hooks and self._hooks.after_llm_call:
             after_payload: Dict[str, Any] = dict(generate_kwargs)
             if "messages" in after_payload:
                 after_payload["messages"] = list(after_payload["messages"])
-            after_ctx = LLMHookContext(payload=after_payload)
+            after_ctx = LLMHookContext(payload=after_payload, metadata=hook_metadata)
             for hook in self._hooks.after_llm_call:
                 result = hook(after_ctx, dict(assistant_message))
                 if isinstance(result, Mutate) and result.payload is not None:

--- a/dapr_agents/hooks.py
+++ b/dapr_agents/hooks.py
@@ -12,10 +12,13 @@
 #
 from __future__ import annotations
 from dataclasses import dataclass, field
-from typing import Any, Callable, Dict, List, Optional
+from typing import TYPE_CHECKING, Any, Callable, Dict, List, Optional
+
+if TYPE_CHECKING:
+    from dapr_agents.agents.durable import DurableAgent
 
 
-@dataclass(kw_only=True)
+@dataclass(frozen=True, kw_only=True)
 class HookContext:
     """all the information available to a hook when a step is about to run."""
 
@@ -34,11 +37,11 @@ class HookContext:
     tool_call_id: str = ""
     """llm-assigned id for this specific call. empty for llm-level hooks."""
 
-    metadata: Dict[str, Any] = field(default_factory=dict)
-    """arbitrary metadata the agent runtime can pass to hooks. hook specific."""
+    agent: "DurableAgent"
+    """the agent that is executing the step."""
 
 
-@dataclass(kw_only=True)
+@dataclass(frozen=True, kw_only=True)
 class LLMHookContext(HookContext):
     """Context for ``before_llm_call`` / ``after_llm_call`` hooks.
 
@@ -52,7 +55,7 @@ class LLMHookContext(HookContext):
     payload: Dict[str, Any] = field(default_factory=dict)
 
 
-@dataclass(kw_only=True)
+@dataclass(frozen=True, kw_only=True)
 class ToolHookContext(HookContext):
     """Context for ``before_tool_call`` / ``after_tool_call`` hooks.
 

--- a/dapr_agents/hooks.py
+++ b/dapr_agents/hooks.py
@@ -20,25 +20,25 @@ if TYPE_CHECKING:
 
 @dataclass(frozen=True, kw_only=True)
 class HookContext:
-    """all the information available to a hook when a step is about to run."""
+    """All the information available to a hook when a step is about to run."""
 
     step_name: str
-    """name of the tool about to run, or 'llm' for llm calls."""
+    """Name of the tool about to run, or 'llm' for LLM calls."""
 
     step_kind: str
-    """'tool' for tool calls, 'llm' for llm calls."""
+    """'tool' for tool calls, 'llm' for LLM calls."""
 
     source: str
-    """where this tool came from: 'local', 'mcp', 'openapi', etc."""
+    """Where this tool came from: 'local', 'mcp', 'openapi', etc."""
 
     payload: Dict[str, Any]
-    """arguments the llm wants to pass to the tool (or llm call params)."""
+    """Arguments the LLM wants to pass to the tool (or LLM call params)."""
 
     tool_call_id: str = ""
-    """llm-assigned id for this specific call. empty for llm-level hooks."""
+    """LLM-assigned ID for this specific call. Empty for LLM-level hooks."""
 
     agent: "DurableAgent"
-    """the agent that is executing the step."""
+    """The agent that is executing the step."""
 
 
 @dataclass(frozen=True, kw_only=True)
@@ -66,14 +66,14 @@ class ToolHookContext(HookContext):
 
 
 class HookDecision:
-    """base class — you never instantiate this directly, use the subclasses."""
+    """Base class — you never instantiate this directly, use the subclasses."""
 
     pass
 
 
 @dataclass
 class Proceed(HookDecision):
-    """run the step normally. returning None from a hook coerces to this."""
+    """Run the step normally. Returning ``None`` from a hook coerces to this."""
 
     pass
 
@@ -81,8 +81,8 @@ class Proceed(HookDecision):
 @dataclass
 class Skip(HookDecision):
     """
-    skip execution entirely and use `result` as the step output instead.
-    useful for returning cached results or safe defaults on policy checks.
+    Skip execution entirely and use `result` as the step output instead.
+    Useful for returning cached results or safe defaults on policy checks.
     """
 
     result: Any = None
@@ -91,12 +91,12 @@ class Skip(HookDecision):
 @dataclass
 class Mutate(HookDecision):
     """
-    run the step but adjust the incoming payload first. semantics vary by slot:
+    Run the step but adjust the incoming payload first. Semantics vary by slot:
 
     * ``before_tool_call`` — ``payload`` *replaces* the tool's arguments dict.
-      the tool sees exactly what's in ``payload`` and nothing else.
+      The tool sees exactly what's in ``payload`` and nothing else.
     * ``before_llm_call`` — ``payload`` is *shallow-merged* into the existing
-      llm generate kwargs. return only the keys you want to change
+      LLM generate kwargs. Return only the keys you want to change
       (e.g. ``Mutate(payload={"messages": enriched})``); other kwargs like
       ``tools`` / ``response_format`` / ``tool_choice`` are preserved.
     * ``after_llm_call`` — ``payload`` *replaces* the assistant message dict
@@ -109,29 +109,29 @@ class Mutate(HookDecision):
 @dataclass
 class RequireApproval(HookDecision):
     """
-    pause the workflow and wait for a human decision before running the step.
-    if no human responds within `timeout_seconds`, the step is auto-denied.
+    Pause the workflow and wait for a human decision before running the step.
+    If no human responds within `timeout_seconds`, the step is auto-denied.
 
-    this is the hook decision that drives the HITL flow — it triggers the same
-    publish → wait_for_external_event → timer-race plumbing as before, but now
-    any tool (local, mcp, openapi) can trigger it, not just ones with a decorator.
+    This is the hook decision that drives the HITL flow — it triggers the same
+    publish → wait for external event → timer-race plumbing as before, but now
+    any tool (`"local"`, `"mcp"`, `"openapi"`) can trigger it, not just ones with a decorator.
     """
 
     timeout_seconds: Optional[int] = None
-    """per-call timeout override. falls back to AgentApprovalConfig.default_timeout_seconds."""
+    """Per-call timeout override. Falls back to ``AgentApprovalConfig.default_timeout_seconds``."""
 
     instructions: Optional[str] = None
-    """message shown to the approver explaining what needs a decision."""
+    """Message shown to the approver explaining what needs a decision."""
 
     reason: Optional[str] = None
-    """optional context about why this step needs a human decision."""
+    """Optional context about why this step needs a human decision."""
 
 
 @dataclass
 class Deny(HookDecision):
     """
-    block the step without involving a human. the workflow synthesizes a
-    ToolMessage so the llm knows the call was blocked and can respond.
+    Block the step without involving a human. The workflow synthesizes a
+    ``ToolMessage`` so the LLM knows the call was blocked and can respond.
     """
 
     reason: Optional[str] = None
@@ -161,8 +161,8 @@ AfterToolHook = Callable[[ToolHookContext, Any], Optional[HookDecision]]
 @dataclass
 class Hooks:
     """
-    container for all hook callbacks you want to register on a DurableAgent.
-    each slot holds a list of callables so multiple hooks can be chained.
+    Container for all hook callbacks you want to register on a ``DurableAgent``.
+    Each slot holds a list of callables so multiple hooks can be chained.
 
     ``before_tool_call`` fires in the workflow body and must be deterministic;
     the non-deterministic tool side-effect runs in its own activity.
@@ -202,7 +202,7 @@ class Hooks:
             hooks=Hooks(before_tool_call=[before_tool]),
         )
 
-    llm-hook example (RAG via hook — inject fresh web context on every turn).
+    LLM-hook example (RAG via hook — inject fresh web context on every turn).
     Note that Tavily / search results are *untrusted* — wrap them in a
     delimited block and tell the model not to follow any instructions inside,
     or you create a prompt-injection surface::
@@ -237,7 +237,7 @@ class Hooks:
                 },
                 messages[-1],
             ]
-            # before_llm_call merges payload into the existing generate kwargs,
+            # ``before_llm_call`` merges payload into the existing generate kwargs,
             # so we only need to return the keys we're changing.
             return Mutate(payload={"messages": enriched})
 
@@ -248,22 +248,22 @@ class Hooks:
     """
 
     before_tool_call: List[BeforeToolHook] = field(default_factory=list)
-    """called before every tool dispatch. return a HookDecision to control execution.
-    runs in the deterministic workflow body. supports Proceed / Skip / Mutate /
-    RequireApproval / Deny."""
+    """Called before every tool dispatch. Return a ``HookDecision`` to control execution.
+    Runs in the deterministic workflow body. Supports ``Proceed`` / ``Skip`` / ``Mutate`` /
+    ``RequireApproval`` / ``Deny``."""
 
     after_tool_call: List[AfterToolHook] = field(default_factory=list)
-    """reserved for forward compatibility — the slot exists on this dataclass but
-    is not yet dispatched by the agent runtime. registering a callback here is a
+    """Reserved for forward compatibility — the slot exists on this dataclass but
+    is not yet dispatched by the agent runtime. Registering a callback here is a
     no-op as of this release."""
 
     before_llm_call: List[BeforeLLMHook] = field(default_factory=list)
-    """called before every llm call from inside the call_llm activity. supports
-    Proceed / Skip / Mutate / Deny. RequireApproval is NOT supported because the
-    activity boundary cannot yield for external events — use before_tool_call
+    """Called before every LLM call from inside the ``call_llm`` activity. Supports
+    ``Proceed`` / ``Skip`` / ``Mutate`` / ``Deny``. ``RequireApproval`` is NOT supported because the
+    activity boundary cannot yield for external events — use ``before_tool_call``
     for HITL flows."""
 
     after_llm_call: List[AfterLLMHook] = field(default_factory=list)
-    """called after every llm response. return Mutate(payload=<assistant_message dict>)
-    to replace the message that gets persisted and returned. Skip / Deny / RequireApproval
+    """Called after every LLM response. Return ``Mutate(payload=<assistant_message dict>)``
+    to replace the message that gets persisted and returned. ``Skip`` / ``Deny`` / ``RequireApproval``
     are no-ops on this slot (the LLM has already produced output)."""

--- a/dapr_agents/hooks.py
+++ b/dapr_agents/hooks.py
@@ -34,6 +34,9 @@ class HookContext:
     tool_call_id: str = ""
     """llm-assigned id for this specific call. empty for llm-level hooks."""
 
+    metadata: Dict[str, Any] = field(default_factory=dict)
+    """arbitrary metadata the agent runtime can pass to hooks. hook specific."""
+
 
 @dataclass(kw_only=True)
 class LLMHookContext(HookContext):

--- a/tests/agents/durableagent/test_hitl.py
+++ b/tests/agents/durableagent/test_hitl.py
@@ -14,6 +14,7 @@
 """Unit tests for the hook-based human-in-the-loop (HITL) system."""
 
 from datetime import timezone
+from unittest.mock import MagicMock
 
 from dapr_agents.agents.schemas import ApprovalRequiredEvent, ApprovalResponseEvent
 from dapr_agents.agents.configs import AgentApprovalConfig, AgentExecutionConfig
@@ -316,6 +317,7 @@ class TestHooksContainer:
             source="local",
             payload={"table": "users"},
             tool_call_id="call-123",
+            agent=MagicMock(),
         )
         decision = h.before_tool_call[0](ctx)
         assert len(received) == 1
@@ -330,7 +332,11 @@ class TestHooksContainer:
         h = Hooks(before_tool_call=[passthrough])
         result = h.before_tool_call[0](
             ToolHookContext(
-                step_name="tool", source="local", payload={}, tool_call_id="id"
+                step_name="tool",
+                source="local",
+                payload={},
+                tool_call_id="id",
+                agent=MagicMock(),
             )
         )
         assert result is None  # workflow code handles the None → Proceed coercion

--- a/tests/agents/durableagent/test_hitl_workflow.py
+++ b/tests/agents/durableagent/test_hitl_workflow.py
@@ -746,6 +746,7 @@ class TestHookWorkflowDispatch:
             source="local",
             payload={"table": "users"},
             tool_call_id="c-1",
+            agent=MagicMock(),
         )
         ctx2 = HookContext(
             step_name="DropTable",
@@ -753,6 +754,7 @@ class TestHookWorkflowDispatch:
             source="local",
             payload={"table": "users"},
             tool_call_id="c-1",
+            agent=MagicMock(),
         )
 
         d1 = stateless_hook(ctx1)
@@ -770,7 +772,11 @@ class TestHookWorkflowDispatch:
             return Proceed()
 
         ctx = ToolHookContext(
-            step_name="AnyTool", source="local", payload={}, tool_call_id="c-1"
+            step_name="AnyTool",
+            source="local",
+            payload={},
+            tool_call_id="c-1",
+            agent=MagicMock(),
         )
         d1 = passthrough(ctx)
         d2 = passthrough(ctx)


### PR DESCRIPTION
# Description
- Add extra agent metadata to the hook context
- Clean up some docs for hook context

**Fields (preliminary)**
    - `agent`: The `DurableAgent` executing the step

## Issue reference

We strive to have all PR being opened based on an issue, where the problem or feature have been discussed prior to implementation.

Please reference the issue this PR closes: #746

## Checklist

Please make sure you've completed the relevant tasks for this PR, out of the following list:

* [ ] Created/updated tests
* [ ] Tested this change against all the quickstarts
* [ ] Extended the documentation
    * [ ] Created the [dapr/docs](https://github.com/dapr/docs) PR: <insert PR link here>

**Note:** We expect contributors to open a corresponding documentation PR in the [dapr/docs](https://github.com/dapr/docs/) repository. As the implementer, you are the best person to document your work! Implementation PRs will not be merged until the documentation PR is opened and ready for review.

## TODO
- [ ] Should `agent` be top-level or in a separate `metadata` field?
- [ ] Add wf input message metadata? Or should it be made part of the initial recorded entry?