### PR TITLE
feat: forward LLM response metadata to after_llm_call hooks

### DIFF
--- a/dapr_agents/agents/durable.py
+++ b/dapr_agents/agents/durable.py
@@ -2372,6 +2372,7 @@ class DurableAgent(AgentBase):
             # `response_format`, or `tool_choice` from generate_kwargs.
             generate_kwargs = {**generate_kwargs, **before_llm_decision.payload}
 
+        response: Any = None
         if synthesized_message is not None:
             assistant_message = synthesized_message
         else:
@@ -2478,6 +2479,11 @@ class DurableAgent(AgentBase):
             after_payload: Dict[str, Any] = dict(generate_kwargs)
             if "messages" in after_payload:
                 after_payload["messages"] = list(after_payload["messages"])
+            # Surface provider response metadata (token usage, finish_reason, …)
+            # so hooks can do per-call usage accounting without having to
+            # wrap/monkeypatch the LLM client themselves.
+            if isinstance(response, LLMChatResponse) and response.metadata:
+                after_payload["response_metadata"] = dict(response.metadata)
             after_ctx = LLMHookContext(payload=after_payload)
             for hook in self._hooks.after_llm_call:
                 result = hook(after_ctx, dict(assistant_message))

--- a/dapr_agents/hooks.py
+++ b/dapr_agents/hooks.py
@@ -260,4 +260,6 @@ class Hooks:
     after_llm_call: List[AfterLLMHook] = field(default_factory=list)
     """called after every llm response. return Mutate(payload=<assistant_message dict>)
     to replace the message that gets persisted and returned. Skip / Deny / RequireApproval
-    are no-ops on this slot (the LLM has already produced output)."""
+    are no-ops on this slot (the LLM has already produced output). ctx.payload includes
+    "response_metadata" (the provider's LLMChatResponse.metadata, e.g. token usage) when
+    the call produced one."""

--- a/tests/agents/durableagent/test_llm_hooks.py
+++ b/tests/agents/durableagent/test_llm_hooks.py
@@ -38,6 +38,7 @@ from dapr_agents.hooks import (
 )
 from dapr_agents.llm import OpenAIChatClient
 from dapr_agents.storage.daprstores.stateservice import StateStoreService
+from dapr_agents.types import AssistantMessage, LLMChatCandidate, LLMChatResponse
 
 
 @pytest.fixture(autouse=True)
@@ -460,6 +461,53 @@ class TestAfterLLMCallHook:
         result = _run_call_llm(agent, mock_activity_ctx)
 
         assert result == {"role": "assistant", "content": "from-llm"}
+
+
+class TestAfterLLMCallResponseMetadata:
+    """Regression tests for issue #731: LLMChatResponse.metadata (token usage,
+    etc.) must reach after_llm_call hooks instead of being silently dropped."""
+
+    def test_response_metadata_is_forwarded_to_after_hook(
+        self, mock_llm, mock_activity_ctx
+    ):
+        usage = {"input_tokens": 12, "output_tokens": 34}
+        mock_llm.generate = Mock(
+            return_value=LLMChatResponse(
+                results=[
+                    LLMChatCandidate(
+                        message=AssistantMessage(content="from-llm"),
+                        finish_reason="end_turn",
+                    )
+                ],
+                metadata={"usage": usage},
+            )
+        )
+        captured: list = []
+
+        def hook(ctx, _msg):
+            captured.append(ctx.payload.get("response_metadata"))
+            return None
+
+        agent = _make_agent(mock_llm, Hooks(after_llm_call=[hook]))
+        _run_call_llm(agent, mock_activity_ctx)
+
+        assert captured == [{"usage": usage}]
+
+    def test_no_response_metadata_key_when_llm_returns_plain_mock(
+        self, mock_llm, mock_activity_ctx
+    ):
+        """The default mock_llm fixture returns a bare Mock, not an
+        LLMChatResponse — the payload must not gain the key in that case."""
+        captured: list = []
+
+        def hook(ctx, _msg):
+            captured.append(ctx.payload)
+            return None
+
+        agent = _make_agent(mock_llm, Hooks(after_llm_call=[hook]))
+        _run_call_llm(agent, mock_activity_ctx)
+
+        assert "response_metadata" not in captured[0]
 
 
 class TestBeforeAfterCombined:


### PR DESCRIPTION
# Description

LLMChatResponse.metadata built by each provider client for example token usage counts on the Anthropic backend was silently dropped inside the call_llm workflow activity. There was no supported way for calling code to capture per call token usage for a DurableAgent run without wrapping or monkeypatching the LLM client's generate method.

The after_llm_call hook already receives a payload dict built for context (a copy of the generate kwargs). This PR adds the LLM response's metadata to that payload under a new response_metadata key whenever the call produced an LLMChatResponse, so a hook can read ctx.payload["response_metadata"]["usage"] for per call usage accounting without needing to touch the LLM client at all. The persisted assistant message and the chat history sent back to the model are unchanged.

## Issue reference

Please reference the issue this PR closes: #731

## Checklist

Please make sure you've completed the relevant tasks for this PR, out of the following list:

* [x] Created/updated tests
* [ ] Tested against all quickstarts
* [ ] Extended the documentation

Notes:
- Tests: added tests/agents/durableagent/test_llm_hooks.py::TestAfterLLMCallResponseMetadata, covering both the case where response_metadata is forwarded and the case where the LLM returns something other than an LLMChatResponse (payload must not gain the key). Verified the new test fails against the pre-fix code and passes with the fix.
- Quickstarts: not run in this environment since it requires a live Dapr sidecar.
- Documentation: the after_llm_call docstring in dapr_agents/hooks.py was updated to describe the new payload key, but before_llm_call/after_llm_call hooks are not currently documented anywhere on the dapr.io docs site, so there is no existing page to extend for this. If the hooks system gets a dedicated docs.dapr.io page in the future, this new payload key would need to be mentioned there as a follow-up.
