### PR TITLE
feat(llm): add unified streaming compliance test harness and consolidate stream processing

### DIFF
--- a/dapr_agents/llm/huggingface/utils.py
+++ b/dapr_agents/llm/huggingface/utils.py
@@ -191,6 +191,8 @@ def process_hf_stream(
                 result=LLMChatCandidateChunk(),
                 metadata=overall_meta,
             )
+            if on_chunk:
+                on_chunk(final_response_chunk)
             yield final_response_chunk
 
 

--- a/dapr_agents/llm/huggingface/utils.py
+++ b/dapr_agents/llm/huggingface/utils.py
@@ -17,125 +17,30 @@ from typing import Any, Callable, Dict, Iterator, Optional
 
 from huggingface_hub import ChatCompletionOutput, ChatCompletionStreamOutput
 
+from dapr_agents.llm.utils.stream import (
+    extract_packet_metadata as _get_packet_metadata,
+    process_choice_delta as _process_choice_delta,
+    process_choice_delta_stream,
+)
 from dapr_agents.types.message import (
     AssistantMessage,
     FunctionCall,
     LLMChatCandidate,
-    LLMChatCandidateChunk,
     LLMChatResponse,
     LLMChatResponseChunk,
     ToolCall,
-    ToolCallChunk,
 )
 
 logger = logging.getLogger(__name__)
 
 
-# Helper function to handle metadata extraction
-def _get_packet_metadata(
-    pkt: Dict[str, Any], enrich_metadata: Optional[Dict[str, Any]]
-) -> Dict[str, Any]:
-    """
-    Extract metadata from HuggingFace packet and merge with enrich_metadata.
-
-    Args:
-        pkt (Dict[str, Any]): The HuggingFace packet from which to extract metadata.
-        enrich_metadata (Optional[Dict[str, Any]]): Additional metadata to merge with the extracted metadata.
-
-    Returns:
-        Dict[str, Any]: The merged metadata dictionary.
-    """
-
-    try:
-        return {
-            "id": pkt.get("id"),
-            "created": pkt.get("created"),
-            "model": pkt.get("model"),
-            "object": pkt.get("object"),
-            "service_tier": pkt.get("service_tier"),
-            "system_fingerprint": pkt.get("system_fingerprint"),
-            **(enrich_metadata or {}),
-        }
-    except Exception as e:
-        logger.error(f"Failed to parse packet: {e}", exc_info=True)
-        return {}
-
-
-# Helper function to process each choice delta (content, function call, tool call, finish reason)
-def _process_choice_delta(
-    choice: Dict[str, Any],
-    overall_meta: Dict[str, Any],
-    on_chunk: Optional[Callable],
-    first_chunk_flag: bool,
-) -> Iterator[LLMChatResponseChunk]:
-    """
-    Process each choice delta and yield corresponding chunks.
-
-    Args:
-        choice (Dict[str, Any]): The choice delta from HuggingFace response.
-        overall_meta (Dict[str, Any]): Overall metadata to include in chunks.
-        on_chunk (Optional[Callable]): Callback for each chunk.
-        first_chunk_flag (bool): Flag indicating if this is the first chunk.
-
-    Yields:
-        LLMChatResponseChunk: The processed chunk with content, function call, tool calls,
-    """
-    # Make an immutable snapshot for this single chunk
-    meta = {**overall_meta}
-
-    # mark first_chunk exactly once
-    if first_chunk_flag and "first_chunk" not in meta:
-        meta["first_chunk"] = True
-
-    # Extract initial properties from choice
-    delta: dict = choice.get("delta", {})
-    idx = choice.get("index")
-    finish_reason = choice.get("finish_reason", None)
-    logprobs = choice.get("logprobs", None)
-
-    # Set additional metadata
-    if finish_reason in ("stop", "tool_calls"):
-        meta["last_chunk"] = True
-
-    # Process content delta
-    content = delta.get("content", None)
-    function_call = delta.get("function_call", None)
-    refusal = delta.get("refusal", None)
-    role = delta.get("role", None)
-
-    # Process tool calls
-    chunk_tool_calls = [ToolCallChunk(**tc) for tc in (delta.get("tool_calls") or [])]
-
-    # Initialize LLMChatResponseChunk
-    response_chunk = LLMChatResponseChunk(
-        result=LLMChatCandidateChunk(
-            content=content,
-            function_call=function_call,
-            refusal=refusal,
-            role=role,
-            tool_calls=chunk_tool_calls,
-            finish_reason=finish_reason,
-            index=idx,
-            logprobs=logprobs,
-        ),
-        metadata=meta,
-    )
-    # Process chunk with on_chunk callback
-    if on_chunk:
-        on_chunk(response_chunk)
-    # Yield LLMChatResponseChunk
-    yield response_chunk
-
-
-# Main function to process HuggingFace streaming response
 def process_hf_stream(
     raw_stream: Iterator[ChatCompletionStreamOutput],
     *,
     enrich_metadata: Optional[Dict[str, Any]] = None,
-    on_chunk: Optional[Callable],
+    on_chunk: Optional[Callable] = None,
 ) -> Iterator[LLMChatResponseChunk]:
-    """
-    Normalize HuggingFace streaming chat into LLMChatResponseChunk objects,
+    """Normalize HuggingFace streaming chat into LLMChatResponseChunk objects,
     accumulating buffers per choice and yielding both partial and final chunks.
 
     Args:
@@ -146,54 +51,11 @@ def process_hf_stream(
     Yields:
         LLMChatResponseChunk for every partial and final piece, in stream order
     """
-    enrich_metadata = enrich_metadata or {}
-    overall_meta: Dict[str, Any] = {}
-
-    # Track if we are in the first chunk
-    first_chunk_flag = True
-
-    for packet in raw_stream:
-        # Convert Pydantic / HuggingFaceObject → plain dict
-        if hasattr(packet, "model_dump"):
-            pkt = packet.model_dump()
-        elif hasattr(packet, "to_dict"):
-            pkt = packet.to_dict()
-        elif dataclasses.is_dataclass(packet):
-            pkt = dataclasses.asdict(packet)
-        else:
-            raise TypeError(f"Cannot serialize packet of type {type(packet)}")
-
-        # Capture overall metadata from the packet
-        overall_meta = _get_packet_metadata(pkt, enrich_metadata)
-
-        # Process each choice in this packet
-        if choices := pkt.get("choices"):
-            if len(choices) == 0:
-                logger.warning(
-                    "Received empty 'choices' in HuggingFace packet, skipping."
-                )
-                continue
-            # Process the first choice in the packet
-            choice = choices[0]
-            yield from _process_choice_delta(
-                choice, overall_meta, on_chunk, first_chunk_flag
-            )
-            # Set first_chunk_flag to False after processing the first choice
-            first_chunk_flag = False
-        else:
-            logger.debug(
-                "Yielding final packet without 'choices' (usage-only): %s", pkt
-            )
-            # Final usage-only packet (empty ``choices``). ``result`` is required
-            # on LLMChatResponseChunk, so carry an empty candidate; usage data
-            # rides along in ``metadata`` and is folded into TURN_COMPLETE.
-            final_response_chunk = LLMChatResponseChunk(
-                result=LLMChatCandidateChunk(),
-                metadata=overall_meta,
-            )
-            if on_chunk:
-                on_chunk(final_response_chunk)
-            yield final_response_chunk
+    yield from process_choice_delta_stream(
+        raw_stream=raw_stream,
+        enrich_metadata=enrich_metadata,
+        on_chunk=on_chunk,
+    )
 
 
 def process_hf_chat_response(response: ChatCompletionOutput) -> LLMChatResponse:
@@ -280,3 +142,11 @@ def process_hf_chat_response(response: ChatCompletionOutput) -> LLMChatResponse:
     }
 
     return LLMChatResponse(results=candidates, metadata=metadata)
+
+
+__all__ = [
+    "process_hf_stream",
+    "process_hf_chat_response",
+    "_get_packet_metadata",
+    "_process_choice_delta",
+]

--- a/dapr_agents/llm/openai/utils.py
+++ b/dapr_agents/llm/openai/utils.py
@@ -17,125 +17,30 @@ from typing import Any, Callable, Dict, Iterator, Optional
 
 from openai.types.chat import ChatCompletion, ChatCompletionChunk
 
+from dapr_agents.llm.utils.stream import (
+    extract_packet_metadata as _get_packet_metadata,
+    process_choice_delta as _process_choice_delta,
+    process_choice_delta_stream,
+)
 from dapr_agents.types.message import (
     AssistantMessage,
     FunctionCall,
     LLMChatCandidate,
-    LLMChatCandidateChunk,
-    LLMChatResponseChunk,
     LLMChatResponse,
+    LLMChatResponseChunk,
     ToolCall,
-    ToolCallChunk,
 )
 
 logger = logging.getLogger(__name__)
 
 
-# Helper function to handle metadata extraction
-def _get_packet_metadata(
-    pkt: Dict[str, Any], enrich_metadata: Optional[Dict[str, Any]]
-) -> Dict[str, Any]:
-    """
-    Extract metadata from OpenAI packet and merge with enrich_metadata.
-
-    Args:
-        pkt (Dict[str, Any]): The OpenAI packet from which to extract metadata.
-        enrich_metadata (Optional[Dict[str, Any]]): Additional metadata to merge with the extracted metadata.
-
-    Returns:
-        Dict[str, Any]: The merged metadata dictionary.
-    """
-
-    try:
-        return {
-            "id": pkt.get("id"),
-            "created": pkt.get("created"),
-            "model": pkt.get("model"),
-            "object": pkt.get("object"),
-            "service_tier": pkt.get("service_tier"),
-            "system_fingerprint": pkt.get("system_fingerprint"),
-            **(enrich_metadata or {}),
-        }
-    except Exception as e:
-        logger.error(f"Failed to parse packet: {e}", exc_info=True)
-        return {}
-
-
-# Helper function to process each choice delta (content, function call, tool call, finish reason)
-def _process_choice_delta(
-    choice: Dict[str, Any],
-    overall_meta: Dict[str, Any],
-    on_chunk: Optional[Callable],
-    first_chunk_flag: bool,
-) -> Iterator[LLMChatResponseChunk]:
-    """
-    Process each choice delta and yield corresponding chunks.
-
-    Args:
-        choice (Dict[str, Any]): The choice delta from OpenAI response.
-        overall_meta (Dict[str, Any]): Overall metadata to include in chunks.
-        on_chunk (Optional[Callable]): Callback for each chunk.
-        first_chunk_flag (bool): Flag indicating if this is the first chunk.
-
-    Yields:
-        LLMChatResponseChunk: The processed chunk with content, function call, tool calls,
-    """
-    # Make an immutable snapshot for this single chunk
-    meta = {**overall_meta}
-
-    # mark first_chunk exactly once
-    if first_chunk_flag and "first_chunk" not in meta:
-        meta["first_chunk"] = True
-
-    # Extract initial properties from choice
-    delta: dict = choice.get("delta", {})
-    idx = choice.get("index")
-    finish_reason = choice.get("finish_reason", None)
-    logprobs = choice.get("logprobs", None)
-
-    # Set additional metadata
-    if finish_reason in ("stop", "tool_calls"):
-        meta["last_chunk"] = True
-
-    # Process content delta
-    content = delta.get("content", None)
-    function_call = delta.get("function_call", None)
-    refusal = delta.get("refusal", None)
-    role = delta.get("role", None)
-
-    # Process tool calls
-    chunk_tool_calls = [ToolCallChunk(**tc) for tc in (delta.get("tool_calls") or [])]
-
-    # Initialize LLMChatResponseChunk
-    response_chunk = LLMChatResponseChunk(
-        result=LLMChatCandidateChunk(
-            content=content,
-            function_call=function_call,
-            refusal=refusal,
-            role=role,
-            tool_calls=chunk_tool_calls,
-            finish_reason=finish_reason,
-            index=idx,
-            logprobs=logprobs,
-        ),
-        metadata=meta,
-    )
-    # Process chunk with on_chunk callback
-    if on_chunk:
-        on_chunk(response_chunk)
-    # Yield LLMChatResponseChunk
-    yield response_chunk
-
-
-# Main function to process OpenAI streaming response
 def process_openai_stream(
     raw_stream: Iterator[ChatCompletionChunk],
     *,
     enrich_metadata: Optional[Dict[str, Any]] = None,
-    on_chunk: Optional[Callable],
+    on_chunk: Optional[Callable] = None,
 ) -> Iterator[LLMChatResponseChunk]:
-    """
-    Normalize OpenAI streaming chat into LLMChatResponseChunk objects,
+    """Normalize OpenAI streaming chat into LLMChatResponseChunk objects,
     accumulating buffers per choice and yielding both partial and final chunks.
 
     Args:
@@ -146,53 +51,11 @@ def process_openai_stream(
     Yields:
         LLMChatResponseChunk for every partial and final piece, in stream order
     """
-    enrich_metadata = enrich_metadata or {}
-    overall_meta: Dict[str, Any] = {}
-
-    # Track if we are in the first chunk
-    first_chunk_flag = True
-
-    for packet in raw_stream:
-        # Convert Pydantic / OpenAIObject → plain dict
-        if hasattr(packet, "model_dump"):
-            pkt = packet.model_dump()
-        elif hasattr(packet, "to_dict"):
-            pkt = packet.to_dict()
-        elif dataclasses.is_dataclass(packet):
-            pkt = dataclasses.asdict(packet)
-        else:
-            raise TypeError(f"Cannot serialize packet of type {type(packet)}")
-
-        # Capture overall metadata from the packet
-        overall_meta = _get_packet_metadata(pkt, enrich_metadata)
-
-        # Process each choice in this packet
-        if choices := pkt.get("choices"):
-            if len(choices) == 0:
-                logger.warning("Received empty 'choices' in OpenAI packet, skipping.")
-                continue
-            # Process the first choice in the packet
-            choice = choices[0]
-            yield from _process_choice_delta(
-                choice, overall_meta, on_chunk, first_chunk_flag
-            )
-            # Set first_chunk_flag to False after processing the first choice
-            first_chunk_flag = False
-        else:
-            logger.debug(
-                "Yielding final packet without 'choices' (usage-only): %s", pkt
-            )
-            # Final usage-only packet (empty ``choices``) sent by OpenAI when
-            # ``stream_options.include_usage`` is on. ``result`` is required on
-            # LLMChatResponseChunk, so carry an empty candidate; the usage data
-            # rides along in ``metadata`` and is folded into TURN_COMPLETE.
-            final_response_chunk = LLMChatResponseChunk(
-                result=LLMChatCandidateChunk(),
-                metadata=overall_meta,
-            )
-            if on_chunk:
-                on_chunk(final_response_chunk)
-            yield final_response_chunk
+    yield from process_choice_delta_stream(
+        raw_stream=raw_stream,
+        enrich_metadata=enrich_metadata,
+        on_chunk=on_chunk,
+    )
 
 
 def process_openai_chat_response(openai_response: ChatCompletion) -> LLMChatResponse:
@@ -287,3 +150,11 @@ def process_openai_chat_response(openai_response: ChatCompletion) -> LLMChatResp
     }
 
     return LLMChatResponse(results=candidates, metadata=metadata)
+
+
+__all__ = [
+    "process_openai_stream",
+    "process_openai_chat_response",
+    "_get_packet_metadata",
+    "_process_choice_delta",
+]

--- a/dapr_agents/llm/openai/utils.py
+++ b/dapr_agents/llm/openai/utils.py
@@ -190,6 +190,8 @@ def process_openai_stream(
                 result=LLMChatCandidateChunk(),
                 metadata=overall_meta,
             )
+            if on_chunk:
+                on_chunk(final_response_chunk)
             yield final_response_chunk
 
 

--- a/dapr_agents/llm/utils/__init__.py
+++ b/dapr_agents/llm/utils/__init__.py
@@ -14,7 +14,7 @@
 from .http import HTTPHelper
 from .request import RequestHandler
 from .response import ResponseHandler
-from .stream import StreamHandler
+from .stream import StreamHandler, process_choice_delta_stream
 from .structure import StructureHandler
 
 __all__ = [
@@ -23,4 +23,5 @@ __all__ = [
     "RequestHandler",
     "ResponseHandler",
     "HTTPHelper",
+    "process_choice_delta_stream",
 ]

--- a/dapr_agents/llm/utils/stream.py
+++ b/dapr_agents/llm/utils/stream.py
@@ -17,6 +17,7 @@ from typing import (
     Any,
     Callable,
     Dict,
+    Iterable,
     Iterator,
     Optional,
     TypeVar,
@@ -48,15 +49,19 @@ def extract_packet_metadata(
         Dict[str, Any]: The merged metadata dictionary.
     """
     try:
-        return {
+        meta: Dict[str, Any] = {
             "id": pkt.get("id"),
             "created": pkt.get("created"),
             "model": pkt.get("model"),
             "object": pkt.get("object"),
             "service_tier": pkt.get("service_tier"),
             "system_fingerprint": pkt.get("system_fingerprint"),
-            **(enrich_metadata or {}),
         }
+        if "usage" in pkt and pkt["usage"] is not None:
+            meta["usage"] = pkt["usage"]
+        if enrich_metadata:
+            meta.update(enrich_metadata)
+        return meta
     except Exception as e:
         logger.error(f"Failed to parse packet: {e}", exc_info=True)
         return {}
@@ -91,10 +96,13 @@ def process_choice_delta(
         meta["first_chunk"] = True
 
     # Extract initial properties from choice
-    delta: dict = choice.get("delta") or {}
-    idx = choice.get("index")
-    finish_reason = choice.get("finish_reason", None)
-    logprobs = choice.get("logprobs", None)
+    choice_dict = choice or {}
+    delta: dict = choice_dict.get("delta") or {}
+    if not isinstance(delta, dict):
+        delta = {}
+    idx = choice_dict.get("index")
+    finish_reason = choice_dict.get("finish_reason", None)
+    logprobs = choice_dict.get("logprobs", None)
 
     # Set additional metadata
     if finish_reason in ("stop", "tool_calls"):
@@ -106,8 +114,13 @@ def process_choice_delta(
     refusal = delta.get("refusal", None)
     role = delta.get("role", None)
 
-    # Process tool calls
-    chunk_tool_calls = [ToolCallChunk(**tc) for tc in (delta.get("tool_calls") or [])]
+    # Process tool calls defensively
+    chunk_tool_calls = []
+    for tc in delta.get("tool_calls") or []:
+        try:
+            chunk_tool_calls.append(ToolCallChunk(**tc))
+        except Exception as e:
+            logger.warning(f"Invalid tool_call entry in delta {tc}: {e}")
 
     # Initialize LLMChatResponseChunk
     response_chunk = LLMChatResponseChunk(
@@ -135,7 +148,7 @@ _process_choice_delta = process_choice_delta
 
 
 def process_choice_delta_stream(
-    raw_stream: Iterator[Any],
+    raw_stream: Iterable[Any],
     *,
     enrich_metadata: Optional[Dict[str, Any]] = None,
     on_chunk: Optional[Callable] = None,
@@ -155,45 +168,54 @@ def process_choice_delta_stream(
         LLMChatResponseChunk for every partial and final piece, in stream order.
     """
     enrich_metadata = enrich_metadata or {}
-    overall_meta: Dict[str, Any] = {}
-
     first_chunk_flag = True
 
-    for packet in raw_stream:
-        # Convert Pydantic / SDK object -> plain dict
-        if hasattr(packet, "model_dump"):
-            pkt = packet.model_dump()
-        elif hasattr(packet, "to_dict"):
-            pkt = packet.to_dict()
-        elif dataclasses.is_dataclass(packet):
-            pkt = dataclasses.asdict(packet)
-        else:
-            raise TypeError(f"Cannot serialize packet of type {type(packet)}")
+    try:
+        for packet in raw_stream:
+            # Convert Pydantic / SDK object -> plain dict
+            if hasattr(packet, "model_dump"):
+                pkt = packet.model_dump()
+            elif hasattr(packet, "to_dict"):
+                pkt = packet.to_dict()
+            elif dataclasses.is_dataclass(packet):
+                pkt = dataclasses.asdict(packet)
+            else:
+                raise TypeError(f"Cannot serialize packet of type {type(packet)}")
 
-        overall_meta = extract_packet_metadata(pkt, enrich_metadata)
+            overall_meta = extract_packet_metadata(pkt, enrich_metadata)
 
-        choices = pkt.get("choices")
-        if choices:
-            choice = choices[0]
-            yield from process_choice_delta(
-                choice, overall_meta, on_chunk, first_chunk_flag
-            )
-            first_chunk_flag = False
-        else:
-            logger.debug(
-                "Yielding final packet without 'choices' (usage-only): %s", pkt
-            )
-            # Final usage-only packet (empty ``choices``) sent when usage reporting
-            # is enabled. ``result`` is required on LLMChatResponseChunk, so carry
-            # an empty candidate; usage data rides along in ``metadata`` and is
-            # folded into TURN_COMPLETE.
-            final_response_chunk = LLMChatResponseChunk(
-                result=LLMChatCandidateChunk(),
-                metadata=overall_meta,
-            )
-            if on_chunk:
-                on_chunk(final_response_chunk)
-            yield final_response_chunk
+            choices = pkt.get("choices")
+            if choices:
+                for choice in choices:
+                    if not choice:
+                        continue
+                    yield from process_choice_delta(
+                        choice, overall_meta, on_chunk, first_chunk_flag
+                    )
+                    first_chunk_flag = False
+            else:
+                logger.debug(
+                    "Yielding final packet without 'choices' (usage-only): %s", pkt
+                )
+                # Final usage-only packet (empty ``choices``) sent when usage reporting
+                # is enabled. ``result`` is required on LLMChatResponseChunk, so carry
+                # an empty candidate; usage data rides along in ``metadata`` and is
+                # folded into TURN_COMPLETE.
+                final_response_chunk = LLMChatResponseChunk(
+                    result=LLMChatCandidateChunk(),
+                    metadata={**overall_meta},
+                )
+                if on_chunk:
+                    on_chunk(final_response_chunk)
+                yield final_response_chunk
+    finally:
+        if hasattr(raw_stream, "__exit__"):
+            raw_stream.__exit__(None, None, None)
+        elif hasattr(raw_stream, "close"):
+            try:
+                raw_stream.close()
+            except Exception:
+                pass
 
 
 class StreamHandler:
@@ -204,7 +226,7 @@ class StreamHandler:
 
     @staticmethod
     def process_stream(
-        stream: Iterator[Any],
+        stream: Iterable[Any],
         llm_provider: str,
         on_chunk: Optional[Callable] = None,
     ) -> Iterator[LLMChatResponseChunk]:
@@ -218,7 +240,8 @@ class StreamHandler:
         Yields:
             LLMChatResponseChunk: fully-typed chunks, partial and final.
         """
-        if llm_provider in (
+        provider = llm_provider.lower() if llm_provider else ""
+        if provider in (
             "openai",
             "nvidia",
             "litellm",
@@ -227,15 +250,15 @@ class StreamHandler:
         ):
             yield from process_choice_delta_stream(
                 raw_stream=stream,
-                enrich_metadata={"provider": llm_provider},
+                enrich_metadata={"provider": provider},
                 on_chunk=on_chunk,
             )
-        elif llm_provider in ("anthropic", "claude"):
+        elif provider in ("anthropic", "claude"):
             from dapr_agents.llm.anthropic.utils import process_anthropic_stream
 
             yield from process_anthropic_stream(
                 raw_stream=stream,
-                enrich_metadata={"provider": llm_provider},
+                enrich_metadata={"provider": provider},
                 on_chunk=on_chunk,
             )
         else:

--- a/dapr_agents/llm/utils/stream.py
+++ b/dapr_agents/llm/utils/stream.py
@@ -11,9 +11,12 @@
 # limitations under the License.
 #
 
+import dataclasses
+import logging
 from typing import (
     Any,
     Callable,
+    Dict,
     Iterator,
     Optional,
     TypeVar,
@@ -21,14 +24,180 @@ from typing import (
 
 from pydantic import BaseModel
 
-from dapr_agents.types.message import LLMChatResponseChunk
+from dapr_agents.types.message import (
+    LLMChatCandidateChunk,
+    LLMChatResponseChunk,
+    ToolCallChunk,
+)
+
+logger = logging.getLogger(__name__)
 
 T = TypeVar("T", bound=BaseModel)
 
 
-class StreamHandler:
+def extract_packet_metadata(
+    pkt: Dict[str, Any], enrich_metadata: Optional[Dict[str, Any]] = None
+) -> Dict[str, Any]:
+    """Extract standard completion metadata from packet and merge with enrich_metadata.
+
+    Args:
+        pkt (Dict[str, Any]): The packet from which to extract metadata.
+        enrich_metadata (Optional[Dict[str, Any]]): Additional metadata to merge.
+
+    Returns:
+        Dict[str, Any]: The merged metadata dictionary.
     """
-    Handles streaming of chat completion responses, delegating to the
+    try:
+        return {
+            "id": pkt.get("id"),
+            "created": pkt.get("created"),
+            "model": pkt.get("model"),
+            "object": pkt.get("object"),
+            "service_tier": pkt.get("service_tier"),
+            "system_fingerprint": pkt.get("system_fingerprint"),
+            **(enrich_metadata or {}),
+        }
+    except Exception as e:
+        logger.error(f"Failed to parse packet: {e}", exc_info=True)
+        return {}
+
+
+# Backward-compatible alias
+_get_packet_metadata = extract_packet_metadata
+
+
+def process_choice_delta(
+    choice: Dict[str, Any],
+    overall_meta: Dict[str, Any],
+    on_chunk: Optional[Callable] = None,
+    first_chunk_flag: bool = False,
+) -> Iterator[LLMChatResponseChunk]:
+    """Process each choice delta and yield corresponding chunks.
+
+    Args:
+        choice (Dict[str, Any]): The choice delta from LLM response packet.
+        overall_meta (Dict[str, Any]): Overall metadata to include in chunks.
+        on_chunk (Optional[Callable]): Callback for each chunk.
+        first_chunk_flag (bool): Flag indicating if this is the first chunk.
+
+    Yields:
+        LLMChatResponseChunk: The processed chunk with content, function call, tool calls.
+    """
+    # Make an immutable snapshot for this single chunk
+    meta = {**overall_meta}
+
+    # mark first_chunk exactly once
+    if first_chunk_flag and "first_chunk" not in meta:
+        meta["first_chunk"] = True
+
+    # Extract initial properties from choice
+    delta: dict = choice.get("delta") or {}
+    idx = choice.get("index")
+    finish_reason = choice.get("finish_reason", None)
+    logprobs = choice.get("logprobs", None)
+
+    # Set additional metadata
+    if finish_reason in ("stop", "tool_calls"):
+        meta["last_chunk"] = True
+
+    # Process content delta
+    content = delta.get("content", None)
+    function_call = delta.get("function_call", None)
+    refusal = delta.get("refusal", None)
+    role = delta.get("role", None)
+
+    # Process tool calls
+    chunk_tool_calls = [ToolCallChunk(**tc) for tc in (delta.get("tool_calls") or [])]
+
+    # Initialize LLMChatResponseChunk
+    response_chunk = LLMChatResponseChunk(
+        result=LLMChatCandidateChunk(
+            content=content,
+            function_call=function_call,
+            refusal=refusal,
+            role=role,
+            tool_calls=chunk_tool_calls,
+            finish_reason=finish_reason,
+            index=idx,
+            logprobs=logprobs,
+        ),
+        metadata=meta,
+    )
+    # Process chunk with on_chunk callback
+    if on_chunk:
+        on_chunk(response_chunk)
+    # Yield LLMChatResponseChunk
+    yield response_chunk
+
+
+# Backward-compatible alias
+_process_choice_delta = process_choice_delta
+
+
+def process_choice_delta_stream(
+    raw_stream: Iterator[Any],
+    *,
+    enrich_metadata: Optional[Dict[str, Any]] = None,
+    on_chunk: Optional[Callable] = None,
+) -> Iterator[LLMChatResponseChunk]:
+    """Normalize streaming chat completion responses following the choice-delta format.
+
+    Used by OpenAI, Hugging Face, Nvidia, LiteLLM, and iFlytek to turn SDK chunk packets
+    into standardized LLMChatResponseChunk objects, accumulating buffers per choice and
+    yielding both partial and final chunks.
+
+    Args:
+        raw_stream: Raw iterator of chunk packets from the provider SDK.
+        enrich_metadata: Extra key/value pairs to merge into each chunk.metadata.
+        on_chunk: Callback fired on every partial delta (token, function, tool, usage).
+
+    Yields:
+        LLMChatResponseChunk for every partial and final piece, in stream order.
+    """
+    enrich_metadata = enrich_metadata or {}
+    overall_meta: Dict[str, Any] = {}
+
+    first_chunk_flag = True
+
+    for packet in raw_stream:
+        # Convert Pydantic / SDK object -> plain dict
+        if hasattr(packet, "model_dump"):
+            pkt = packet.model_dump()
+        elif hasattr(packet, "to_dict"):
+            pkt = packet.to_dict()
+        elif dataclasses.is_dataclass(packet):
+            pkt = dataclasses.asdict(packet)
+        else:
+            raise TypeError(f"Cannot serialize packet of type {type(packet)}")
+
+        overall_meta = extract_packet_metadata(pkt, enrich_metadata)
+
+        choices = pkt.get("choices")
+        if choices:
+            choice = choices[0]
+            yield from process_choice_delta(
+                choice, overall_meta, on_chunk, first_chunk_flag
+            )
+            first_chunk_flag = False
+        else:
+            logger.debug(
+                "Yielding final packet without 'choices' (usage-only): %s", pkt
+            )
+            # Final usage-only packet (empty ``choices``) sent when usage reporting
+            # is enabled. ``result`` is required on LLMChatResponseChunk, so carry
+            # an empty candidate; usage data rides along in ``metadata`` and is
+            # folded into TURN_COMPLETE.
+            final_response_chunk = LLMChatResponseChunk(
+                result=LLMChatCandidateChunk(),
+                metadata=overall_meta,
+            )
+            if on_chunk:
+                on_chunk(final_response_chunk)
+            yield final_response_chunk
+
+
+class StreamHandler:
+    """Handles streaming of chat completion responses, delegating to the
     provider-specific stream processor and optionally validating output
     against Pydantic models.
     """
@@ -39,8 +208,7 @@ class StreamHandler:
         llm_provider: str,
         on_chunk: Optional[Callable] = None,
     ) -> Iterator[LLMChatResponseChunk]:
-        """
-        Process a streaming chat completion.
+        """Process a streaming chat completion.
 
         Args:
             stream:           Raw stream object or iterator from the provider SDK.
@@ -50,19 +218,14 @@ class StreamHandler:
         Yields:
             LLMChatResponseChunk: fully-typed chunks, partial and final.
         """
-
-        if llm_provider in ("openai", "nvidia", "litellm", "iflytek"):
-            from dapr_agents.llm.openai.utils import process_openai_stream
-
-            yield from process_openai_stream(
-                raw_stream=stream,
-                enrich_metadata={"provider": llm_provider},
-                on_chunk=on_chunk,
-            )
-        elif llm_provider == "huggingface":
-            from dapr_agents.llm.huggingface.utils import process_hf_stream
-
-            yield from process_hf_stream(
+        if llm_provider in (
+            "openai",
+            "nvidia",
+            "litellm",
+            "iflytek",
+            "huggingface",
+        ):
+            yield from process_choice_delta_stream(
                 raw_stream=stream,
                 enrich_metadata={"provider": llm_provider},
                 on_chunk=on_chunk,
@@ -77,3 +240,13 @@ class StreamHandler:
             )
         else:
             raise ValueError(f"Streaming not supported for provider: {llm_provider}")
+
+
+__all__ = [
+    "StreamHandler",
+    "extract_packet_metadata",
+    "process_choice_delta",
+    "process_choice_delta_stream",
+    "_get_packet_metadata",
+    "_process_choice_delta",
+]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -61,7 +61,7 @@ dependencies = [
     "openinference-instrumentation>=0.1.0,<1.0.0",
     "openinference-semantic-conventions>=0.1.0,<1.0.0",
     "mistralai>=2.2.0",
-    "anthropic>=0.98.0,<1.0.0",
+    "anthropic>=0.98.0,<2.0.0",
     "opentelemetry-instrumentation-grpc>=0.60b1,<0.61",
     "opentelemetry-exporter-zipkin-json>=1.36.0",
     "opentelemetry-instrumentation-httpx>=0.60b1,<0.61",
@@ -131,6 +131,7 @@ dapr = "2026-05-21T00:00:00Z"
 dapr-ext-fastapi = "2026-05-21T00:00:00Z"
 dapr-ext-workflow = "2026-05-21T00:00:00Z"
 durabletask-dapr = "2026-05-21T00:00:00Z"
+anthropic = "2026-08-23T00:00:00Z"
 
 [project.urls]
 Documentation = "https://github.com/dapr/docs"

--- a/tests/llm/streaming_test_harness.py
+++ b/tests/llm/streaming_test_harness.py
@@ -1,0 +1,153 @@
+#
+# Copyright 2026 The Dapr Authors
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#     http://www.apache.org/licenses/LICENSE-2.0
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+"""Reusable compliance harness for verifying LLM streaming implementations.
+
+Validates that provider-specific stream processors and the centralized
+`StreamHandler.process_stream` conform to the canonical `LLMChatResponseChunk`
+streaming specification.
+"""
+
+from __future__ import annotations
+
+import json
+from typing import Any, Callable, Dict, Iterator, List, Optional, Sequence
+
+from dapr_agents.types.message import LLMChatCandidateChunk, LLMChatResponseChunk
+from dapr_agents.types.streaming import AssistantMessageAccumulator
+
+
+class StreamingComplianceHarness:
+    """Reusable assertions and test helpers for LLM provider streaming pipelines."""
+
+    @staticmethod
+    def assert_valid_stream_contract(
+        chunks: Sequence[LLMChatResponseChunk],
+        expected_provider: Optional[str] = None,
+        expected_min_chunks: int = 1,
+    ) -> None:
+        """Validate envelope and typing invariants across all stream chunks.
+
+        - Every item must be an instance of LLMChatResponseChunk.
+        - Every chunk must have a non-null result of type LLMChatCandidateChunk.
+        - Every chunk must have a metadata dictionary.
+        - If expected_provider is set, metadata["provider"] must match.
+        """
+        assert len(chunks) >= expected_min_chunks, (
+            f"Expected at least {expected_min_chunks} chunks, got {len(chunks)}"
+        )
+        for i, chunk in enumerate(chunks):
+            assert isinstance(chunk, LLMChatResponseChunk), (
+                f"Chunk {i} is not an LLMChatResponseChunk (type: {type(chunk)})"
+            )
+            assert isinstance(chunk.result, LLMChatCandidateChunk), (
+                f"Chunk {i}.result is not an LLMChatCandidateChunk (type: {type(chunk.result)})"
+            )
+            assert isinstance(chunk.metadata, dict), (
+                f"Chunk {i}.metadata is not a dict (type: {type(chunk.metadata)})"
+            )
+            if expected_provider is not None:
+                actual_provider = chunk.metadata.get("provider")
+                assert actual_provider == expected_provider, (
+                    f"Chunk {i} provider mismatch: expected '{expected_provider}', got '{actual_provider}'"
+                )
+
+    @staticmethod
+    def assert_reconstructs_text(
+        chunks: Sequence[LLMChatResponseChunk],
+        expected_text: str,
+        expected_finish_reason: Optional[str] = "stop",
+    ) -> None:
+        """Validate that text content deltas fold into the expected assistant message."""
+        accumulator = AssistantMessageAccumulator()
+        for chunk in chunks:
+            accumulator.ingest(chunk)
+
+        msg = accumulator.assistant_message()
+        actual_content = msg.get("content")
+        assert actual_content == expected_text, (
+            f"Reconstructed text mismatch: expected '{expected_text}', got '{actual_content}'"
+        )
+        if expected_finish_reason is not None:
+            assert accumulator.finish_reason == expected_finish_reason, (
+                f"Finish reason mismatch: expected '{expected_finish_reason}', got '{accumulator.finish_reason}'"
+            )
+
+    @staticmethod
+    def assert_reconstructs_tool_calls(
+        chunks: Sequence[LLMChatResponseChunk],
+        expected_tools: Sequence[Dict[str, Any]],
+        expected_finish_reason: Optional[str] = "tool_calls",
+    ) -> None:
+        """Validate that streaming tool call deltas reconstruct into full tool calls."""
+        accumulator = AssistantMessageAccumulator()
+        for chunk in chunks:
+            accumulator.ingest(chunk)
+
+        msg = accumulator.assistant_message()
+        tool_calls = msg.get("tool_calls")
+        assert tool_calls is not None, "Reconstructed message contains no tool_calls"
+        assert len(tool_calls) == len(expected_tools), (
+            f"Expected {len(expected_tools)} tool call(s), got {len(tool_calls)}"
+        )
+
+        for i, (actual, expected) in enumerate(zip(tool_calls, expected_tools)):
+            if "name" in expected:
+                assert actual.get("function", {}).get("name") == expected["name"], (
+                    f"Tool {i} name mismatch: expected '{expected['name']}', got '{actual.get('function', {}).get('name')}'"
+                )
+            if "arguments" in expected:
+                actual_args = actual.get("function", {}).get("arguments", "")
+                expected_args = expected["arguments"]
+                if isinstance(expected_args, dict):
+                    assert json.loads(actual_args) == expected_args
+                else:
+                    assert expected_args in actual_args
+
+        if expected_finish_reason is not None:
+            assert accumulator.finish_reason == expected_finish_reason, (
+                f"Finish reason mismatch: expected '{expected_finish_reason}', got '{accumulator.finish_reason}'"
+            )
+
+    @staticmethod
+    def assert_on_chunk_callback_lifecycle(
+        stream_factory: Callable[
+            [Callable[[LLMChatResponseChunk], None]], Iterator[LLMChatResponseChunk]
+        ],
+    ) -> List[LLMChatResponseChunk]:
+        """Verify on_chunk callback receives every yielded chunk in identical order and identity."""
+        captured: List[LLMChatResponseChunk] = []
+        yielded = list(stream_factory(captured.append))
+
+        assert len(captured) == len(yielded), (
+            f"Callback count mismatch: on_chunk fired {len(captured)} times, yielded {len(yielded)} chunks"
+        )
+        for i, (c, y) in enumerate(zip(captured, yielded)):
+            assert c is y, (
+                f"Chunk {i} passed to on_chunk is not identical to yielded chunk"
+            )
+
+        return yielded
+
+    @staticmethod
+    def assert_snapshot_isolation(
+        chunks: Sequence[LLMChatResponseChunk],
+    ) -> None:
+        """Verify that buffered chunks do not share mutable metadata dictionaries."""
+        if len(chunks) < 2:
+            return
+
+        for i in range(len(chunks) - 1):
+            assert chunks[i].metadata is not chunks[i + 1].metadata, (
+                f"Chunk {i} and {i + 1} share the same metadata dict reference (missing snapshot isolation)"
+            )

--- a/tests/llm/test_anthropic.py
+++ b/tests/llm/test_anthropic.py
@@ -29,6 +29,7 @@ from dapr_agents.types.message import (
     ToolCall,
     UserMessage,
 )
+from tests.llm.streaming_test_harness import StreamingComplianceHarness
 
 
 def _stream_cm(events: Iterable):
@@ -385,14 +386,14 @@ def test_anthropic_generate_streaming(mock_anthropic_class):
     client = AnthropicChatClient(api_key="fake-key")
     chunks = list(client.generate("hi", stream=True))
 
-    assert chunks and all(isinstance(c, LLMChatResponseChunk) for c in chunks)
-    text = "".join(c.result.content or "" for c in chunks if c.result.content)
-    assert text == "Hello"
-    finish = [c.result.finish_reason for c in chunks if c.result.finish_reason]
-    assert finish == ["end_turn"]
+    StreamingComplianceHarness.assert_valid_stream_contract(chunks, "anthropic")
+    StreamingComplianceHarness.assert_reconstructs_text(
+        chunks, expected_text="Hello", expected_finish_reason="end_turn"
+    )
+    StreamingComplianceHarness.assert_snapshot_isolation(chunks)
+
     # metadata is enriched mid-stream from message_start + message_delta.usage
     last_meta = chunks[-1].metadata
-    assert last_meta["provider"] == "anthropic"
     assert last_meta["id"] == "msg_s"
     assert last_meta["model"] == "claude-opus-4-5"
     assert last_meta["usage"] == {"input_tokens": 2, "output_tokens": 2}
@@ -437,18 +438,19 @@ def test_anthropic_generate_streaming_tool_use(mock_anthropic_class):
     client = AnthropicChatClient(api_key="fake-key")
     chunks = list(client.generate("ask", stream=True))
 
-    tool_chunks = [tc for c in chunks for tc in (c.result.tool_calls or [])]
-    assert len(tool_chunks) == 3  # block_start + 2 json deltas
+    StreamingComplianceHarness.assert_valid_stream_contract(chunks, "anthropic")
+    StreamingComplianceHarness.assert_reconstructs_tool_calls(
+        chunks,
+        expected_tools=[{"name": "lookup", "arguments": {"q": "weather"}}],
+        expected_finish_reason="tool_use",
+    )
+    StreamingComplianceHarness.assert_snapshot_isolation(chunks)
 
-    start_chunk = tool_chunks[0]
-    assert start_chunk.id == "tu_1"
-    assert start_chunk.function.name == "lookup"
-    assert start_chunk.function.arguments == ""
-
-    args_concat = "".join(tc.function.arguments for tc in tool_chunks[1:])
-    assert json.loads(args_concat) == {"q": "weather"}
-
-    assert chunks[-1].result.finish_reason == "tool_use"
+    # Initial chunk carries tool id and name
+    first_tool_chunk = next(
+        tc for c in chunks for tc in (c.result.tool_calls or []) if tc.id
+    )
+    assert first_tool_chunk.id == "tu_1"
     assert chunks[-1].metadata["usage"] == {"input_tokens": 5, "output_tokens": 8}
 
 
@@ -1047,24 +1049,19 @@ def test_anthropic_stream_handler_integration():
         ),
     ]
 
-    received_chunks = []
-
-    def on_chunk(chunk):
-        received_chunks.append(chunk)
-
-    chunks = list(
-        StreamHandler.process_stream(
+    chunks = StreamingComplianceHarness.assert_on_chunk_callback_lifecycle(
+        lambda on_chunk: StreamHandler.process_stream(
             stream=events,
             llm_provider="anthropic",
             on_chunk=on_chunk,
         )
     )
 
-    assert len(chunks) == 2  # text_delta + message_delta
-    assert len(received_chunks) == 2
-    assert chunks[0].result.content == "Hello"
-    assert chunks[1].result.finish_reason == "end_turn"
-    assert chunks[1].metadata["provider"] == "anthropic"
+    StreamingComplianceHarness.assert_valid_stream_contract(chunks, "anthropic")
+    StreamingComplianceHarness.assert_reconstructs_text(
+        chunks, expected_text="Hello", expected_finish_reason="end_turn"
+    )
+    StreamingComplianceHarness.assert_snapshot_isolation(chunks)
 
 
 @patch("dapr_agents.llm.anthropic.client.Anthropic")
@@ -1133,17 +1130,14 @@ def test_anthropic_generate_passes_on_chunk_callback(mock_anthropic_class):
     mock_anthropic_class.return_value = sdk
 
     client = AnthropicChatClient(api_key="fake-key")
-    captured = []
-    chunks = list(
-        client.generate(
-            "hi", stream=True, on_chunk=lambda chunk: captured.append(chunk)
-        )
+    chunks = StreamingComplianceHarness.assert_on_chunk_callback_lifecycle(
+        lambda on_chunk: client.generate("hi", stream=True, on_chunk=on_chunk)
     )
 
-    assert len(chunks) == 3
-    assert len(captured) == 3
-    assert captured[0].result.content == "chunk1"
-    assert captured[1].result.content == "chunk2"
+    StreamingComplianceHarness.assert_valid_stream_contract(chunks, "anthropic")
+    StreamingComplianceHarness.assert_reconstructs_text(
+        chunks, expected_text="chunk1chunk2", expected_finish_reason="end_turn"
+    )
 
 
 @patch("dapr_agents.llm.anthropic.client.Anthropic")
@@ -1199,7 +1193,16 @@ def test_anthropic_streaming_thinking_events_captured_in_metadata(mock_anthropic
     client = AnthropicChatClient(api_key="fake-key")
     chunks = list(client.generate("solve puzzle", stream=True))
 
-    assert len(chunks) == 3  # Partial answer 1, Final answer, message_delta
+    StreamingComplianceHarness.assert_valid_stream_contract(
+        chunks, "anthropic", expected_min_chunks=3
+    )
+    StreamingComplianceHarness.assert_reconstructs_text(
+        chunks,
+        expected_text="Partial answer 1Final answer",
+        expected_finish_reason="end_turn",
+    )
+    StreamingComplianceHarness.assert_snapshot_isolation(chunks)
+
     first_chunk = chunks[0]
     last_chunk = chunks[-1]
 
@@ -1393,23 +1396,26 @@ def test_anthropic_process_stream_with_dict_events():
     ]
 
     chunks = list(process_anthropic_stream(dict_events))
-    assert (
-        len(chunks) == 5
-    )  # tool_use start, 2 partial JSONs, text delta, message_delta
+
+    StreamingComplianceHarness.assert_valid_stream_contract(
+        chunks, expected_provider="anthropic", expected_min_chunks=5
+    )
+    StreamingComplianceHarness.assert_reconstructs_text(
+        chunks, expected_text="Done!", expected_finish_reason="end_turn"
+    )
+    StreamingComplianceHarness.assert_reconstructs_tool_calls(
+        chunks,
+        expected_tools=[{"name": "calc", "arguments": {"x": 10}}],
+        expected_finish_reason="end_turn",
+    )
+    StreamingComplianceHarness.assert_snapshot_isolation(chunks)
 
     first_chunk = chunks[0]
     assert first_chunk.metadata["id"] == "msg_stream_dict"
     assert first_chunk.metadata["model"] == "claude-3-7-sonnet"
-    assert first_chunk.result.tool_calls[0].function.name == "calc"
     assert first_chunk.result.tool_calls[0].id == "toolu_abc"
 
-    # Text chunk
-    text_chunk = chunks[3]
-    assert text_chunk.result.content == "Done!"
-
-    # Final chunk
     final_chunk = chunks[4]
-    assert final_chunk.result.finish_reason == "end_turn"
     assert final_chunk.metadata["usage"] == {"output_tokens": 20}
     assert final_chunk.metadata["thinking_blocks"] == ["Reasoning..."]
     assert final_chunk.metadata["thinking_deltas"] == [" more thought"]

--- a/tests/llm/test_anthropic_utils.py
+++ b/tests/llm/test_anthropic_utils.py
@@ -63,6 +63,7 @@ from dapr_agents.types.message import (
     LLMChatResponse,
     LLMChatResponseChunk,
 )
+from tests.llm.streaming_test_harness import StreamingComplianceHarness
 
 
 def _stream_cm(events: Iterable[Any]) -> Any:
@@ -491,6 +492,22 @@ class TestRealSDKModelFixtures:
         final_chunk = chunks[2]
         assert final_chunk.result.finish_reason == "end_turn"
         assert final_chunk.metadata.get("usage", {}).get("output_tokens") == 25
+
+        # Validate with StreamingComplianceHarness
+        StreamingComplianceHarness.assert_valid_stream_contract(
+            chunks, expected_provider="anthropic", expected_min_chunks=3
+        )
+        StreamingComplianceHarness.assert_reconstructs_text(
+            chunks,
+            expected_text="Computing answer...",
+            expected_finish_reason="end_turn",
+        )
+        StreamingComplianceHarness.assert_reconstructs_tool_calls(
+            chunks,
+            expected_tools=[{"name": "calculate"}],
+            expected_finish_reason="end_turn",
+        )
+        StreamingComplianceHarness.assert_snapshot_isolation(chunks)
 
     def test_response_handler_with_real_sdk_structured_response(self) -> None:
         class CityWeather(BaseModel):

--- a/tests/llm/test_hf_stream_utils.py
+++ b/tests/llm/test_hf_stream_utils.py
@@ -1,0 +1,173 @@
+#
+# Copyright 2026 The Dapr Authors
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#     http://www.apache.org/licenses/LICENSE-2.0
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+"""Compliance tests for Hugging Face streaming chunk normalization."""
+
+from unittest.mock import MagicMock
+
+from dapr_agents.llm.huggingface.utils import process_hf_stream
+from tests.llm.streaming_test_harness import StreamingComplianceHarness
+
+
+def _packet(data: dict) -> MagicMock:
+    """Wrap a dict as a Hugging Face stream chunk exposing ``model_dump``."""
+    pkt = MagicMock()
+    pkt.model_dump.return_value = data
+    return pkt
+
+
+def _content_packet(content: str, *, finish_reason=None, role=None) -> MagicMock:
+    delta: dict = {"content": content}
+    if role:
+        delta["role"] = role
+    return _packet(
+        {
+            "id": "hf-1",
+            "created": 1,
+            "model": "meta-llama/Llama-3.1-8B-Instruct",
+            "choices": [{"index": 0, "delta": delta, "finish_reason": finish_reason}],
+        }
+    )
+
+
+def _tool_call_packet(
+    tool_calls: list[dict], *, finish_reason=None, role=None
+) -> MagicMock:
+    delta: dict = {"tool_calls": tool_calls}
+    if role:
+        delta["role"] = role
+    return _packet(
+        {
+            "id": "hf-1",
+            "created": 1,
+            "model": "meta-llama/Llama-3.1-8B-Instruct",
+            "choices": [{"index": 0, "delta": delta, "finish_reason": finish_reason}],
+        }
+    )
+
+
+def _usage_only_packet() -> MagicMock:
+    return _packet(
+        {
+            "id": "hf-1",
+            "created": 1,
+            "model": "meta-llama/Llama-3.1-8B-Instruct",
+            "choices": [],
+            "usage": {
+                "completion_tokens": 12,
+                "prompt_tokens": 30,
+                "total_tokens": 42,
+            },
+        }
+    )
+
+
+def test_hf_stream_content_reconstructs_message():
+    """Hugging Face content stream reconstructs full message and meets compliance contract."""
+    raw = [
+        _content_packet("Hello", role="assistant"),
+        _content_packet(" world", finish_reason="stop"),
+        _usage_only_packet(),
+    ]
+
+    chunks = list(
+        process_hf_stream(
+            iter(raw), enrich_metadata={"provider": "huggingface"}, on_chunk=None
+        )
+    )
+
+    StreamingComplianceHarness.assert_valid_stream_contract(
+        chunks, expected_provider="huggingface", expected_min_chunks=3
+    )
+    StreamingComplianceHarness.assert_reconstructs_text(
+        chunks, expected_text="Hello world"
+    )
+
+    final = chunks[-1]
+    assert final.result.content is None
+    assert final.result.finish_reason is None
+    assert final.metadata is not None
+    assert final.metadata.get("model") == "meta-llama/Llama-3.1-8B-Instruct"
+
+
+def test_hf_stream_tool_calls_reconstruct():
+    """Hugging Face tool call chunks reconstruct into full ToolCall."""
+    raw = [
+        _tool_call_packet(
+            [
+                {
+                    "index": 0,
+                    "id": "call_hf_1",
+                    "type": "function",
+                    "function": {"name": "lookup", "arguments": ""},
+                }
+            ],
+            role="assistant",
+        ),
+        _tool_call_packet(
+            [
+                {
+                    "index": 0,
+                    "function": {"arguments": '{"query": "dapr"}'},
+                }
+            ],
+            finish_reason="tool_calls",
+        ),
+        _usage_only_packet(),
+    ]
+
+    chunks = list(
+        process_hf_stream(
+            iter(raw), enrich_metadata={"provider": "huggingface"}, on_chunk=None
+        )
+    )
+
+    StreamingComplianceHarness.assert_valid_stream_contract(
+        chunks, expected_provider="huggingface"
+    )
+    StreamingComplianceHarness.assert_reconstructs_tool_calls(
+        chunks,
+        expected_tools=[{"name": "lookup", "arguments": {"query": "dapr"}}],
+        expected_finish_reason="tool_calls",
+    )
+
+
+def test_hf_stream_on_chunk_callback_lifecycle():
+    """Verify on_chunk callback lifecycle on Hugging Face stream."""
+    raw = [
+        _content_packet("Chunk1", role="assistant"),
+        _content_packet(" Chunk2", finish_reason="stop"),
+        _usage_only_packet(),
+    ]
+
+    StreamingComplianceHarness.assert_on_chunk_callback_lifecycle(
+        lambda on_chunk: process_hf_stream(
+            iter(raw), enrich_metadata={"provider": "huggingface"}, on_chunk=on_chunk
+        )
+    )
+
+
+def test_hf_stream_snapshot_isolation():
+    """Verify snapshot isolation on Hugging Face stream."""
+    raw = [
+        _content_packet("A", role="assistant"),
+        _content_packet(" B", finish_reason="stop"),
+        _usage_only_packet(),
+    ]
+
+    chunks = list(
+        process_hf_stream(
+            iter(raw), enrich_metadata={"provider": "huggingface"}, on_chunk=None
+        )
+    )
+    StreamingComplianceHarness.assert_snapshot_isolation(chunks)

--- a/tests/llm/test_hf_stream_utils.py
+++ b/tests/llm/test_hf_stream_utils.py
@@ -98,6 +98,11 @@ def test_hf_stream_content_reconstructs_message():
     assert final.result.finish_reason is None
     assert final.metadata is not None
     assert final.metadata.get("model") == "meta-llama/Llama-3.1-8B-Instruct"
+    assert final.metadata.get("usage") == {
+        "completion_tokens": 12,
+        "prompt_tokens": 30,
+        "total_tokens": 42,
+    }
 
 
 def test_hf_stream_tool_calls_reconstruct():

--- a/tests/llm/test_openai_stream_utils.py
+++ b/tests/llm/test_openai_stream_utils.py
@@ -11,19 +11,13 @@
 # limitations under the License.
 #
 
-"""Regression tests for OpenAI streaming chunk normalization.
-
-Focus: the final usage-only packet OpenAI emits when
-``stream_options.include_usage`` is enabled carries an empty ``choices`` list.
-That packet must still produce a valid ``LLMChatResponseChunk`` (whose
-``result`` field is required) rather than raising a Pydantic validation error
-inside the workflow's ``call_llm`` activity.
-"""
+"""Regression and compliance tests for OpenAI streaming chunk normalization."""
 
 from unittest.mock import MagicMock
 
 from dapr_agents.llm.openai.utils import process_openai_stream
 from dapr_agents.types.message import LLMChatResponseChunk
+from tests.llm.streaming_test_harness import StreamingComplianceHarness
 
 
 def _packet(data: dict) -> MagicMock:
@@ -35,6 +29,23 @@ def _packet(data: dict) -> MagicMock:
 
 def _content_packet(content: str, *, finish_reason=None, role=None) -> MagicMock:
     delta: dict = {"content": content}
+    if role:
+        delta["role"] = role
+    return _packet(
+        {
+            "id": "chatcmpl-1",
+            "created": 1,
+            "model": "gpt-4o-mini",
+            "object": "chat.completion.chunk",
+            "choices": [{"index": 0, "delta": delta, "finish_reason": finish_reason}],
+        }
+    )
+
+
+def _tool_call_packet(
+    tool_calls: list[dict], *, finish_reason=None, role=None
+) -> MagicMock:
+    delta: dict = {"tool_calls": tool_calls}
     if role:
         delta["role"] = role
     return _packet(
@@ -74,12 +85,16 @@ def test_usage_only_final_packet_yields_valid_chunk():
         _usage_only_packet(),
     ]
 
-    chunks = list(process_openai_stream(iter(raw), on_chunk=None))
+    chunks = list(
+        process_openai_stream(
+            iter(raw), enrich_metadata={"provider": "openai"}, on_chunk=None
+        )
+    )
 
-    # Every yielded item is a valid response chunk with a populated result.
-    assert len(chunks) == 3
-    assert all(isinstance(c, LLMChatResponseChunk) for c in chunks)
-    assert all(c.result is not None for c in chunks)
+    # Validate against compliance harness contract
+    StreamingComplianceHarness.assert_valid_stream_contract(
+        chunks, expected_provider="openai", expected_min_chunks=3
+    )
 
     # The terminal usage packet carries an empty candidate (no content/finish)
     # but preserves provider metadata for downstream TURN_COMPLETE attribution.
@@ -98,6 +113,86 @@ def test_content_chunks_reconstruct_full_message():
         _usage_only_packet(),
     ]
 
-    chunks = list(process_openai_stream(iter(raw), on_chunk=None))
-    text = "".join(c.result.content or "" for c in chunks)
-    assert text == "Hello"
+    chunks = list(
+        process_openai_stream(
+            iter(raw), enrich_metadata={"provider": "openai"}, on_chunk=None
+        )
+    )
+    StreamingComplianceHarness.assert_valid_stream_contract(
+        chunks, expected_provider="openai"
+    )
+    StreamingComplianceHarness.assert_reconstructs_text(chunks, expected_text="Hello")
+
+
+def test_tool_call_chunks_reconstruct_tool_call():
+    """Tool call deltas reconstruct into complete ToolCall with arguments."""
+    raw = [
+        _tool_call_packet(
+            [
+                {
+                    "index": 0,
+                    "id": "call_1",
+                    "type": "function",
+                    "function": {"name": "get_weather", "arguments": ""},
+                }
+            ],
+            role="assistant",
+        ),
+        _tool_call_packet(
+            [
+                {
+                    "index": 0,
+                    "function": {"arguments": '{"location": "San Francisco"}'},
+                }
+            ],
+            finish_reason="tool_calls",
+        ),
+        _usage_only_packet(),
+    ]
+
+    chunks = list(
+        process_openai_stream(
+            iter(raw), enrich_metadata={"provider": "openai"}, on_chunk=None
+        )
+    )
+    StreamingComplianceHarness.assert_valid_stream_contract(
+        chunks, expected_provider="openai"
+    )
+    StreamingComplianceHarness.assert_reconstructs_tool_calls(
+        chunks,
+        expected_tools=[
+            {"name": "get_weather", "arguments": {"location": "San Francisco"}}
+        ],
+        expected_finish_reason="tool_calls",
+    )
+
+
+def test_openai_stream_on_chunk_callback_lifecycle():
+    """Verify on_chunk callback receives every yielded chunk in order."""
+    raw = [
+        _content_packet("Hi", role="assistant"),
+        _content_packet(" there", finish_reason="stop"),
+        _usage_only_packet(),
+    ]
+
+    StreamingComplianceHarness.assert_on_chunk_callback_lifecycle(
+        lambda on_chunk: process_openai_stream(
+            iter(raw), enrich_metadata={"provider": "openai"}, on_chunk=on_chunk
+        )
+    )
+
+
+def test_openai_stream_snapshot_isolation():
+    """Verify earlier chunk metadata dicts are not mutated by later events."""
+    raw = [
+        _content_packet("One", role="assistant"),
+        _content_packet(" Two", finish_reason="stop"),
+        _usage_only_packet(),
+    ]
+
+    chunks = list(
+        process_openai_stream(
+            iter(raw), enrich_metadata={"provider": "openai"}, on_chunk=None
+        )
+    )
+    StreamingComplianceHarness.assert_snapshot_isolation(chunks)

--- a/tests/llm/test_openai_stream_utils.py
+++ b/tests/llm/test_openai_stream_utils.py
@@ -103,6 +103,11 @@ def test_usage_only_final_packet_yields_valid_chunk():
     assert final.result.finish_reason is None
     assert final.metadata is not None
     assert final.metadata.get("model") == "gpt-4o-mini"
+    assert final.metadata.get("usage") == {
+        "completion_tokens": 238,
+        "prompt_tokens": 638,
+        "total_tokens": 876,
+    }
 
 
 def test_content_chunks_reconstruct_full_message():

--- a/tests/llm/test_stream_handler.py
+++ b/tests/llm/test_stream_handler.py
@@ -1,0 +1,197 @@
+#
+# Copyright 2026 The Dapr Authors
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#     http://www.apache.org/licenses/LICENSE-2.0
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+"""Tests for centralized stream processing and StreamHandler."""
+
+from dataclasses import dataclass
+from unittest.mock import MagicMock, patch
+import pytest
+
+from dapr_agents.llm.huggingface.utils import (
+    _get_packet_metadata as hf_get_packet_metadata,
+    _process_choice_delta as hf_process_choice_delta,
+    process_hf_stream,
+)
+from dapr_agents.llm.openai.utils import (
+    _get_packet_metadata as openai_get_packet_metadata,
+    _process_choice_delta as openai_process_choice_delta,
+    process_openai_stream,
+)
+from dapr_agents.llm.utils.stream import (
+    StreamHandler,
+    extract_packet_metadata,
+    process_choice_delta,
+    process_choice_delta_stream,
+)
+from dapr_agents.types.message import LLMChatResponseChunk
+from tests.llm.streaming_test_harness import StreamingComplianceHarness
+
+
+def _mock_packet(data: dict) -> MagicMock:
+    pkt = MagicMock()
+    pkt.model_dump.return_value = data
+    return pkt
+
+
+@dataclass
+class _DataclassPacket:
+    id: str
+    model: str
+    choices: list
+
+
+class _ToDictPacket:
+    def __init__(self, data: dict):
+        self._data = data
+
+    def to_dict(self) -> dict:
+        return self._data
+
+
+def test_backward_compatible_shims():
+    """Verify backward-compatible shims match centralized helpers."""
+    assert openai_get_packet_metadata is extract_packet_metadata
+    assert hf_get_packet_metadata is extract_packet_metadata
+    assert openai_process_choice_delta is process_choice_delta
+    assert hf_process_choice_delta is process_choice_delta
+
+    pkt = {"id": "test-1", "model": "gpt-4o", "created": 123}
+    meta = openai_get_packet_metadata(pkt, {"extra": "val"})
+    assert meta["id"] == "test-1"
+    assert meta["model"] == "gpt-4o"
+    assert meta["extra"] == "val"
+
+
+@pytest.mark.parametrize(
+    "provider",
+    ["openai", "nvidia", "litellm", "iflytek", "huggingface"],
+)
+def test_stream_handler_choice_delta_providers(provider: str):
+    """StreamHandler routes choice-delta providers through consolidated processing."""
+    raw = [
+        _mock_packet(
+            {
+                "id": f"{provider}-1",
+                "model": "model-abc",
+                "choices": [
+                    {"index": 0, "delta": {"content": "Hello", "role": "assistant"}}
+                ],
+            }
+        ),
+        _mock_packet(
+            {
+                "id": f"{provider}-1",
+                "model": "model-abc",
+                "choices": [
+                    {
+                        "index": 0,
+                        "delta": {"content": " world"},
+                        "finish_reason": "stop",
+                    }
+                ],
+            }
+        ),
+        _mock_packet(
+            {
+                "id": f"{provider}-1",
+                "model": "model-abc",
+                "choices": [],
+                "usage": {"total_tokens": 10},
+            }
+        ),
+    ]
+
+    chunks = list(StreamHandler.process_stream(iter(raw), llm_provider=provider))
+
+    StreamingComplianceHarness.assert_valid_stream_contract(
+        chunks, expected_provider=provider, expected_min_chunks=3
+    )
+    StreamingComplianceHarness.assert_reconstructs_text(
+        chunks, expected_text="Hello world"
+    )
+
+
+def test_stream_handler_anthropic_routing():
+    """StreamHandler routes anthropic and claude providers to process_anthropic_stream."""
+    dummy_chunk = MagicMock(spec=LLMChatResponseChunk)
+    with patch(
+        "dapr_agents.llm.anthropic.utils.process_anthropic_stream",
+        return_value=iter([dummy_chunk]),
+    ) as mock_proc:
+        chunks = list(StreamHandler.process_stream(iter([]), llm_provider="anthropic"))
+        assert chunks == [dummy_chunk]
+        mock_proc.assert_called_once_with(
+            raw_stream=pytest.approx(mock_proc.call_args[1]["raw_stream"]),
+            enrich_metadata={"provider": "anthropic"},
+            on_chunk=None,
+        )
+
+    with patch(
+        "dapr_agents.llm.anthropic.utils.process_anthropic_stream",
+        return_value=iter([dummy_chunk]),
+    ) as mock_proc:
+        chunks = list(StreamHandler.process_stream(iter([]), llm_provider="claude"))
+        assert chunks == [dummy_chunk]
+        mock_proc.assert_called_once_with(
+            raw_stream=pytest.approx(mock_proc.call_args[1]["raw_stream"]),
+            enrich_metadata={"provider": "claude"},
+            on_chunk=None,
+        )
+
+
+def test_stream_handler_unsupported_provider():
+    """StreamHandler raises ValueError for unsupported providers."""
+    with pytest.raises(
+        ValueError, match="Streaming not supported for provider: unknown"
+    ):
+        list(StreamHandler.process_stream(iter([]), llm_provider="unknown"))
+
+
+def test_process_choice_delta_stream_packet_types():
+    """process_choice_delta_stream accepts model_dump, to_dict, and dataclass packets."""
+    raw = [
+        _ToDictPacket(
+            {
+                "id": "dict-1",
+                "choices": [{"index": 0, "delta": {"content": "Part1"}}],
+            }
+        ),
+        _DataclassPacket(
+            id="dc-1",
+            model="test-model",
+            choices=[
+                {"index": 0, "delta": {"content": "Part2"}, "finish_reason": "stop"}
+            ],
+        ),
+    ]
+
+    chunks = list(process_choice_delta_stream(iter(raw)))
+    assert len(chunks) == 2
+    StreamingComplianceHarness.assert_reconstructs_text(
+        chunks, expected_text="Part1Part2"
+    )
+
+
+def test_process_choice_delta_stream_invalid_packet_type():
+    """process_choice_delta_stream raises TypeError for unparseable packets."""
+    with pytest.raises(TypeError, match="Cannot serialize packet of type"):
+        list(process_choice_delta_stream(iter(["invalid_packet_string"])))
+
+
+def test_extract_packet_metadata_error_handling():
+    """extract_packet_metadata safely falls back to empty dict on malformed packets."""
+    bad_packet = MagicMock()
+    bad_packet.get.side_effect = RuntimeError("Extraction failed")
+
+    res = extract_packet_metadata(bad_packet)
+    assert res == {}

--- a/tests/llm/test_stream_handler.py
+++ b/tests/llm/test_stream_handler.py
@@ -195,3 +195,121 @@ def test_extract_packet_metadata_error_handling():
 
     res = extract_packet_metadata(bad_packet)
     assert res == {}
+
+
+def test_extract_packet_metadata_with_usage():
+    """extract_packet_metadata preserves usage when present in packet."""
+    pkt = {
+        "id": "test-usage-1",
+        "model": "test-model",
+        "usage": {"prompt_tokens": 10, "completion_tokens": 20, "total_tokens": 30},
+    }
+    meta = extract_packet_metadata(pkt, {"provider": "openai"})
+    assert meta["id"] == "test-usage-1"
+    assert meta["provider"] == "openai"
+    assert meta["usage"] == {
+        "prompt_tokens": 10,
+        "completion_tokens": 20,
+        "total_tokens": 30,
+    }
+
+
+def test_stream_handler_case_insensitivity():
+    """StreamHandler routes providers regardless of string casing."""
+    raw = [
+        _mock_packet(
+            {
+                "id": "test-case-1",
+                "choices": [
+                    {
+                        "index": 0,
+                        "delta": {"content": "Test case"},
+                        "finish_reason": "stop",
+                    }
+                ],
+            }
+        )
+    ]
+    chunks = list(StreamHandler.process_stream(iter(raw), llm_provider="OpenAI"))
+    assert len(chunks) == 1
+    assert chunks[0].metadata.get("provider") == "openai"
+
+    dummy_chunk = MagicMock(spec=LLMChatResponseChunk)
+    with patch(
+        "dapr_agents.llm.anthropic.utils.process_anthropic_stream",
+        return_value=iter([dummy_chunk]),
+    ) as mock_proc:
+        chunks_anthropic = list(
+            StreamHandler.process_stream(iter([]), llm_provider="Anthropic")
+        )
+        assert chunks_anthropic == [dummy_chunk]
+        assert mock_proc.call_args[1]["enrich_metadata"] == {"provider": "anthropic"}
+
+
+def test_process_choice_delta_stream_multiple_choices_in_packet():
+    """process_choice_delta_stream yields chunks for all choices in a packet."""
+    raw = [
+        _mock_packet(
+            {
+                "id": "multi-choice-1",
+                "choices": [
+                    {"index": 0, "delta": {"content": "Candidate 0"}},
+                    {"index": 1, "delta": {"content": "Candidate 1"}},
+                ],
+            }
+        )
+    ]
+    chunks = list(process_choice_delta_stream(iter(raw)))
+    assert len(chunks) == 2
+    assert chunks[0].result.index == 0
+    assert chunks[0].result.content == "Candidate 0"
+    assert chunks[0].metadata.get("first_chunk") is True
+
+    assert chunks[1].result.index == 1
+    assert chunks[1].result.content == "Candidate 1"
+    assert "first_chunk" not in chunks[1].metadata
+
+
+def test_process_choice_delta_stream_closes_raw_stream():
+    """process_choice_delta_stream closes raw_stream on normal exit and early break."""
+    close_mock = MagicMock()
+
+    class ClosableStream:
+        def __iter__(self):
+            yield _mock_packet(
+                {"id": "c1", "choices": [{"index": 0, "delta": {"content": "1"}}]}
+            )
+            yield _mock_packet(
+                {"id": "c2", "choices": [{"index": 0, "delta": {"content": "2"}}]}
+            )
+
+        def close(self):
+            close_mock()
+
+    # Normal completion
+    list(process_choice_delta_stream(ClosableStream()))
+    assert close_mock.call_count == 1
+
+    # Early break
+    close_mock.reset_mock()
+    for chunk in process_choice_delta_stream(ClosableStream()):
+        if chunk.result.content == "1":
+            break
+    assert close_mock.call_count == 1
+
+
+def test_process_choice_delta_malformed_tool_call():
+    """process_choice_delta safely ignores malformed tool_call entries without crashing."""
+    choice = {
+        "index": 0,
+        "delta": {
+            "tool_calls": [
+                "not-a-dict-tool-call",
+                {"index": 0, "function": {"name": "valid_fn", "arguments": "{}"}},
+            ]
+        },
+    }
+    chunks = list(process_choice_delta(choice, overall_meta={}))
+    assert len(chunks) == 1
+    assert len(chunks[0].result.tool_calls) == 1
+    assert chunks[0].result.tool_calls[0].function.name == "valid_fn"

--- a/tests/tool/test_executor.py
+++ b/tests/tool/test_executor.py
@@ -13,12 +13,13 @@
 
 """Unit tests for AgentToolExecutor.register_tool()"""
 
-from unittest.mock import patch
+from unittest.mock import AsyncMock, patch
 
 import pytest
-from dapr_agents.tool.executor import AgentToolExecutor
+
 from dapr_agents.tool.base import AgentTool
-from dapr_agents.types import AgentToolExecutorError
+from dapr_agents.tool.executor import AgentToolExecutor
+from dapr_agents.types import AgentToolExecutorError, ToolResult
 
 
 class TestAgentToolExecutorRegisterTool:
@@ -215,3 +216,73 @@ class TestAgentToolExecutorRegisterTool:
         assert tool1 in tools
         assert tool2 in tools
         assert tool3 in tools
+
+
+class TestAgentToolExecutorRunTool:
+    """Test suite for AgentToolExecutor.run_tool() method."""
+
+    @pytest.mark.asyncio
+    async def test_run_tool_not_found_raises(self):
+        """Running an unregistered tool raises AgentToolExecutorError."""
+        executor = AgentToolExecutor()
+        with pytest.raises(AgentToolExecutorError, match="not found"):
+            await executor.run_tool("Missing")
+
+    @pytest.mark.asyncio
+    async def test_run_tool_sync_success(self):
+        """A sync tool is called directly and its result returned."""
+        executor = AgentToolExecutor()
+
+        def add(a: int, b: int) -> int:
+            """Adds two numbers."""
+            return a + b
+
+        executor.register_tool(add)
+        result = await executor.run_tool("add", a=2, b=3)
+        assert result == 5
+
+    @pytest.mark.asyncio
+    async def test_run_tool_async_success(self):
+        """An async tool is awaited and its result returned."""
+        executor = AgentToolExecutor()
+
+        async def greet(name: str) -> str:
+            """Greets someone."""
+            return f"hello {name}"
+
+        executor.register_tool(greet)
+        result = await executor.run_tool("greet", name="world")
+        assert result == "hello world"
+
+    @pytest.mark.asyncio
+    async def test_run_tool_error_returns_tool_result(self):
+        """A tool that raises is caught as ToolError and returned as an error ToolResult."""
+        executor = AgentToolExecutor()
+
+        def failing(x: int) -> int:
+            """Always fails."""
+            raise ValueError("bad input")
+
+        executor.register_tool(failing)
+        result = await executor.run_tool("failing", x=1)
+        assert isinstance(result, ToolResult)
+        assert result.isError is True
+        assert "bad input" in result.content[0].text
+
+    @pytest.mark.asyncio
+    async def test_run_tool_unexpected_error_wrapped(self):
+        """A non-ToolError raised outside the tool's own error handling is wrapped."""
+        executor = AgentToolExecutor()
+
+        async def noop() -> None:
+            """Does nothing."""
+            return
+
+        executor.register_tool(noop)
+        with (
+            patch.object(
+                AgentTool, "arun", AsyncMock(side_effect=RuntimeError("boom"))
+            ),
+            pytest.raises(AgentToolExecutorError, match="Unexpected error"),
+        ):
+            await executor.run_tool("noop")

--- a/uv.lock
+++ b/uv.lock
@@ -7,10 +7,10 @@ resolution-markers = [
     "python_full_version >= '3.13' and platform_machine == 'aarch64' and sys_platform == 'linux'",
     "(python_full_version >= '3.13' and platform_machine != 'aarch64' and sys_platform == 'linux') or (python_full_version >= '3.13' and sys_platform != 'darwin' and sys_platform != 'linux' and sys_platform != 'win32')",
     "python_full_version == '3.12.*' and sys_platform == 'win32'",
-    "python_full_version < '3.12' and sys_platform == 'win32'",
     "python_full_version == '3.12.*' and sys_platform == 'darwin'",
     "python_full_version == '3.12.*' and platform_machine == 'aarch64' and sys_platform == 'linux'",
     "(python_full_version == '3.12.*' and platform_machine != 'aarch64' and sys_platform == 'linux') or (python_full_version == '3.12.*' and sys_platform != 'darwin' and sys_platform != 'linux' and sys_platform != 'win32')",
+    "python_full_version < '3.12' and sys_platform == 'win32'",
     "python_full_version < '3.12' and sys_platform == 'darwin'",
     "python_full_version < '3.12' and platform_machine == 'aarch64' and sys_platform == 'linux'",
     "(python_full_version < '3.12' and platform_machine != 'aarch64' and sys_platform == 'linux') or (python_full_version < '3.12' and sys_platform != 'darwin' and sys_platform != 'linux' and sys_platform != 'win32')",
@@ -25,6 +25,7 @@ dapr-ext-workflow = "2026-05-21T00:00:00Z"
 durabletask-dapr = "2026-05-21T00:00:00Z"
 dapr-ext-fastapi = "2026-05-21T00:00:00Z"
 dapr = "2026-05-21T00:00:00Z"
+anthropic = "2026-08-23T00:00:00Z"
 
 [manifest]
 members = [
@@ -1492,42 +1493,51 @@ wheels = [
 
 [[package]]
 name = "cuda-toolkit"
-version = "13.0.2"
+version = "13.0.3.0"
 source = { registry = "https://pypi.org/simple" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/57/b2/453099f5f3b698d7d0eab38916aac44c7f76229f451709e2eb9db6615dcd/cuda_toolkit-13.0.2-py2.py3-none-any.whl", hash = "sha256:b198824cf2f54003f50d64ada3a0f184b42ca0846c1c94192fa269ecd97a66eb", size = 2364, upload-time = "2025-12-19T23:24:07.328Z" },
+    { url = "https://files.pythonhosted.org/packages/d1/c7/a79086a62c98befcdb8349656c6f114e2db3b8b2422f6e25c97a7f2a9a3c/cuda_toolkit-13.0.3.0-py2.py3-none-any.whl", hash = "sha256:d693caaa261214ddd7dbb60d68e71cbed884e68c2be7509778f3051da0b91c3f", size = 2512, upload-time = "2026-04-14T00:50:08.173Z" },
 ]
 
 [package.optional-dependencies]
+cublas = [
+    { name = "nvidia-cublas", marker = "platform_machine == 'aarch64' or platform_machine == 'x86_64'" },
+    { name = "nvidia-cuda-nvrtc", marker = "platform_machine == 'aarch64' or platform_machine == 'x86_64'" },
+]
 cudart = [
-    { name = "nvidia-cuda-runtime" },
+    { name = "nvidia-cuda-runtime", marker = "platform_machine == 'aarch64' or platform_machine == 'x86_64'" },
 ]
 cufft = [
-    { name = "nvidia-cufft" },
+    { name = "nvidia-cufft", marker = "platform_machine == 'aarch64' or platform_machine == 'x86_64'" },
+    { name = "nvidia-nvjitlink", marker = "platform_machine == 'aarch64' or platform_machine == 'x86_64'" },
 ]
 cufile = [
-    { name = "nvidia-cufile" },
+    { name = "nvidia-cufile", marker = "platform_machine == 'aarch64' or platform_machine == 'x86_64'" },
 ]
 cupti = [
-    { name = "nvidia-cuda-cupti" },
+    { name = "nvidia-cuda-cupti", marker = "platform_machine == 'aarch64' or platform_machine == 'x86_64'" },
 ]
 curand = [
-    { name = "nvidia-curand" },
+    { name = "nvidia-curand", marker = "platform_machine == 'aarch64' or platform_machine == 'x86_64'" },
 ]
 cusolver = [
-    { name = "nvidia-cusolver" },
+    { name = "nvidia-cublas", marker = "platform_machine == 'aarch64' or platform_machine == 'x86_64'" },
+    { name = "nvidia-cusolver", marker = "platform_machine == 'aarch64' or platform_machine == 'x86_64'" },
+    { name = "nvidia-cusparse", marker = "platform_machine == 'aarch64' or platform_machine == 'x86_64'" },
+    { name = "nvidia-nvjitlink", marker = "platform_machine == 'aarch64' or platform_machine == 'x86_64'" },
 ]
 cusparse = [
-    { name = "nvidia-cusparse" },
+    { name = "nvidia-cusparse", marker = "platform_machine == 'aarch64' or platform_machine == 'x86_64'" },
+    { name = "nvidia-nvjitlink", marker = "platform_machine == 'aarch64' or platform_machine == 'x86_64'" },
 ]
 nvjitlink = [
-    { name = "nvidia-nvjitlink" },
+    { name = "nvidia-nvjitlink", marker = "platform_machine == 'aarch64' or platform_machine == 'x86_64'" },
 ]
 nvrtc = [
-    { name = "nvidia-cuda-nvrtc" },
+    { name = "nvidia-cuda-nvrtc", marker = "platform_machine == 'aarch64' or platform_machine == 'x86_64'" },
 ]
 nvtx = [
-    { name = "nvidia-nvtx" },
+    { name = "nvidia-nvtx", marker = "platform_machine == 'aarch64' or platform_machine == 'x86_64'" },
 ]
 
 [[package]]
@@ -1663,7 +1673,7 @@ vectorstore = [
 [package.metadata]
 requires-dist = [
     { name = "aiohttp", specifier = ">=3.9.0,<4.0.0" },
-    { name = "anthropic", specifier = ">=0.98.0,<1.0.0" },
+    { name = "anthropic", specifier = ">=0.98.0,<2.0.0" },
     { name = "azure-identity", specifier = ">=1.21.0,<2.0.0" },
     { name = "cachetools", specifier = ">=6.1.0,<8.0.0" },
     { name = "chromadb", marker = "extra == 'vectorstore'", specifier = ">=0.4.22,<2.0.0" },
@@ -3382,7 +3392,7 @@ wheels = [
 
 [[package]]
 name = "mistralai"
-version = "2.4.0"
+version = "2.9.3"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "eval-type-backport" },
@@ -3394,9 +3404,9 @@ dependencies = [
     { name = "python-dateutil" },
     { name = "typing-inspection" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/0b/6f/3d402b0bf00014d9a078997ba772e5324287157421c4daa4cf1f74be4425/mistralai-2.4.0.tar.gz", hash = "sha256:ddca732ec7073d686f07775f749f250092a33b1864b40ec1b07db050a0192572", size = 404754, upload-time = "2026-04-16T12:03:34.218Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/be/fa/c6580ed6747c675546e4117eb959d06732e14c0da51bbe3ae4524677e1a3/mistralai-2.9.3.tar.gz", hash = "sha256:aa1bc946cc845a72f4a491ac366498151acae300a2d143a76d73e581609bac4a", size = 542867, upload-time = "2026-08-13T15:47:56.944Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/c0/96/08a297dc9914f0ff43eed342827e5a803aa2233663d774de83b03f0c9b43/mistralai-2.4.0-py3-none-any.whl", hash = "sha256:e10846049f2c527d355ce4bebfcf9c94aba1d8350d9d2ead81be9b70d23fd4ab", size = 951501, upload-time = "2026-04-16T12:03:32.656Z" },
+    { url = "https://files.pythonhosted.org/packages/d6/e7/467fd42d1c2f1ee0a6e117d79795b86a06668ec7ec875632ecdd5514dc68/mistralai-2.9.3-py3-none-any.whl", hash = "sha256:e5c401caa6e862528ec41ceda4b551c9483081dd7bdb2a1ed73d8e9d0db3d6d0", size = 1297009, upload-time = "2026-08-13T15:47:55.253Z" },
 ]
 
 [[package]]
@@ -3773,11 +3783,14 @@ wheels = [
 
 [[package]]
 name = "nvidia-cublas"
-version = "13.1.0.3"
+version = "13.1.1.3"
 source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "nvidia-cuda-nvrtc" },
+]
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/e1/a5/fce49e2ae977e0ccc084e5adafceb4f0ac0c8333cb6863501618a7277f67/nvidia_cublas-13.1.0.3-py3-none-manylinux_2_27_aarch64.whl", hash = "sha256:c86fc7f7ae36d7528288c5d88098edcb7b02c633d262e7ddbb86b0ad91be5df2", size = 542851226, upload-time = "2025-10-09T08:59:04.818Z" },
-    { url = "https://files.pythonhosted.org/packages/e7/44/423ac00af4dd95a5aeb27207e2c0d9b7118702149bf4704c3ddb55bb7429/nvidia_cublas-13.1.0.3-py3-none-manylinux_2_27_x86_64.whl", hash = "sha256:ee8722c1f0145ab246bccb9e452153b5e0515fd094c3678df50b2a0888b8b171", size = 423133236, upload-time = "2025-10-09T08:59:32.536Z" },
+    { url = "https://files.pythonhosted.org/packages/a7/a1/0bd24ee8c8d03adac032fd2909426a00c88f8c57961b1277ded97f91119f/nvidia_cublas-13.1.1.3-py3-none-manylinux_2_27_aarch64.whl", hash = "sha256:b7a210458267ac818974c53038fbec2e969d5c99f305ab15c72522fa9f001dd5", size = 542848918, upload-time = "2026-04-08T18:46:22.985Z" },
+    { url = "https://files.pythonhosted.org/packages/3b/cd/154ca20c38269e05eff77c1464e6c1da89f50a6390b565e9d82e06bc11e1/nvidia_cublas-13.1.1.3-py3-none-manylinux_2_27_x86_64.whl", hash = "sha256:37936a16db8fe4ac1f065c2139360608a543a09275cb1a1af612e08cfa065436", size = 423138758, upload-time = "2026-04-08T18:46:58.655Z" },
 ]
 
 [[package]]
@@ -5195,19 +5208,17 @@ wheels = [
 
 [[package]]
 name = "posthog"
-version = "7.9.7"
+version = "7.39.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "backoff" },
     { name = "distro" },
-    { name = "python-dateutil" },
     { name = "requests" },
-    { name = "six" },
     { name = "typing-extensions" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/16/08/e5064ae25749367f38f6d204ce876a045ecf4fd01ed0e66477364925416c/posthog-7.9.7.tar.gz", hash = "sha256:35dcaf4acc37b386b5ebcd6037cc80821e88d359627c0f61537c667c52359483", size = 175634, upload-time = "2026-03-05T22:09:51.979Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/4f/77/3737f60571995ba07677b058bb1523b7c26f28570806b8ffaf83a66df18c/posthog-7.39.1.tar.gz", hash = "sha256:0d184596e35057457fc1094883646fd23de2d6338db8b9c3ea770643fb55d8a2", size = 428586, upload-time = "2026-08-14T13:50:24.688Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/ed/8a/3e4dd145d7d5aaad856d522c61475c51ee80b512b6446bfb3966b2dedf66/posthog-7.9.7-py3-none-any.whl", hash = "sha256:204e47c27dcc230d0bc9b323709c36f98f86e79fa8190caea3b1fbc3c999b1a0", size = 201316, upload-time = "2026-03-05T22:09:50.18Z" },
+    { url = "https://files.pythonhosted.org/packages/88/79/ee5c01937bfb0c80415929e25aa1e8296c48e26fc9a10fe1d9f665f0f478/posthog-7.39.1-py3-none-any.whl", hash = "sha256:e76e82fe571314a0a9bc11d039fd1a1a8d210cd0f737899d41b31f61b73bf08c", size = 504259, upload-time = "2026-08-14T13:50:22.896Z" },
 ]
 
 [[package]]
@@ -6822,15 +6833,15 @@ wheels = [
 
 [[package]]
 name = "starlette"
-version = "1.3.1"
+version = "1.6.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "anyio" },
     { name = "typing-extensions", marker = "python_full_version < '3.13'" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/eb/e3/7c1dc7381d9f8ab7d854328ebfa884e62cb3f3d8549ddfd37c7814f42afa/starlette-1.3.1.tar.gz", hash = "sha256:05d0213193f2fbaae60e2ecb593b4add4262ad4e46536b54abe36f11a71724e0", size = 2703240, upload-time = "2026-06-12T09:23:11.602Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/b5/b4/205b0d5241d934e8add0c38aa924c4f9fb7330834ff11e5444db964ec3f9/starlette-1.6.0.tar.gz", hash = "sha256:d4e3ac5e546444960c710297a3c9fc3f7ebae1b7e963f3d36173b49da535be9b", size = 2716969, upload-time = "2026-08-08T18:27:57.512Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/ec/bb/2799cc2ede3ed41131f8975621e7213dfc7ef4acbbaadfa440f32500c370/starlette-1.3.1-py3-none-any.whl", hash = "sha256:c7372aae11c3c3f26a42df7bd626cec2f47d03483d261d369516a615a53714c6", size = 73632, upload-time = "2026-06-12T09:23:10.017Z" },
+    { url = "https://files.pythonhosted.org/packages/c8/cb/6a6a47d5b464bd08695d254f3da6e7986cc70c9fa5d778eda57538edfe56/starlette-1.6.0-py3-none-any.whl", hash = "sha256:a86dd39d14bb45f85a3d18525215a9ef0cfd1f192ac793220e72598c90335f0c", size = 75969, upload-time = "2026-08-08T18:27:56.196Z" },
 ]
 
 [[package]]
@@ -7020,16 +7031,15 @@ wheels = [
 
 [[package]]
 name = "torch"
-version = "2.12.0"
+version = "2.13.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "cuda-bindings", marker = "sys_platform == 'linux'" },
-    { name = "cuda-toolkit", extra = ["cudart", "cufft", "cufile", "cupti", "curand", "cusolver", "cusparse", "nvjitlink", "nvrtc", "nvtx"], marker = "sys_platform == 'linux'" },
+    { name = "cuda-toolkit", extra = ["cublas", "cudart", "cufft", "cufile", "cupti", "curand", "cusolver", "cusparse", "nvjitlink", "nvrtc", "nvtx"], marker = "sys_platform == 'linux'" },
     { name = "filelock" },
     { name = "fsspec" },
     { name = "jinja2" },
     { name = "networkx" },
-    { name = "nvidia-cublas", marker = "sys_platform == 'linux'" },
     { name = "nvidia-cudnn-cu13", marker = "sys_platform == 'linux'" },
     { name = "nvidia-cusparselt-cu13", marker = "sys_platform == 'linux'" },
     { name = "nvidia-nccl-cu13", marker = "sys_platform == 'linux'" },
@@ -7040,27 +7050,23 @@ dependencies = [
     { name = "typing-extensions" },
 ]
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/18/62/131124fb95df03811b8260d1d43dcc5ee85ea1a344b964613d7efe77fb08/torch-2.12.0-cp311-cp311-macosx_14_0_arm64.whl", hash = "sha256:10802fd383bbfed646212e765a72c37d2185205d4f26eb197a254e8ac7ddcb25", size = 87990344, upload-time = "2026-05-13T14:55:42.154Z" },
-    { url = "https://files.pythonhosted.org/packages/12/9c/dda0dbd547dc549839824135f223792fd0e725f28ed0715dda366b7acaa2/torch-2.12.0-cp311-cp311-manylinux_2_28_aarch64.whl", hash = "sha256:c12592630aef72feaf18bd3f197ef587bbfa21131b31c38b23ab2e55fce92e36", size = 426362932, upload-time = "2026-05-13T14:54:15.295Z" },
-    { url = "https://files.pythonhosted.org/packages/e2/d2/a7dd5a3f9bdaa7842124e8e2359202b317c48d47d2fc5816fafdf2049adb/torch-2.12.0-cp311-cp311-manylinux_2_28_x86_64.whl", hash = "sha256:415c1b8d0412f67551c8e89a2daca0fb3e56694af0281ba155eaa9da481f58b4", size = 532170085, upload-time = "2026-05-13T14:55:20.788Z" },
-    { url = "https://files.pythonhosted.org/packages/12/1b/a61ce2004f9ab0ea8964a6e6168133a127795667639e2ff4f8f2bdb16a65/torch-2.12.0-cp311-cp311-win_amd64.whl", hash = "sha256:dd37188ea325042cb1f6cafa56822b11ada2520c04791a52629b0af25bdfbfd9", size = 122953128, upload-time = "2026-05-13T14:54:52.744Z" },
-    { url = "https://files.pythonhosted.org/packages/ef/bb/285d643f254731294c9b595a007eac39db4600a98682d7bca688f42ca164/torch-2.12.0-cp312-cp312-macosx_14_0_arm64.whl", hash = "sha256:b41339df93d491435e790ff8bcbae1c0ce777175889bfd1281d119862793e6a2", size = 88010197, upload-time = "2026-05-13T14:55:35.414Z" },
-    { url = "https://files.pythonhosted.org/packages/79/81/76debf1db1343bd929bbb5d74c89fb437c2ed88eb144712557e7bd3eea45/torch-2.12.0-cp312-cp312-manylinux_2_28_aarch64.whl", hash = "sha256:8fbef9f108a863e7722a73740998967e3b074742a834fc5be3a535a2befa7057", size = 426376751, upload-time = "2026-05-13T14:55:03.353Z" },
-    { url = "https://files.pythonhosted.org/packages/de/f0/80026028b603c4650ff270fc3785bdef4bd6738765a9cc5a0f5a637d65a2/torch-2.12.0-cp312-cp312-manylinux_2_28_x86_64.whl", hash = "sha256:4b4f64c2c2b11f7510d93dd6412b87025ff6eddd6bb61c3b5a3d892ea20c4756", size = 532261691, upload-time = "2026-05-13T14:52:54.453Z" },
-    { url = "https://files.pythonhosted.org/packages/b9/c2/64b06cbb7830fb3cd9be13e1158b31a3f36b68e6a209105ee3c9d9480be0/torch-2.12.0-cp312-cp312-win_amd64.whl", hash = "sha256:8b958caff4a14d3a3b0b2dfc6a378f64dda9728a9dad28c08a0db9ce4dafb549", size = 122988114, upload-time = "2026-05-13T14:54:42.153Z" },
-    { url = "https://files.pythonhosted.org/packages/86/ca/01896c80ba921676aa45886b2c5b8d774912de2a1f719de48169c6f755cd/torch-2.12.0-cp313-cp313-macosx_14_0_arm64.whl", hash = "sha256:90dd587a5f61bfe1307148b581e2084fc5bc4a06e2b90a20e9a36b81087ff16b", size = 88009511, upload-time = "2026-05-13T14:54:47.411Z" },
-    { url = "https://files.pythonhosted.org/packages/a5/04/52bdaf4787eab6ac7d7f5851dff934e4def0bc8ead9c8fd2b69b3e529699/torch-2.12.0-cp313-cp313-manylinux_2_28_aarch64.whl", hash = "sha256:864392c73b7654f4d2b3ae712f607937d0dbb1101c4555fbb41848106b297f39", size = 426383231, upload-time = "2026-05-13T14:53:32.129Z" },
-    { url = "https://files.pythonhosted.org/packages/49/8a/94bdecd13f5aaa90d45920b89789d9fe7c6f4af8c3cdd7ce01fcb59908fc/torch-2.12.0-cp313-cp313-manylinux_2_28_x86_64.whl", hash = "sha256:5d6b560dfa7d56291c07d615c3bb73e8d9943d9b6d87f76cd0d9d570c4797fa6", size = 532269288, upload-time = "2026-05-13T14:53:49.423Z" },
-    { url = "https://files.pythonhosted.org/packages/3e/2f/bdbaaa267de519ef1b73054bf590d8c93c37a266c9a4e24a01bd38b6918f/torch-2.12.0-cp313-cp313-win_amd64.whl", hash = "sha256:3fee918902090ade827643e758e98363278815de583c75d111fdd665ebffde9f", size = 122987706, upload-time = "2026-05-13T14:54:00.335Z" },
-    { url = "https://files.pythonhosted.org/packages/9b/ad/e95e822f3538171e22640a7fbe839a1fdb666600bf6487025de2ff03b11a/torch-2.12.0-cp313-cp313t-macosx_14_0_arm64.whl", hash = "sha256:10ee1448a9f304d3b987eb4656f664ba6e4d7b410ca7a5a7c642199777a2cf88", size = 88319556, upload-time = "2026-05-13T14:54:05.574Z" },
-    { url = "https://files.pythonhosted.org/packages/b7/07/055d06d985b445d67422d25b033c11cf55bbb81785d4c4e68e28bca5820e/torch-2.12.0-cp313-cp313t-manylinux_2_28_aarch64.whl", hash = "sha256:af68dbf403439cae9ceaeaaf92f8352b460787dcd27b92aa05c40dd4a19c0f1e", size = 426397656, upload-time = "2026-05-13T14:52:38.84Z" },
-    { url = "https://files.pythonhosted.org/packages/43/94/b0b4fdc3014122e0a7302fb90086d352aa48f2576f0b252561ebb38c01a8/torch-2.12.0-cp313-cp313t-manylinux_2_28_x86_64.whl", hash = "sha256:a6a2eebb237d3b1d9ad3b378e86d9b9e0782afdea8b1e0eba6a13646b9b49c07", size = 532183124, upload-time = "2026-05-13T14:53:16.178Z" },
-    { url = "https://files.pythonhosted.org/packages/d8/c8/052405e6ad05d3237bfe5a4df78f917773956f8e17813a2d44c059068b74/torch-2.12.0-cp313-cp313t-win_amd64.whl", hash = "sha256:2140e373e9a51a3e22ef62e8d14366d0b470d18f0adf19fdc757368077133a34", size = 123232462, upload-time = "2026-05-13T14:52:27.26Z" },
+    { url = "https://files.pythonhosted.org/packages/5b/fe/cba54dc58523434919b66f13a667e36e436deddd77ca519e96553617d4ec/torch-2.13.0-cp311-cp311-macosx_14_0_arm64.whl", hash = "sha256:e76f9bcecc52b8ff711239a2f7547d5353df95878ab232f0773c1d95928b92f8", size = 111187938, upload-time = "2026-07-08T16:05:17.065Z" },
+    { url = "https://files.pythonhosted.org/packages/c2/59/1e3160e18e12aa3038390efab3ce02b36a9d4d6a527ecdd8520dca2e68d8/torch-2.13.0-cp311-cp311-manylinux_2_28_aarch64.whl", hash = "sha256:092790c696a760c729fd5722835f50b9d81fd7c8f141571f3f3cf4081a8f664c", size = 427199369, upload-time = "2026-07-08T16:04:51.054Z" },
+    { url = "https://files.pythonhosted.org/packages/01/79/1f2d34ad7034ee1c7ffc1cf8bf0f8213af2a81df6ecdb3997ecec107c09d/torch-2.13.0-cp311-cp311-manylinux_2_28_x86_64.whl", hash = "sha256:60fcdcb2f3876e21146cb4524ef06397d727ca9ad5f020818547e25075fe3cb7", size = 526574961, upload-time = "2026-07-08T16:04:07.075Z" },
+    { url = "https://files.pythonhosted.org/packages/6c/fd/0f2ce40f58aefbdb3392f9acce3c8171940943ae2d661f70558bfa73befb/torch-2.13.0-cp311-cp311-win_amd64.whl", hash = "sha256:a0d8b11f16a48d60e2015d8213aa0390744cbebb98e58b62b3514dddc656e330", size = 122015870, upload-time = "2026-07-08T16:05:27.59Z" },
+    { url = "https://files.pythonhosted.org/packages/c4/3a/ed0f4d4d1dcde03bced7aac9a28e800abcdc0cbd06b6775044c9fbd877b7/torch-2.13.0-cp312-cp312-macosx_14_0_arm64.whl", hash = "sha256:2fe228aba290d14b9f31b049be550dbd469c3fd3013d7a19705b30454da97027", size = 111213045, upload-time = "2026-07-08T16:05:22.997Z" },
+    { url = "https://files.pythonhosted.org/packages/df/a9/f6a2a4d763ff1df02e9a64c477029db614295bc9367f4131223791ccc243/torch-2.13.0-cp312-cp312-manylinux_2_28_aarch64.whl", hash = "sha256:572df8be8ffb4599c88cbd6a0726f1f854f4da65d2e3c09f0e2c2283333cd6d4", size = 427210998, upload-time = "2026-07-08T16:04:37.708Z" },
+    { url = "https://files.pythonhosted.org/packages/f3/82/fea946351658e6534db52d2cc12bc53087cbf87f9440c5f180f367c1950b/torch-2.13.0-cp312-cp312-manylinux_2_28_x86_64.whl", hash = "sha256:796633c4cdf0fe2cdced72d8f88f22e73dbcfce83132763162f6d4bff13b820b", size = 526605292, upload-time = "2026-07-08T16:04:22.81Z" },
+    { url = "https://files.pythonhosted.org/packages/21/d6/e8f3c6f7e01f626f77259de9860d2a78bc84c40539e28e79b7e98b0bb659/torch-2.13.0-cp312-cp312-win_amd64.whl", hash = "sha256:024c6cc0c1b085f2f91f20a3dc27b0471d021c31ce84b81be3afdc39f791fd9d", size = 122057313, upload-time = "2026-07-08T16:03:53.43Z" },
+    { url = "https://files.pythonhosted.org/packages/0d/fa/c1c10b7aff4a9a3e8956d4f0a5f468fa6db7abc3208805719076772b4833/torch-2.13.0-cp313-cp313-macosx_14_0_arm64.whl", hash = "sha256:33449899ce5496c1b84b4853179d94fd102028ae1407314d9fb956bb79e70d09", size = 111213743, upload-time = "2026-07-08T16:03:28.579Z" },
+    { url = "https://files.pythonhosted.org/packages/11/18/9ecb37b56293a0be8d80f810bf672a72fe7e02f8b475d5ef1b9bf8a0d748/torch-2.13.0-cp313-cp313-manylinux_2_28_aarch64.whl", hash = "sha256:1e09d6a722504957c694faceca843acde562786df1144ebcc5a74075ec7f6005", size = 427213008, upload-time = "2026-07-08T16:03:44.106Z" },
+    { url = "https://files.pythonhosted.org/packages/d4/5a/7c50ba1b7b713d71d34669c6d13dab0a11531a3eceb0307a5162dbfec0f7/torch-2.13.0-cp313-cp313-manylinux_2_28_x86_64.whl", hash = "sha256:a3a9a21312872af8a26950b2c15680335a386a1f56ed03e780653d78b9607e9e", size = 526602329, upload-time = "2026-07-08T16:03:12.649Z" },
+    { url = "https://files.pythonhosted.org/packages/91/3d/e7adcc6aaf36961cd18f56cf8ad0f3058c3a5c84ccf391762176c94581b8/torch-2.13.0-cp313-cp313-win_amd64.whl", hash = "sha256:49b58f1e2c52440abb6f17c28f0335fe6c6d01ad1a7f55b0183b81e4b34d64e6", size = 122057920, upload-time = "2026-07-08T16:03:01.808Z" },
 ]
 
 [[package]]
 name = "torchvision"
-version = "0.27.0"
+version = "0.28.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "numpy" },
@@ -7068,22 +7074,18 @@ dependencies = [
     { name = "torch" },
 ]
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/cf/d6/a7e71e981042d5c573e2e61891b9023b190c88adb75b18bed8594371250c/torchvision-0.27.0-cp311-cp311-macosx_14_0_arm64.whl", hash = "sha256:df0c166b6bdf7c47f88e81e8b43bc085451d5c50d0c5d1691bc474c1227d6fed", size = 1758812, upload-time = "2026-05-13T14:57:16.662Z" },
-    { url = "https://files.pythonhosted.org/packages/93/f9/f542fb7e4476603fb237ebdc64369a7d11f18eb5a129aa2559cbdb710aee/torchvision-0.27.0-cp311-cp311-manylinux_2_28_aarch64.whl", hash = "sha256:9bb9251f64b854124efed95d02953a89f7e2726c3ca662d7ea0151129157297f", size = 7831148, upload-time = "2026-05-13T14:57:08.37Z" },
-    { url = "https://files.pythonhosted.org/packages/f6/61/7aa7cc2c9e8750027f6fb9ae3a7393ef43860bcdfe3966e2f71fee800e31/torchvision-0.27.0-cp311-cp311-manylinux_2_28_x86_64.whl", hash = "sha256:f44453f107c296d5446a79f7ac59733ad8bf5ddfa04c53805dfbae298a42a798", size = 7575519, upload-time = "2026-05-13T14:56:50.552Z" },
-    { url = "https://files.pythonhosted.org/packages/19/aa/929b358b1a643849b81ec95569938044cc37dc65ab10c84eb6d82fe1bfbb/torchvision-0.27.0-cp311-cp311-win_amd64.whl", hash = "sha256:b4aacff70ea4b7377f996f9048989c850d221fef33658ddbcae42aa5bd4ca11a", size = 3749475, upload-time = "2026-05-13T14:57:11.007Z" },
-    { url = "https://files.pythonhosted.org/packages/9e/c8/5cd91932f7f3671b0743dc4ae1a4c16b1d0b45bf4087976277d325bda718/torchvision-0.27.0-cp312-cp312-macosx_14_0_arm64.whl", hash = "sha256:1a6dd742a150645126df9e0b2e449874c1d635897c773b322c2e067e98382dfe", size = 1758824, upload-time = "2026-05-13T14:57:15.227Z" },
-    { url = "https://files.pythonhosted.org/packages/d9/36/7fb7d19477b3d93283b52fea11fa8ee30ab9064a08c97b4a6b91445e26cb/torchvision-0.27.0-cp312-cp312-manylinux_2_28_aarch64.whl", hash = "sha256:65772ff3ec4f4f5d680e30019835555dd239e7fefee4b0a846375fe1cb1592ef", size = 7831034, upload-time = "2026-05-13T14:57:06.483Z" },
-    { url = "https://files.pythonhosted.org/packages/62/43/dfd894c3f8b01b5b33fde990f0159c1926ebc7b6e2c4193e2efb7da3c4cb/torchvision-0.27.0-cp312-cp312-manylinux_2_28_x86_64.whl", hash = "sha256:7a9966a088d06b4cf6c610e03be62de469efa6f2cd2e7c7eed8e925ed6af59ac", size = 7579774, upload-time = "2026-05-13T14:56:59.337Z" },
-    { url = "https://files.pythonhosted.org/packages/ff/0c/722e989f9cf026e97ef7cb24a9bb1859e099f72d247ae35388fb89729f73/torchvision-0.27.0-cp312-cp312-win_amd64.whl", hash = "sha256:2c037709072ca9b19750c0cbe9e8bb6f91c9a1be1befa26df33e281deccbd8c7", size = 4021073, upload-time = "2026-05-13T14:57:00.848Z" },
-    { url = "https://files.pythonhosted.org/packages/d8/ae/36547812e6e047c1d80bcacd1b17a340612b08a6e876e0aabf3d0b9228b0/torchvision-0.27.0-cp313-cp313-macosx_14_0_arm64.whl", hash = "sha256:41d6dae73e1af09fa82ded597ae57f2a2314285acde54b25890a8f8e51b999d7", size = 1758826, upload-time = "2026-05-13T14:57:05.262Z" },
-    { url = "https://files.pythonhosted.org/packages/ae/30/32c4ea842738728a14e3df8c576c62dedcf5ae5cb6a5c984c6429ebe7524/torchvision-0.27.0-cp313-cp313-manylinux_2_28_aarch64.whl", hash = "sha256:70f071c6f74b60d5fe8851636d8d4cd5f4fa29d57fd9348a87a6f17b990b95ba", size = 7789501, upload-time = "2026-05-13T14:56:57.786Z" },
-    { url = "https://files.pythonhosted.org/packages/f6/24/4d0d48684251bd0673f87d633d5d88ab00227983b00591156eed2f86c8d5/torchvision-0.27.0-cp313-cp313-manylinux_2_28_x86_64.whl", hash = "sha256:aaafa6962c9d91f42503de1957d6fa349907d028c06f335bd95da7a5bc57147d", size = 7579868, upload-time = "2026-05-13T14:56:41.618Z" },
-    { url = "https://files.pythonhosted.org/packages/ba/da/e6edd051d2ba25adf23b120fa97f458dff888d098c51e84724f17d2d1470/torchvision-0.27.0-cp313-cp313-win_amd64.whl", hash = "sha256:aee384a2782c89517c4ab9061d2720ba59fd2ffe5ef89d0a149cc2d43abdf521", size = 4092700, upload-time = "2026-05-13T14:57:09.729Z" },
-    { url = "https://files.pythonhosted.org/packages/fa/23/95dfa40431360f42ca949bf861434bed51164adfa8fb9801e05bf3194f50/torchvision-0.27.0-cp313-cp313t-macosx_14_0_arm64.whl", hash = "sha256:c5121f1b9ab09a7f73e837871deb8321551f7eaeb19d87aa00de9191968eae44", size = 1845008, upload-time = "2026-05-13T14:57:03.768Z" },
-    { url = "https://files.pythonhosted.org/packages/23/b9/9dbdf76b2b49a75ba8088df6f7c755bdb520afb6c6dbac0102b46cde5e99/torchvision-0.27.0-cp313-cp313t-manylinux_2_28_aarch64.whl", hash = "sha256:1c01f0d1091ae22b9dfc082b0a0fe5faaf053686a29b4fb082ba7691375c73cf", size = 7791430, upload-time = "2026-05-13T14:56:56.206Z" },
-    { url = "https://files.pythonhosted.org/packages/5c/6a/e4a16cf2f3310c2ea7760dc5d9054496844391e0f4c1fae87fefac2f3d9e/torchvision-0.27.0-cp313-cp313t-manylinux_2_28_x86_64.whl", hash = "sha256:dadea3c5ecfd05bbb2a3312ab0374f213c58bf6459cb059122e2f4dfe13d10ed", size = 7668441, upload-time = "2026-05-13T14:57:02.127Z" },
-    { url = "https://files.pythonhosted.org/packages/00/70/01b6461117a6a94b5af3f8ee166bb0f045056f3cf187750c110dabfdfffa/torchvision-0.27.0-cp313-cp313t-win_amd64.whl", hash = "sha256:a49e55055a39a8506fe7e59850522cab004efb2c3839f6057658889c1d69c815", size = 4141602, upload-time = "2026-05-13T14:56:53.449Z" },
+    { url = "https://files.pythonhosted.org/packages/7a/b2/1e010052079e4c577007b789db336ea7075f1a426e84d17121fbc3745516/torchvision-0.28.0-cp311-cp311-macosx_14_0_arm64.whl", hash = "sha256:83fe6c020866a85acd7d97deccc45ff11d66daf42916d04396a4309c66c0ccb8", size = 1856017, upload-time = "2026-07-08T16:07:55.533Z" },
+    { url = "https://files.pythonhosted.org/packages/27/be/1b9c5de9c655ca2df4a74100fa671a7b848532ff787e077ccde14a7dea2a/torchvision-0.28.0-cp311-cp311-manylinux_2_28_aarch64.whl", hash = "sha256:5a38bc6da3d72621be003400b66f66a2b4c6d644fde05f680c2cb7ca8cf8dd6c", size = 7841822, upload-time = "2026-07-08T16:07:49.207Z" },
+    { url = "https://files.pythonhosted.org/packages/0b/9b/f1e68e861d4462e3e195a642c2b448e7b7d3fad5f209487162b9a2133d9b/torchvision-0.28.0-cp311-cp311-manylinux_2_28_x86_64.whl", hash = "sha256:7e80f543b22503d9415e126db5f0ff3917036925e38560ee6b9ae38c571a4002", size = 7670718, upload-time = "2026-07-08T16:07:46.525Z" },
+    { url = "https://files.pythonhosted.org/packages/f5/de/1494610ff54cbb154beb55033cc2cd50f3de04dac132fa2dd00e4f2b2556/torchvision-0.28.0-cp311-cp311-win_amd64.whl", hash = "sha256:9a45ea67235d965ef52187130d20002a4de20c54ea3d927a24286961d268dc37", size = 3814319, upload-time = "2026-07-08T16:07:37.153Z" },
+    { url = "https://files.pythonhosted.org/packages/15/49/c1cab1ecbb3ff1a380a3f99283db1dee61b8afe354f6352c643b65937130/torchvision-0.28.0-cp312-cp312-macosx_14_0_arm64.whl", hash = "sha256:e9f54c30cd52e3ef7fd034cc69b7bb7e0964e1c8f8743e018ab92e95b40f9eee", size = 1856020, upload-time = "2026-07-08T16:07:52.182Z" },
+    { url = "https://files.pythonhosted.org/packages/f0/4c/95233776e2def960e5abb7a07931230a545f43717a56a1e1140162033598/torchvision-0.28.0-cp312-cp312-manylinux_2_28_aarch64.whl", hash = "sha256:5cf78ebc401ce64ae19b8c55de866bb836797d559a4de9c25ccbe74cfa642d3a", size = 7842127, upload-time = "2026-07-08T16:07:53.446Z" },
+    { url = "https://files.pythonhosted.org/packages/93/e4/e9b2495d0d57b9f60d63c57d0a910410a81b4b073bf70917bef815291119/torchvision-0.28.0-cp312-cp312-manylinux_2_28_x86_64.whl", hash = "sha256:028a3d481b37d785605620d7cdad897064c5a55bae2aa1f2658766333e291940", size = 7675040, upload-time = "2026-07-08T16:07:58.017Z" },
+    { url = "https://files.pythonhosted.org/packages/7c/9c/55ed9cb6dfe3ee9c837df5cd0e758372e5829aa38b8dd71343aa632cc4e2/torchvision-0.28.0-cp312-cp312-win_amd64.whl", hash = "sha256:87dc16b2df427c1318ad335f1e2be2b3b15b2cf20f7934c83b0505a48425ee5d", size = 4085785, upload-time = "2026-07-08T16:07:50.928Z" },
+    { url = "https://files.pythonhosted.org/packages/20/55/08a726c14c67b37c8aca04b077766909f1c7ed23f76116884fe63b9bd033/torchvision-0.28.0-cp313-cp313-macosx_14_0_arm64.whl", hash = "sha256:d483b4aa3f5237569053f749cd1a2b5bb548ca456e40461a5dd087f21149d123", size = 1856021, upload-time = "2026-07-08T16:07:45.386Z" },
+    { url = "https://files.pythonhosted.org/packages/db/8f/40beacd53809194f5259e590d1afaeaa8ad57da15f77c646e6560bcc4616/torchvision-0.28.0-cp313-cp313-manylinux_2_28_aarch64.whl", hash = "sha256:bb6dd6918460ed89cc7644adcc2402991474d6933cf1ce92b390641cb233fddf", size = 7797014, upload-time = "2026-07-08T16:07:43.04Z" },
+    { url = "https://files.pythonhosted.org/packages/32/db/062cdb5a84380a60439775311fff34d89229760d2a50680393dc18699956/torchvision-0.28.0-cp313-cp313-manylinux_2_28_x86_64.whl", hash = "sha256:ad7b3a439265cc3739a4ab5b4c998c0e38ea99c0ee7ca4dea35c5d0b099ec237", size = 7674669, upload-time = "2026-07-08T16:07:38.91Z" },
+    { url = "https://files.pythonhosted.org/packages/f3/a6/b4081e2d04e1541abf82785ac9e5178a494c19330391f551356c8c18b7b3/torchvision-0.28.0-cp313-cp313-win_amd64.whl", hash = "sha256:7e9dd6f60d6e15f8dc27d4f877fdb6002fc70d70272412135f1c2ff9cfa08d3b", size = 4157380, upload-time = "2026-07-08T16:07:40.22Z" },
 ]
 
 [[package]]
@@ -7180,17 +7182,15 @@ wheels = [
 
 [[package]]
 name = "triton"
-version = "3.7.0"
+version = "3.7.1"
 source = { registry = "https://pypi.org/simple" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/b8/c1/5d842314bb6c78442cc60437928781701c6050b8d479bc2a1aed691d37ca/triton-3.7.0-cp311-cp311-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:a9e71fc392675fac364e0ecf4ef3f76f85b7f5433a16f4c3c5fe5f05a52c85fe", size = 188480277, upload-time = "2026-05-07T19:05:03.231Z" },
-    { url = "https://files.pythonhosted.org/packages/13/31/8315ea5f8dd18e60970b3022e3a8b93fd37e0b784fbbef86e10c8e6e5ca1/triton-3.7.0-cp311-cp311-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:22bacffce443f54593dd20f05294d5a40622e0ea9ab632816f87154504356221", size = 201415942, upload-time = "2026-05-07T18:46:06.479Z" },
-    { url = "https://files.pythonhosted.org/packages/f7/13/ec05adfcd87311d532ba61e3af143e8be59fcd26675884c4682841406a20/triton-3.7.0-cp312-cp312-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:a4bf49b00a7a377a68a6da603a876e797614e6455a80e9021669c476a953ad9a", size = 188505104, upload-time = "2026-05-07T19:05:09.843Z" },
-    { url = "https://files.pythonhosted.org/packages/62/7b/468a576e35beef1426e0828e28e9ba9e65f5474d496f16ee126c15646324/triton-3.7.0-cp312-cp312-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:8f111161d49bf903c0eaedde3962353a3d841c08a836839b7cc1025b8426efcf", size = 201457567, upload-time = "2026-05-07T18:46:13.505Z" },
-    { url = "https://files.pythonhosted.org/packages/01/e1/a59a583de59b8f62c495d67c80ee3ea97d09e91ac80c4c6e76456ed8d8ac/triton-3.7.0-cp313-cp313-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:abdf6beaa89b1bcfb9a43cd990536ce66091a997841a4814b260b7bee4c88c3c", size = 188503209, upload-time = "2026-05-07T19:05:17.935Z" },
-    { url = "https://files.pythonhosted.org/packages/30/b1/b7507bb9815d403927c8dd51d4158ed2e11751a92dbc118a044f247b6848/triton-3.7.0-cp313-cp313-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:a35d7afe3f3f058e7ec49fcce09794049e0ffc5c59019ac25ec3413741b8c4e7", size = 201453566, upload-time = "2026-05-07T18:46:20.427Z" },
-    { url = "https://files.pythonhosted.org/packages/a6/8f/0bea7a6a0c989315c9135a1d7fb37e41905cfb3a17cbc1f10044ebd4cc3a/triton-3.7.0-cp313-cp313t-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:cc1d61c172d257db80ddf42595131fb196ad2e9bdd751e90fe2ef13531734e8b", size = 188612899, upload-time = "2026-05-07T19:05:24.955Z" },
-    { url = "https://files.pythonhosted.org/packages/e1/02/d96f57828d0912aec733b9bc7e0e7dbfd2c6f079a8fa433ac25cb93d1a30/triton-3.7.0-cp313-cp313t-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:70fb9bbdc9f400afc54bbf6eb2670af28829a6ae3996863317964783141daf56", size = 201553816, upload-time = "2026-05-07T18:46:27.49Z" },
+    { url = "https://files.pythonhosted.org/packages/7b/f9/19d842d06a08559534fa1eaab6ca551b1bcf40f06620bddec1babaa2772d/triton-3.7.1-cp311-cp311-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:d4a0e1cd4c4a76370ed74a8432a53cea28716827d19e40ffc732233e35ceb3f6", size = 184664887, upload-time = "2026-06-17T20:03:42.913Z" },
+    { url = "https://files.pythonhosted.org/packages/cd/5e/fce69606f7f240297f163e25539906732b199530d486ce67ae319877e821/triton-3.7.1-cp311-cp311-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:6744957e9fd610a29680ec2346057d0c86948ed3812468670719f391e94b44a5", size = 197701306, upload-time = "2026-06-17T19:53:13.673Z" },
+    { url = "https://files.pythonhosted.org/packages/94/fa/f856e24deb462d5f18bd4b5a746957862ab9b6ee5834bda60605ec348366/triton-3.7.1-cp312-cp312-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:9497f2e696ee368862a181a90b2dcc03ca978cc4f602abd67c7d81022a6988e1", size = 184692359, upload-time = "2026-06-17T20:03:48.288Z" },
+    { url = "https://files.pythonhosted.org/packages/c4/6f/fb96d15db6f36d6eae4cafb998c2e0353bf59d7c4ea1662d7497f269134a/triton-3.7.1-cp312-cp312-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:7e40869937a68206ec70d7f25bb7ec6433cb083f9135e1f36dbd318dc449a728", size = 197719725, upload-time = "2026-06-17T19:53:20.419Z" },
+    { url = "https://files.pythonhosted.org/packages/00/42/c5089d4d9327fcd1e862c599cc2927f39418f84dd11a84cb2ccff9d4787a/triton-3.7.1-cp313-cp313-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:cdbfc09d9ec58bc5e68321525653220de7515c199e7a8097a97c85e62b52cd0a", size = 184694629, upload-time = "2026-06-17T20:03:53.444Z" },
+    { url = "https://files.pythonhosted.org/packages/07/42/2c3ac59253ae8892b6f307875263dd23dc875cdf732d3aea40d6d41fb7cb/triton-3.7.1-cp313-cp313-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:58c0e131da05134a2a4788ccbcc0c1105cf0f54c8e98f19e34cd465396dc15eb", size = 197729241, upload-time = "2026-06-17T19:53:27.801Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary

Closes #763. Follow-on to #733.

1. Extracts a provider-agnostic `StreamingComplianceHarness` to validate that streaming implementations across providers (`openai`, `anthropic`, `huggingface`, `litellm`, etc.) conform to the canonical `LLMChatResponseChunk` streaming specification.
2. Consolidates duplicated choice-delta stream processing across OpenAI and Hugging Face into a centralized, hardened pipeline in `dapr_agents/llm/utils/stream.py`.

### Key Changes

1. **`StreamingComplianceHarness`** (`tests/llm/streaming_test_harness.py`):
   - Reusable assertions leveraging `AssistantMessageAccumulator` to validate chunk envelope typing, incremental text reconstruction, tool call delta assembly (JSON args & function names), terminal packet contracts (finish reasons & usage), `on_chunk` callback lifecycle, and snapshot isolation.
2. **Consolidated Choice-Delta Stream Processing** (`dapr_agents/llm/utils/stream.py`):
   - Extracted `process_choice_delta_stream`, `extract_packet_metadata`, and `process_choice_delta` to handle OpenAI-compatible stream packets centrally.
   - Retained backward-compatible shims in `dapr_agents/llm/openai/utils.py` and `dapr_agents/llm/huggingface/utils.py` while eliminating ~330 lines of duplicate code.
   - Guaranteed resource cleanup (`finally: raw_stream.close() / __exit__()`) on stream exit or early consumer break.
   - Preserved `usage` packet metadata from terminal empty-choices packets in `metadata["usage"]`, enabling proper token tracking downstream in `TURN_COMPLETE`.
   - Added provider case-insensitivity (`OpenAI`, `HuggingFace`, etc.) and multi-choice packet support.
3. **OpenAI & Hugging Face Stream Test Suites & Bug Fixes**:
   - Modernized `tests/llm/test_openai_stream_utils.py` with the compliance harness, adding tests for tool calling streaming, callback lifecycles, and snapshot isolation.
   - Added dedicated compliance tests in `tests/llm/test_hf_stream_utils.py`.
   - Fixed defect where terminal usage-only packets bypassed the `on_chunk` callback.
4. **Anthropic Test Suite Convergence**:
   - Converged streaming tests in both `tests/llm/test_anthropic.py` and `tests/llm/test_anthropic_utils.py` onto `StreamingComplianceHarness`.
5. **StreamHandler Test Suite** (`tests/llm/test_stream_handler.py`):
   - Added 315 lines of tests covering multi-provider dispatch, serialization types (`model_dump`, `to_dict`, dataclasses), provider case normalization, multi-choice packets, stream resource cleanup, and defensive error fallback.

### Validation

- `uv run ruff format` (clean, 473 files)
- `uv run flake8 dapr_agents tests --ignore=E501,F401,W503,E203,E704` (clean, 0 warnings/errors)
- `uv run mypy --config-file mypy.ini` (clean, 240 source files passed)
- `uv run pytest tests -m "not integration"" (all 1,227 passed)