### PR TITLE
fix(service): surface FastAPIServerBase start failures instead of hanging

### DIFF
--- a/dapr_agents/service/fastapi/base.py
+++ b/dapr_agents/service/fastapi/base.py
@@ -126,6 +126,9 @@ class FastAPIServerBase(APIServerBase, SignalMixin):
 
             # Wait for startup to complete
             while not self.server.started:
+                if server_task.done():
+                    server_task.result()
+                    return
                 await asyncio.sleep(0.1)
 
             # Extract the real port from the bound socket

--- a/tests/service/__init__.py
+++ b/tests/service/__init__.py
@@ -1,0 +1,12 @@
+#
+# Copyright 2026 The Dapr Authors
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#     http://www.apache.org/licenses/LICENSE-2.0
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#

--- a/tests/service/fastapi/__init__.py
+++ b/tests/service/fastapi/__init__.py
@@ -1,0 +1,12 @@
+#
+# Copyright 2026 The Dapr Authors
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#     http://www.apache.org/licenses/LICENSE-2.0
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#

--- a/tests/service/fastapi/test_base.py
+++ b/tests/service/fastapi/test_base.py
@@ -1,0 +1,42 @@
+#
+# Copyright 2026 The Dapr Authors
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#     http://www.apache.org/licenses/LICENSE-2.0
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+"""Unit tests for ``FastAPIServerBase.start``."""
+
+import asyncio
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from dapr_agents.service.fastapi.base import FastAPIServerBase
+
+START_TIMEOUT = 5
+
+
+class TestStart:
+    @pytest.mark.asyncio
+    async def test_server_failure_before_startup_is_raised(self):
+        server = FastAPIServerBase(service_name="test-service")
+
+        fake_uvicorn_server = MagicMock()
+        fake_uvicorn_server.started = False
+
+        async def failing_serve():
+            raise OSError("address already in use")
+
+        fake_uvicorn_server.serve = failing_serve
+
+        with patch("uvicorn.Server", return_value=fake_uvicorn_server), pytest.raises(
+            OSError, match="address already in use"
+        ):
+            await asyncio.wait_for(server.start(), START_TIMEOUT)


### PR DESCRIPTION
# Description

FastAPIServerBase.start() waits for the server to come up by polling self.server.started in a loop, with no way to exit that loop if the uvicorn server task fails before it ever sets started, for example when the configured port is already in use. The task's exception went unretrieved and start just spun forever instead of raising. This checks server_task.done() on each iteration and calls server_task.result(), so a startup failure is raised immediately instead of hanging.

## Issue reference

No existing issue tracks this; found while reading the FastAPI service startup path.

## Checklist

* [x] Created/updated tests
* [ ] Tested this change against all the quickstarts
* [ ] Extended the documentation
    * [ ] Created the dapr/docs PR

This is an internal bug fix with no user-facing API or documented behavior change, so no docs PR is needed.