### PR TITLE
deps: bump chainlit to 2.12.0 (GHSA-w3fx-mc44-mf6j)

### DIFF
--- a/examples/05-document-agent-chainlit/pyproject.toml
+++ b/examples/05-document-agent-chainlit/pyproject.toml
@@ -16,7 +16,7 @@ name = "05-document-agent-chainlit"
 version = "0.1.0"
 requires-python = ">=3.11, <3.14"
 dependencies = [
-    "chainlit==2.9.4",
+    "chainlit==2.12.0",
     "dapr-agents",
     "python-dotenv>=1.2.1",
     "unstructured[all-docs]==0.18.18",

--- a/examples/07-data-agent-mcp-chainlit/pyproject.toml
+++ b/examples/07-data-agent-mcp-chainlit/pyproject.toml
@@ -16,7 +16,7 @@ name = "07-data-agent-mcp-chainlit"
 version = "0.1.0"
 requires-python = ">=3.11, <3.14"
 dependencies = [
-    "chainlit==2.9.4",
+    "chainlit==2.12.0",
     "dapr-agents",
     "psycopg[binary]==3.2.9",
     "python-dotenv>=1.2.1",

--- a/examples/11-expert-agent-tavily/pyproject.toml
+++ b/examples/11-expert-agent-tavily/pyproject.toml
@@ -16,7 +16,7 @@ name = "11-expert-agent-tavily"
 version = "0.1.0"
 requires-python = ">=3.11, <3.14"
 dependencies = [
-    "chainlit==2.9.4",
+    "chainlit==2.12.0",
     "dapr-agents",
     "python-dotenv>=1.2.1",
     "tavily-python>=0.5.0",


### PR DESCRIPTION
Updates `chainlit` in the three example apps to address GHSA-w3fx-mc44-mf6j (critical) and GHSA-hvfh-5mj3-5f3j, which affect 2.4.0 through 2.11.x.

Evidence:
- `examples/05-document-agent-chainlit/pyproject.toml`, `examples/07-data-agent-mcp-chainlit/pyproject.toml`, and `examples/11-expert-agent-tavily/pyproject.toml` pinned `chainlit==2.9.4`
- osv-scanner reported PYSEC-2026-3812 / GHSA-w3fx-mc44-mf6j (CVSS 9.8) and PYSEC-2026-3811 / GHSA-hvfh-5mj3-5f3j against `chainlit@2.9.4`
- updated version: `2.12.0` (first fixed release; requires Python >=3.10, examples already require >=3.11)

Validation:
- osv-scanner no longer reports any advisory for `chainlit@2.12.0`
- the example apps' usage surface (`@cl.on_chat_start`, `@cl.on_message`, `cl.Step`) verified working on 2.12.0; no `ChatInterface` usage in the examples
- dependabot's earlier 2.11.1 bump (#622) was closed before this advisory was fixed; 2.11.1 is still in the affected range, 2.12.0 is the fixed line

Scope: `chainlit` pins in the three example `pyproject.toml` files only.
