### PR TITLE
fix(utils): schedule async graceful_shutdown() from signal handler instead of dropping it

### DIFF
--- a/dapr_agents/utils/signal_mixin.py
+++ b/dapr_agents/utils/signal_mixin.py
@@ -39,6 +39,7 @@ class SignalHandlingMixin:
         super().__init__(*args, **kwargs)
         self._shutdown_event: Optional[asyncio.Event] = None
         self._signal_handlers_setup = False
+        self._loop: Optional[asyncio.AbstractEventLoop] = None
 
     def setup_signal_handlers(self) -> None:
         """
@@ -81,6 +82,7 @@ class SignalHandlingMixin:
             # Set up signal handlers
             add_signal_handlers_cross_platform(loop, self._handle_shutdown_signal)
 
+            self._loop = loop
             self._signal_handlers_setup = True
             logger.debug("Signal handlers set up for graceful shutdown")
         except Exception as e:
@@ -103,11 +105,18 @@ class SignalHandlingMixin:
         # Call the graceful shutdown method if it exists
         if hasattr(self, "graceful_shutdown"):
             try:
-                # Call synchronously since we're in a signal handler
-                import asyncio
-
                 if asyncio.iscoroutinefunction(self.graceful_shutdown):
-                    logger.debug("Async graceful shutdown - shutdown event set")
+                    # We're in a signal handler, so the coroutine can't be
+                    # awaited directly. Schedule it on the loop captured at
+                    # setup time instead, or it would silently never run.
+                    if self._loop is not None:
+                        self._loop.call_soon_threadsafe(
+                            lambda: asyncio.ensure_future(self.graceful_shutdown())
+                        )
+                    else:
+                        logger.debug(
+                            "No event loop captured; cannot schedule async graceful_shutdown()"
+                        )
                 else:
                     self.graceful_shutdown()  # type: ignore[unused-coroutine]
             except Exception as e:

--- a/tests/test_signal_mixin.py
+++ b/tests/test_signal_mixin.py
@@ -1,0 +1,90 @@
+#
+# Copyright 2026 The Dapr Authors
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#     http://www.apache.org/licenses/LICENSE-2.0
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+import asyncio
+
+import pytest
+
+from dapr_agents.utils.signal_mixin import SignalHandlingMixin
+
+
+class DummyService(SignalHandlingMixin):
+    def __init__(self):
+        super().__init__()
+        self.stopped = False
+
+    async def stop(self):
+        self.stopped = True
+
+
+@pytest.mark.asyncio
+async def test_handle_shutdown_signal_schedules_async_graceful_shutdown():
+    """A real SIGINT/SIGTERM callback must not silently drop the default
+    async graceful_shutdown()/stop() cleanup path."""
+    service = DummyService()
+    service._loop = asyncio.get_running_loop()
+    service._shutdown_event = asyncio.Event()
+
+    service._handle_shutdown_signal(15)
+
+    assert service._shutdown_event.is_set()
+    # graceful_shutdown() is scheduled via call_soon_threadsafe, not awaited
+    # inline, so give the loop a turn to run it.
+    await asyncio.sleep(0)
+    await asyncio.sleep(0)
+
+    assert service.stopped is True
+
+
+def test_handle_shutdown_signal_without_captured_loop_does_not_raise():
+    """Before setup_signal_handlers() runs (or if it never captured a loop),
+    the signal callback must degrade gracefully instead of raising."""
+    service = DummyService()
+    service._shutdown_event = asyncio.Event()
+
+    service._handle_shutdown_signal(2)
+
+    assert service._shutdown_event.is_set()
+    assert service.stopped is False
+
+
+@pytest.mark.asyncio
+async def test_setup_signal_handlers_captures_loop():
+    class NoOpService(SignalHandlingMixin):
+        pass
+
+    service = NoOpService()
+    assert service._loop is None
+
+    service.setup_signal_handlers()
+
+    assert service._loop is asyncio.get_running_loop()
+    assert service._signal_handlers_setup is True
+
+
+@pytest.mark.asyncio
+async def test_handle_shutdown_signal_calls_sync_graceful_shutdown_directly():
+    class SyncService(SignalHandlingMixin):
+        def __init__(self):
+            super().__init__()
+            self.called = False
+
+        def graceful_shutdown(self):
+            self.called = True
+
+    service = SyncService()
+    service._shutdown_event = asyncio.Event()
+
+    service._handle_shutdown_signal(15)
+
+    assert service.called is True


### PR DESCRIPTION
# Description

SignalHandlingMixin._handle_shutdown_signal is invoked from a real signal.signal() OS callback, not the event loop. When graceful_shutdown is a coroutine function, which it is by default since the class's own implementation is `async def graceful_shutdown`, the handler only logged a debug message and never scheduled or awaited it. So the default cleanup path (`await self.stop()`) silently never ran on a real SIGINT/SIGTERM; only the shutdown event got set.

This class is still exported as public API from `dapr_agents.utils` (`SignalHandlingMixin` in `__all__`), even though internal code has moved to the newer `dapr_agents.utils.signal.mixin.SignalMixin`, which already schedules graceful shutdown correctly via `loop.call_soon_threadsafe` + `loop.create_task`. This PR ports the same fix into the older, still-public class: capture the event loop in `setup_signal_handlers`, then use it to properly schedule the coroutine in `_handle_shutdown_signal`.

Had no test coverage before this change.

## Issue reference

No existing issue tracks this; found while reading the signal-handling utilities.

## Checklist

* [x] Created/updated tests
* [ ] Tested this change against all the quickstarts
* [ ] Extended the documentation
    * [ ] Created the dapr/docs PR

This is an internal bug fix with no public API or documented behavior change, so no docs PR is needed.