### PR TITLE
fix(memory): return most recent messages, not oldest, from get_messages

### DIFF
--- a/dapr_agents/memory/daprstatestore.py
+++ b/dapr_agents/memory/daprstatestore.py
@@ -201,7 +201,7 @@ class ConversationDaprStateMemory(MemoryBase):
         if response and hasattr(response, "data") and response.data:
             raw_messages = json.loads(response.data)
             if raw_messages:
-                messages = raw_messages[:limit]
+                messages = raw_messages[-limit:]
                 logger.info(
                     f"Retrieved {len(messages)} messages for workflow instance {workflow_instance_id}",
                 )

--- a/dapr_agents/memory/daprstatestore.py
+++ b/dapr_agents/memory/daprstatestore.py
@@ -201,7 +201,7 @@ class ConversationDaprStateMemory(MemoryBase):
         if response and hasattr(response, "data") and response.data:
             raw_messages = json.loads(response.data)
             if raw_messages:
-                messages = raw_messages[-limit:]
+                messages = raw_messages[-limit:] if limit > 0 else []
                 logger.info(
                     f"Retrieved {len(messages)} messages for workflow instance {workflow_instance_id}",
                 )

--- a/tests/memory/test_daprstatestore.py
+++ b/tests/memory/test_daprstatestore.py
@@ -61,3 +61,22 @@ def test_add_message_records_created_at_in_utc(monkeypatch):
     assert parsed == true_utc
     # And must NOT be the naive local wall clock mislabeled as UTC.
     assert parsed != naive_local.replace(tzinfo=timezone.utc)
+
+
+def test_get_messages_returns_most_recent_when_over_limit():
+    """get_messages(limit=N) must return the N most recently added messages, not
+    the N oldest.
+
+    add_message always appends, so stored messages are ordered oldest to newest;
+    slicing from the front returns the same first N messages forever once a
+    conversation grows past the limit, never surfacing anything new.
+    """
+    memory = _make_memory()
+    stored = [{"role": "user", "content": f"message-{i}"} for i in range(5)]
+    memory.dapr_store.get_state.return_value = MagicMock(
+        data=json.dumps(stored), etag="etag-1"
+    )
+
+    messages = memory.get_messages("wf-1", limit=2)
+
+    assert [m["content"] for m in messages] == ["message-3", "message-4"]

--- a/tests/memory/test_daprstatestore.py
+++ b/tests/memory/test_daprstatestore.py
@@ -80,3 +80,21 @@ def test_get_messages_returns_most_recent_when_over_limit():
     messages = memory.get_messages("wf-1", limit=2)
 
     assert [m["content"] for m in messages] == ["message-3", "message-4"]
+
+
+def test_get_messages_with_limit_zero_returns_empty():
+    """get_messages(limit=0) must return no messages.
+
+    raw_messages[-0:] is raw_messages[0:], the entire list, since -0 == 0 in
+    Python slicing. Without an explicit guard, limit=0 silently returns
+    everything instead of nothing.
+    """
+    memory = _make_memory()
+    stored = [{"role": "user", "content": f"message-{i}"} for i in range(5)]
+    memory.dapr_store.get_state.return_value = MagicMock(
+        data=json.dumps(stored), etag="etag-1"
+    )
+
+    messages = memory.get_messages("wf-1", limit=0)
+
+    assert messages == []


### PR DESCRIPTION
# Description

add_message always appends, so stored messages in ConversationDaprStateMemory are ordered oldest to newest. get_messages sliced with raw_messages[:limit], which returns the oldest messages instead of the most recent ones. Once a conversation grows past the limit, this means it forever returns the same first N messages and never surfaces anything new. This slices from the end instead so the limit keeps the most recent messages.

Found by reading the code, not tied to an existing issue.

## Issue reference

Please reference the issue this PR closes: none, self discovered

## Checklist

Please make sure you've completed the relevant tasks for this PR, out of the following list:

* [x] Created/updated tests
* [ ] Tested this change against all the quickstarts
* [ ] Extended the documentation
    * [ ] Created the dapr/docs PR: not applicable, no user facing behavior to document beyond the bug fix itself