### PR TITLE
fix(workflow): retry transient 'actor is closed' error during completion wait

### DIFF
--- a/dapr_agents/workflow/runners/base.py
+++ b/dapr_agents/workflow/runners/base.py
@@ -30,6 +30,8 @@ from typing import (
     overload,
 )
 
+import grpc
+
 from dapr.clients import DaprClient
 from dapr.ext.workflow import DaprWorkflowClient
 from dapr.ext.workflow.workflow_state import WorkflowState
@@ -44,6 +46,21 @@ from dapr_agents.workflow.utils.registration import (
 )
 
 logger = logging.getLogger(__name__)
+
+# gRPC error detail emitted by the workflow actor runtime when the actor is
+# deactivated (e.g. idle scale-to-zero) while a completion wait is in flight.
+# The workflow itself keeps executing and the actor is re-activated on demand,
+# so this is transient and must be retried rather than treated as fatal.
+_ACTOR_CLOSED_DETAIL = "actor is closed"
+
+
+def _is_actor_closed_error(exc: BaseException) -> bool:
+    """Return True for the transient 'actor is closed' gRPC error."""
+    if not isinstance(exc, grpc.RpcError):
+        return False
+    return exc.code() == grpc.StatusCode.UNKNOWN and _ACTOR_CLOSED_DETAIL in (
+        exc.details() or ""
+    )
 
 
 class WorkflowRunner(SignalMixin):
@@ -419,8 +436,6 @@ class WorkflowRunner(SignalMixin):
                 logger.debug(f"{self._name} Scheduled workflow id={result}")
                 return result
             except Exception as e:
-                import grpc
-
                 is_transient = isinstance(e, grpc.RpcError) and e.code() in (
                     grpc.StatusCode.CANCELLED,
                     grpc.StatusCode.UNAVAILABLE,
@@ -537,7 +552,7 @@ class WorkflowRunner(SignalMixin):
         """
         effective_timeout = timeout_in_seconds or self._timeout_in_seconds
         try:
-            return self._wf_client.wait_for_workflow_completion(
+            return self._wait_for_completion_with_retry(
                 instance_id,
                 fetch_payloads=fetch_payloads,
                 timeout_in_seconds=effective_timeout,
@@ -547,6 +562,64 @@ class WorkflowRunner(SignalMixin):
             return None
 
     # ----------------------- internal helpers ---------------------------
+
+    def _wait_for_completion_with_retry(
+        self,
+        instance_id: str,
+        *,
+        fetch_payloads: bool,
+        timeout_in_seconds: int,
+    ) -> Optional[WorkflowState]:
+        """
+        Wait for a workflow to complete, retrying the transient 'actor is
+        closed' gRPC error with backoff until the timeout budget is spent.
+
+        The workflow actor can be deactivated (e.g. idle scale-to-zero) while
+        a completion wait is in flight. The workflow itself keeps executing,
+        so instead of surfacing the error, keep polling within the caller's
+        timeout budget. All other errors propagate unchanged.
+
+        Args:
+            instance_id: Workflow instance id.
+            fetch_payloads: Include payloads.
+            timeout_in_seconds: Total time budget for the wait.
+
+        Returns:
+            WorkflowState | None: Final state, or None when the budget was
+            spent retrying deactivated actors.
+        """
+        deadline = time.monotonic() + timeout_in_seconds
+        backoff = 1.0
+        while True:
+            remaining = deadline - time.monotonic()
+            if remaining <= 0:
+                logger.warning(
+                    "[%s] %s: workflow actor stayed deactivated for %ss; "
+                    "giving up on this wait.",
+                    self._name,
+                    instance_id,
+                    timeout_in_seconds,
+                )
+                return None
+            try:
+                return self._wf_client.wait_for_workflow_completion(
+                    instance_id,
+                    fetch_payloads=fetch_payloads,
+                    timeout_in_seconds=min(timeout_in_seconds, remaining),
+                )
+            except grpc.RpcError as exc:
+                if not _is_actor_closed_error(exc):
+                    raise
+                sleep_for = min(backoff, 5.0)
+                logger.warning(
+                    "[%s] %s: workflow actor was deactivated (expected during "
+                    "scale-to-zero); retrying completion wait in %.1fs",
+                    self._name,
+                    instance_id,
+                    sleep_for,
+                )
+                time.sleep(sleep_for)
+                backoff = min(backoff * 2, 5.0)
 
     async def _await_state(
         self,
@@ -567,7 +640,7 @@ class WorkflowRunner(SignalMixin):
         """
 
         def _wait() -> Optional[WorkflowState]:
-            return self._wf_client.wait_for_workflow_completion(
+            return self._wait_for_completion_with_retry(
                 instance_id,
                 fetch_payloads=fetch_payloads,
                 timeout_in_seconds=timeout_in_seconds,

--- a/tests/workflow/test_workflow_runner.py
+++ b/tests/workflow/test_workflow_runner.py
@@ -15,10 +15,13 @@
 
 from __future__ import annotations
 
+import asyncio
+import logging
 import time
 from concurrent.futures import ThreadPoolExecutor, as_completed
 from unittest.mock import MagicMock, patch
 
+import grpc
 import pytest
 
 from dapr_agents.workflow.runners.base import WorkflowRunner
@@ -145,3 +148,120 @@ def test_run_workflow_retry_on_transient_grpc_error():
 
     assert result == "id-retry-success"
     assert client.schedule_new_workflow.call_count == 2
+
+
+# ---------------------------------------------------------------------------
+# Issue #520: 'actor is closed' during completion wait must be retried
+# ---------------------------------------------------------------------------
+
+
+class _FakeRpcError(grpc.RpcError):
+    def __init__(self, code, details):
+        self._code = code
+        self._details = details
+
+    def code(self):
+        return self._code
+
+    def details(self):
+        return self._details
+
+
+class _FakeActorClosedError(_FakeRpcError):
+    def __init__(self):
+        super().__init__(
+            grpc.StatusCode.UNKNOWN, "actor is closed, cannot handle deactivated"
+        )
+
+
+class _FakeClock:
+    """Deterministic monotonic clock so retry loops advance instantly."""
+
+    def __init__(self) -> None:
+        self.now = 1000.0
+
+    def monotonic(self) -> float:
+        return self.now
+
+    def sleep(self, seconds: float) -> None:
+        self.now += seconds
+
+
+def _patch_clock(clock: _FakeClock):
+    return patch.multiple(
+        "dapr_agents.workflow.runners.base.time",
+        monotonic=clock.monotonic,
+        sleep=clock.sleep,
+    )
+
+
+def _completed_state() -> MagicMock:
+    state = MagicMock()
+    state.runtime_status = MagicMock()
+    state.runtime_status.name = "COMPLETED"
+    return state
+
+
+def test_wait_for_workflow_completion_retries_actor_closed(caplog):
+    """'actor is closed' is transient: keep waiting instead of raising."""
+    client = MagicMock()
+    state = _completed_state()
+    client.wait_for_workflow_completion.side_effect = [_FakeActorClosedError(), state]
+    runner = _make_runner(client)
+
+    with _patch_clock(_FakeClock()):
+        result = runner.wait_for_workflow_completion("instance-123")
+
+    assert result is state
+    assert client.wait_for_workflow_completion.call_count == 2
+    assert "actor was deactivated" in caplog.text
+
+
+def test_wait_for_workflow_completion_gives_up_after_budget(caplog):
+    """Persistent deactivation exhausts the budget and returns None."""
+    client = MagicMock()
+    client.wait_for_workflow_completion.side_effect = _FakeActorClosedError()
+    runner = _make_runner(client)
+
+    with _patch_clock(_FakeClock()):
+        result = runner.wait_for_workflow_completion(
+            "instance-123", timeout_in_seconds=1
+        )
+
+    assert result is None
+    assert "stayed deactivated" in caplog.text
+
+
+def test_wait_for_workflow_completion_non_transient_error_unchanged(caplog):
+    """Other gRPC errors keep the existing error-and-None contract."""
+    client = MagicMock()
+    client.wait_for_workflow_completion.side_effect = _FakeRpcError(
+        grpc.StatusCode.INTERNAL, "boom"
+    )
+    runner = _make_runner(client)
+
+    with patch("dapr_agents.workflow.runners.base.time.sleep"):
+        result = runner.wait_for_workflow_completion("instance-123")
+
+    assert result is None
+    assert client.wait_for_workflow_completion.call_count == 1
+    assert "Error while waiting" in caplog.text
+
+
+def test_await_and_log_state_survives_actor_closed(caplog):
+    """The fire-and-forget monitor retries and logs the final state."""
+    client = MagicMock()
+    state = _completed_state()
+    state.serialized_output = "done"
+    client.wait_for_workflow_completion.side_effect = [_FakeActorClosedError(), state]
+    runner = _make_runner(client)
+
+    with (
+        caplog.at_level(logging.INFO, logger="dapr_agents.workflow.runners.base"),
+        _patch_clock(_FakeClock()),
+    ):
+        asyncio.run(runner._await_and_log_state("instance-123", 600, True))
+
+    assert client.wait_for_workflow_completion.call_count == 2
+    assert "completed" in caplog.text
+    assert not any(record.levelno >= logging.ERROR for record in caplog.records)


### PR DESCRIPTION
## Description

The workflow actor can be deactivated (e.g. idle scale-to-zero) while a completion wait is in flight. The Dapr workflow SDK then raises a gRPC error with code `UNKNOWN` and details `"actor is closed, cannot handle deactivated"`. The workflow itself keeps executing, but this transient error surfaced as a full ERROR traceback from the fire-and-forget monitor (`_await_and_log_state`), alarming operators unnecessarily (#520).

Rather than downgrading the log level (the #714 approach), this PR makes the completion wait **actually fulfill its contract**: the transient `actor is closed` error is retried with backoff inside the caller's timeout budget at both completion-wait call sites (`wait_for_workflow_completion` and `_await_state`), so the monitor keeps polling until the actor is re-activated and the workflow completes — or the budget is spent, in which case the wait returns `None` gracefully (no traceback).

All other errors keep their existing behavior (logged at ERROR, wait returns `None`).

## Changes

- Add `_is_actor_closed_error()` helper: matches `grpc.RpcError` with code `UNKNOWN` + `"actor is closed"` details (public `grpc.RpcError` API — no private `grpc._channel._InactiveRpcError` usage).
- Add `_wait_for_completion_with_retry()`: shared retry loop (1s → 5s exponential backoff, bounded by the caller's timeout budget) used by both `wait_for_workflow_completion` and `_await_state`.
- Remove the now-redundant local `import grpc` in `run_workflow` (module-level import added).
- Tests: retry-then-success, budget exhaustion → `None`, non-transient errors unchanged, and the fire-and-forget monitor end-to-end (no ERROR records).

## Testing

- `uv run ruff format && uv run flake8 dapr_agents tests --ignore=E501,F401,W503,E203,E704 && uv run mypy --config-file mypy.ini` — clean
- `uv run pytest tests -m "not integration"` — 1174 passed, 2 failed (pre-existing `tests/llm/test_anthropic.py` failures, confirmed failing on clean main, unrelated to this change)

## Notes

- Fixes #520
- Supersedes #714 (WARNING-only downgrade approach)

## AGENTS.md Notes

- Suggestion: document the transient-error retry policy for completion waits (codes + budget) in AGENTS.md so future contributors extend it consistently instead of adding one-off special cases.
