### PR TITLE
fix(document): stop TextSplitter from silently dropping content at chunk boundaries

### DIFF
--- a/dapr_agents/document/splitter/base.py
+++ b/dapr_agents/document/splitter/base.py
@@ -116,43 +116,42 @@ class SplitterBase(BaseModel, ABC):
         for split in splits:
             split_size = self._get_chunk_size(split)
 
-            # If adding the current split exceeds max_size, finalize the current chunk
-            if current_size + split_size > max_size:
-                if current_chunk:
-                    # Finalize the current chunk
-                    full_chunk = "".join(current_chunk)
-                    chunks.append(full_chunk)
+            # If adding the current split exceeds max_size, finalize the current
+            # chunk first. If current_chunk is empty, there's nothing to finalize
+            # and split is simply appended below, becoming its own chunk if it
+            # alone exceeds max_size.
+            if current_size + split_size > max_size and current_chunk:
+                # Finalize the current chunk
+                full_chunk = "".join(current_chunk)
+                chunks.append(full_chunk)
 
-                    # Logging information for overlap and chunk size
-                    logger.debug(
-                        f"Chunk {len(chunks)} finalized. Size: {current_size}. Overlap size: {self.chunk_overlap}"
-                    )
+                # Logging information for overlap and chunk size
+                logger.debug(
+                    f"Chunk {len(chunks)} finalized. Size: {current_size}. Overlap size: {self.chunk_overlap}"
+                )
 
-                    # Create an overlap using sentences from the current chunk
-                    overlap = []
-                    overlap_size = 0
-                    for sentence in reversed(current_chunk):
-                        sentence_size = self._get_chunk_size(sentence)
-                        if overlap_size + sentence_size > self.chunk_overlap:
-                            break
-                        overlap.insert(0, sentence)
-                        overlap_size += sentence_size
+                # Create an overlap using sentences from the current chunk
+                overlap = []
+                overlap_size = 0
+                for sentence in reversed(current_chunk):
+                    sentence_size = self._get_chunk_size(sentence)
+                    if overlap_size + sentence_size > self.chunk_overlap:
+                        break
+                    overlap.insert(0, sentence)
+                    overlap_size += sentence_size
 
-                    # Logging information for overlap content
-                    logger.debug(f"Chunk {len(chunks)} overlap: {''.join(overlap)}")
+                # Logging information for overlap content
+                logger.debug(f"Chunk {len(chunks)} overlap: {''.join(overlap)}")
 
-                    # Start the new chunk with the overlap
-                    current_chunk = overlap
-                    current_size = overlap_size
-                else:
-                    # If a single split exceeds max_size, treat it as a standalone chunk
-                    chunks.append(split)
-                    current_chunk = []
-                    current_size = 0
-            else:
-                # Add the current split to the ongoing chunk
-                current_chunk.append(split)
-                current_size += split_size
+                # Start the new chunk with the overlap
+                current_chunk = overlap
+                current_size = overlap_size
+
+            # Add the current split to the ongoing chunk. This must happen
+            # unconditionally (not just in the size-fits branch above), or the
+            # split that triggered finalization above would be dropped entirely.
+            current_chunk.append(split)
+            current_size += split_size
 
         # Finalize the last chunk
         if current_chunk:

--- a/tests/document/splitter/test_text.py
+++ b/tests/document/splitter/test_text.py
@@ -1,0 +1,77 @@
+#
+# Copyright 2026 The Dapr Authors
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#     http://www.apache.org/licenses/LICENSE-2.0
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+from dapr_agents.document.splitter.text import TextSplitter
+
+
+def test_merge_splits_does_not_drop_content_that_triggers_finalization():
+    """A split that overflows the current chunk must still end up in the
+    output somewhere, not be silently discarded when the in-progress chunk
+    is finalized to make room for it."""
+    splitter = TextSplitter(
+        chunk_size=10150, chunk_overlap=0, separator=None, fallback_separators=[]
+    )
+    splits = ["A" * 100, "B" * 100, "C" * 3000]
+
+    merged = splitter._merge_splits(splits, max_size=150)
+
+    combined = "".join(merged)
+    assert combined.count("A") == 100
+    assert combined.count("B") == 100
+    assert combined.count("C") == 3000
+
+
+def test_merge_splits_respects_max_size_for_normal_splits():
+    splitter = TextSplitter(
+        chunk_size=10150, chunk_overlap=0, separator=None, fallback_separators=[]
+    )
+    splits = ["A" * 50, "B" * 50, "C" * 50, "D" * 50]
+
+    merged = splitter._merge_splits(splits, max_size=100)
+
+    assert merged == ["A" * 50 + "B" * 50, "C" * 50 + "D" * 50]
+
+
+def test_merge_splits_with_overlap_carries_previous_content_forward():
+    splitter = TextSplitter(
+        chunk_size=10150, chunk_overlap=10, separator=None, fallback_separators=[]
+    )
+    splits = ["A" * 50, "B" * 50, "C" * 50]
+
+    merged = splitter._merge_splits(splits, max_size=100)
+
+    assert len(merged) >= 2
+    # every split must appear in at least one chunk; none dropped
+    combined = "".join(merged)
+    assert combined.count("A") == 50
+    assert combined.count("B") == 50
+    assert combined.count("C") == 50
+
+
+def test_split_short_text_returns_single_chunk():
+    splitter = TextSplitter(chunk_size=100, chunk_overlap=0)
+    text = "short text"
+
+    assert splitter.split(text) == [text]
+
+
+def test_split_long_text_preserves_all_content():
+    splitter = TextSplitter(chunk_size=50, chunk_overlap=0, separator="\n\n")
+    text = "\n\n".join(f"paragraph {i} " + "x" * 40 for i in range(10))
+
+    chunks = splitter.split(text)
+
+    for i in range(10):
+        assert any(f"paragraph {i} " in chunk for chunk in chunks), (
+            f"paragraph {i} missing from output chunks"
+        )


### PR DESCRIPTION
# Description

SplitterBase._merge_splits, the chunk-merging logic behind every TextSplitter call including split_documents (used for RAG document ingestion), silently dropped the split that triggered finalizing the current chunk. When a split didn't fit in the in-progress chunk, the code finalized that chunk and reset to the overlap-seeded new chunk, but never added the triggering split anywhere before the loop moved on to the next item. Any split landing exactly on a chunk-size boundary simply vanished from the output.

Reproduced directly: `splits=['A'*100, 'B'*100, 'C'*3000]` with `max_size=150` produced output missing the `B` chunk entirely.

Fix: move the append outside the size-check branch so the triggering split is always added to the new chunk. This also makes the old "standalone oversized chunk" branch redundant, since an oversized split with an empty current_chunk now naturally becomes its own chunk once appended, so that branch is removed.

Had no test coverage before this change.

## Issue reference

No existing issue tracks this; found while reading the document splitting pipeline.

## Checklist

* [x] Created/updated tests
* [ ] Tested this change against all the quickstarts
* [ ] Extended the documentation
    * [ ] Created the dapr/docs PR

This is an internal bug fix with no public API or documented behavior change, so no docs PR is needed.