### PR TITLE
fix(executors): fix missing package probe in LocalCodeExecutor

### DIFF
--- a/dapr_agents/executors/local.py
+++ b/dapr_agents/executors/local.py
@@ -241,8 +241,8 @@ class LocalCodeExecutor(CodeExecutorBase):
         async def probe(pkg: str) -> str | None:
             proc = await asyncio.create_subprocess_exec(
                 str(python),
-                "- <<PY\nimport importlib.util, sys;"
-                f"sys.exit(importlib.util.find_spec('{pkg}') is None)\nPY",
+                "-c",
+                f"import importlib.util, sys; sys.exit(importlib.util.find_spec('{pkg}') is None)",
                 stdout=asyncio.subprocess.DEVNULL,
                 stderr=asyncio.subprocess.DEVNULL,
             )

--- a/tests/executors/test_local.py
+++ b/tests/executors/test_local.py
@@ -13,6 +13,7 @@
 
 """Unit tests for ``LocalCodeExecutor``."""
 
+import asyncio
 import sys
 from pathlib import Path
 
@@ -20,20 +21,27 @@ import pytest
 
 from dapr_agents.executors.local import LocalCodeExecutor
 
+PROBE_TIMEOUT = 5
+
 
 class TestGetMissingPackages:
     @pytest.mark.asyncio
     async def test_installed_package_is_not_reported_missing(self):
         executor = LocalCodeExecutor()
         env_path = Path(sys.executable).parent.parent
-        missing = await executor._get_missing_packages(["sys"], env_path)
+        missing = await asyncio.wait_for(
+            executor._get_missing_packages(["sys"], env_path), PROBE_TIMEOUT
+        )
         assert missing == []
 
     @pytest.mark.asyncio
     async def test_uninstalled_package_is_reported_missing(self):
         executor = LocalCodeExecutor()
         env_path = Path(sys.executable).parent.parent
-        missing = await executor._get_missing_packages(
-            ["definitely_not_a_real_package_xyz"], env_path
+        missing = await asyncio.wait_for(
+            executor._get_missing_packages(
+                ["definitely_not_a_real_package_xyz"], env_path
+            ),
+            PROBE_TIMEOUT,
         )
         assert missing == ["definitely_not_a_real_package_xyz"]

--- a/tests/executors/test_local.py
+++ b/tests/executors/test_local.py
@@ -1,0 +1,39 @@
+#
+# Copyright 2026 The Dapr Authors
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#     http://www.apache.org/licenses/LICENSE-2.0
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+"""Unit tests for ``LocalCodeExecutor``."""
+
+import sys
+from pathlib import Path
+
+import pytest
+
+from dapr_agents.executors.local import LocalCodeExecutor
+
+
+class TestGetMissingPackages:
+    @pytest.mark.asyncio
+    async def test_installed_package_is_not_reported_missing(self):
+        executor = LocalCodeExecutor()
+        env_path = Path(sys.executable).parent.parent
+        missing = await executor._get_missing_packages(["sys"], env_path)
+        assert missing == []
+
+    @pytest.mark.asyncio
+    async def test_uninstalled_package_is_reported_missing(self):
+        executor = LocalCodeExecutor()
+        env_path = Path(sys.executable).parent.parent
+        missing = await executor._get_missing_packages(
+            ["definitely_not_a_real_package_xyz"], env_path
+        )
+        assert missing == ["definitely_not_a_real_package_xyz"]


### PR DESCRIPTION
# Description

`_get_missing_packages` ran `python3` with a heredoc string as a single `argv` entry instead of a shell, so the probe subprocess always failed (or hung) instead of exiting 0 for an installed package. Every extracted import, including stdlib modules like `sys`, was always reported as missing. That forces an unnecessary `pip install` attempt for every import on every execution, and any of those failing (for example trying to `pip install` a stdlib name) raises and aborts the whole snippet run.

Use `python3 -c` directly instead of the shell heredoc string, matching how `-c` is used everywhere else in this file.

## Issue reference

Please reference the issue this PR closes: #754

## Checklist

Please make sure you've completed the relevant tasks for this PR, out of the following list:

* [x] Created/updated tests
* [ ] Tested against all quickstarts
* [ ] Extended the documentation

Notes:
- Tests: added tests/executors/test_local.py (none existed before), confirmed both cases fail against the pre-fix code (one hangs rather than failing cleanly) and pass against the fix.
- Quickstarts: not run in this environment since it requires a live Dapr sidecar; the fix is covered by the new unit tests instead.
- Documentation: this is an internal bug fix with no change to any public API or configuration surface, so no dapr.io documentation update is needed for it.
